### PR TITLE
Revert "Migrate away from our http-client fork, use upstream."

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -24,7 +24,6 @@ common common-all
   ghc-options:
     -Wall -Wpartial-fields -fwarn-tabs -Wno-incomplete-uni-patterns
 
-  -- NoImportQualifiedPost is required
   default-extensions:
     AllowAmbiguousTypes
     BangPatterns

--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -162,7 +162,7 @@ instance MonadIO m => MonadHttp (SessionT m) where
               Wai.requestHeaderReferer = lookupHeader "REFERER" req,
               Wai.requestHeaderUserAgent = lookupHeader "USER-AGENT" req
             }
-      toBilgeResponse :: BodyReader -> WaiTest.SResponse -> Request -> Response BodyReader
+      toBilgeResponse :: BodyReader -> WaiTest.SResponse -> Client.Request -> Response BodyReader
       toBilgeResponse bodyReader WaiTest.SResponse {WaiTest.simpleStatus, WaiTest.simpleHeaders} originalReq =
         Client.Response
           { responseStatus = simpleStatus,

--- a/libs/ssl-util/default.nix
+++ b/libs/ssl-util/default.nix
@@ -8,10 +8,10 @@
 , bytestring
 , gitignoreSource
 , HsOpenSSL
+, http-client
 , imports
 , lib
 , time
-, types-common
 }:
 mkDerivation {
   pname = "ssl-util";
@@ -22,9 +22,9 @@ mkDerivation {
     byteable
     bytestring
     HsOpenSSL
+    http-client
     imports
     time
-    types-common
   ];
   description = "SSL-related utilities";
   license = lib.licenses.agpl3Only;

--- a/libs/ssl-util/src/Ssl/Util.hs
+++ b/libs/ssl-util/src/Ssl/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -26,27 +28,25 @@ module Ssl.Util
     -- * Cipher suites
     rsaCiphers,
 
-    -- * to be used when initializing SSL Contexts to obtain SSL enabled
-
-    --   'Network.HTTP.Client.ManagerSettings'
-    extEnvCallback,
+    -- * Network
+    withVerifiedSslConnection,
   )
 where
 
 import Control.Exception
 import Data.ByteString.Builder
 import Data.Byteable (constEqBytes)
-import Data.Misc (Fingerprint (fingerprintBytes), Rsa)
+import Data.Dynamic (fromDynamic)
 import Data.Time.Clock (getCurrentTime)
 import Imports
+import Network.HTTP.Client.Internal
 import OpenSSL.BN (integerToMPI)
-import OpenSSL.EVP.Digest (Digest, digestLBS, getDigestByName)
+import OpenSSL.EVP.Digest (Digest, digestLBS)
 import OpenSSL.EVP.PKey (SomePublicKey, toPublicKey)
 import OpenSSL.EVP.Verify (VerifyStatus (..))
 import OpenSSL.RSA
 import OpenSSL.Session as SSL
 import OpenSSL.X509 as X509
-import OpenSSL.X509.Store (X509StoreCtx, getStoreCtxCert)
 
 -- Cipher Suites ------------------------------------------------------------
 
@@ -180,28 +180,34 @@ verifyRsaFingerprint d = verifyFingerprint $ \pk ->
 -- [1] https://wiki.openssl.org/index.php/Hostname_validation
 -- [2] https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 
--- | this is used as a 'OpenSSL.Session.vpCallback' in 'Brig.App.initExtGetManager'
---   and 'Galley.Env.initExtEnv'
-extEnvCallback :: [Fingerprint Rsa] -> X509StoreCtx -> IO Bool
-extEnvCallback fingerprints store = do
-  Just sha <- getDigestByName "SHA256"
-  cert <- getStoreCtxCert store
-  pk <- getPublicKey cert
-  case toPublicKey @RSAPubKey pk of
-    Nothing -> pure False
-    Just k -> do
-      fp <- rsaFingerprint sha k
-      -- find at least one matching fingerprint to continue
-      if not (any (constEqBytes fp . fingerprintBytes) fingerprints)
-        then pure False
-        else do
-          -- Check if the certificate is self-signed.
-          self <- verifyX509 cert pk
-          if (self /= VerifySuccess)
-            then pure False
-            else do
-              -- For completeness, perform a date check as well.
-              now <- getCurrentTime
-              notBefore <- getNotBefore cert
-              notAfter <- getNotAfter cert
-              pure (now >= notBefore && now <= notAfter)
+-- Utilities -----------------------------------------------------------------
+
+-- | Get an SSL connection that has definitely had its fingerprints checked
+-- (internally it just grabs a connection from a pool and does verification
+-- if it's a fresh one).
+--
+-- Throws an error for other types of connections.
+withVerifiedSslConnection ::
+  -- | A function to verify fingerprints given an SSL connection
+  (SSL -> IO ()) ->
+  Manager ->
+  -- | Request builder
+  (Request -> Request) ->
+  -- | This callback will be passed a modified
+  --   request that always uses the verified
+  --   connection
+  (Request -> IO a) ->
+  IO a
+withVerifiedSslConnection verify man reqBuilder act =
+  withConnection' req man Reuse $ \mConn -> do
+    -- If we see this connection for the first time, verify fingerprints
+    let conn = managedResource mConn
+        seen = managedReused mConn
+    unless seen $ case fromDynamic @SSL (connectionRaw conn) of
+      Nothing -> error ("withVerifiedSslConnection: only SSL allowed: " <> show req)
+      Just ssl -> verify ssl
+    -- Make a request using this connection and return it back to the
+    -- pool (that's what 'Reuse' is for)
+    act req {connectionOverride = Just mConn}
+  where
+    req = reqBuilder defaultRequest

--- a/libs/ssl-util/ssl-util.cabal
+++ b/libs/ssl-util/ssl-util.cabal
@@ -63,12 +63,12 @@ library
     -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      base          >=4.7  && <5
-    , byteable      >=0.1
-    , bytestring    >=0.10
-    , HsOpenSSL     >=0.11
+      base         >=4.7  && <5
+    , byteable     >=0.1
+    , bytestring   >=0.10
+    , HsOpenSSL    >=0.11
+    , http-client  >=0.7
     , imports
-    , time          >=1.5
-    , types-common
+    , time         >=1.5
 
   default-language:   GHC2021

--- a/libs/types-common-aws/default.nix
+++ b/libs/types-common-aws/default.nix
@@ -4,6 +4,7 @@
 # dependencies are added or removed.
 { mkDerivation
 , amazonka
+, amazonka-core
 , amazonka-sqs
 , base
 , base64-bytestring
@@ -23,6 +24,7 @@ mkDerivation {
   src = gitignoreSource ./.;
   libraryHaskellDepends = [
     amazonka
+    amazonka-core
     amazonka-sqs
     base
     base64-bytestring

--- a/libs/types-common-aws/src/AWS/Util.hs
+++ b/libs/types-common-aws/src/AWS/Util.hs
@@ -18,6 +18,7 @@
 module AWS.Util where
 
 import Amazonka qualified as AWS
+import Amazonka.Data.Time qualified as AWS
 import Data.Time
 import Imports
 

--- a/libs/types-common-aws/src/Util/Test/SQS.hs
+++ b/libs/types-common-aws/src/Util/Test/SQS.hs
@@ -164,13 +164,5 @@ parseDeleteMessage url m = do
         liftIO $ putStrLn $ "Failed to delete message, this error will be ignored. Message: " <> show m <> ", Exception: " <> displayException e
   pure evt
 
-sendEnv ::
-  ( MonadReader AWS.Env m,
-    MonadResource m,
-    Typeable a,
-    Typeable (AWS.AWSResponse a),
-    AWS.AWSRequest a
-  ) =>
-  a ->
-  m (AWS.AWSResponse a)
+sendEnv :: (MonadReader AWS.Env m, MonadResource m, AWS.AWSRequest a) => a -> m (AWS.AWSResponse a)
 sendEnv x = flip AWS.send x =<< ask

--- a/libs/types-common-aws/types-common-aws.cabal
+++ b/libs/types-common-aws/types-common-aws.cabal
@@ -78,6 +78,7 @@ library
   ghc-prof-options:   -fprof-auto-exported
   build-depends:
       amazonka
+    , amazonka-core
     , amazonka-sqs
     , base               >=4    && <5
     , base64-bytestring  >=1.0

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -73,6 +73,25 @@ let
         sha256 = "sha256-ov85XFztGM0mEoj01lRZN9xYJttKa/crPnp0lh4A5DA=";
       };
     };
+    amazonka = {
+      src = fetchgit {
+        url = "https://github.com/brendanhay/amazonka";
+        rev = "cfe2584aef0b03c86650372d362c74f237925d8c";
+        sha256 = "sha256-ss8IuIN0BbS6LMjlaFmUdxUqQu+IHsA8ucsjxXJwbyg=";
+      };
+      packages = {
+        amazonka = "lib/amazonka";
+        amazonka-core = "lib/amazonka-core";
+        amazonka-cloudfront = "lib/services/amazonka-cloudfront";
+        amazonka-dynamodb = "lib/services/amazonka-dynamodb";
+        amazonka-s3 = "lib/services/amazonka-s3";
+        amazonka-ses = "lib/services/amazonka-ses";
+        amazonka-sns = "lib/services/amazonka-sns";
+        amazonka-sqs = "lib/services/amazonka-sqs";
+        amazonka-sso = "lib/services/amazonka-sso";
+        amazonka-sts = "lib/services/amazonka-sts";
+      };
+    };
     bloodhound = {
       src = fetchgit {
         url = "https://github.com/wireapp/bloodhound";
@@ -101,6 +120,19 @@ let
         url = "https://github.com/wireapp/hsaml2";
         rev = "51d1fcecebf2417e658b9a78943c84a76a0ed347";
         sha256 = "sha256-jYJBhXBQ1MTLPI8JsiF2XUtgDxK+eniavNB2B1zaSQg=";
+      };
+    };
+    http-client = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/http-client";
+        rev = "eabf64b4a8ff4c0fe6a3b39cb0f396ba8c2fb236";
+        sha256 = "sha256-8NPRVDlul9Xnj6IyUOUe6w7fDt/5WWZNjR07CaAp/Kk=";
+      };
+      packages = {
+        http-client = "http-client";
+        http-client-openssl = "http-client-openssl";
+        http-client-tls = "http-client-tls";
+        http-conduit = "http-conduit";
       };
     };
     hspec-wai = {

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -63,8 +63,6 @@ hself: hsuper: {
   hsaml2 = hlib.dontCheck hsuper.hsaml2;
   saml2-web-sso = hlib.dontCheck hsuper.saml2-web-sso;
   http2 = hlib.dontCheck hsuper.http2;
-  http-client-tls = hsuper.http-client-tls_0_3_6_3;
-  http-client = hsuper.http-client;
 
 
   # Disable tests because they need network access to a running cassandra
@@ -78,6 +76,19 @@ hself: hsuper: {
   # also the test suite doesn't compile https://github.com/NixOS/nixpkgs/pull/167957
   # due to related broken quickcheck-arbitrary-template
   bloodhound = hlib.dontCheck hsuper.bloodhound;
+
+  # These tests require newer version on hspec-wai, which doesn't work with some of the wire-server packages.
+  amazonka = hlib.doJailbreak (hlib.dontCheck hsuper.amazonka);
+  amazonka-cloudfront = hlib.dontCheck hsuper.amazonka-cloudfront;
+  amazonka-core = hlib.doJailbreak (hlib.dontCheck hsuper.amazonka-core);
+  amazonka-dynamodb = hlib.dontCheck hsuper.amazonka-dynamodb;
+  amazonka-s3 = hlib.dontCheck hsuper.amazonka-s3;
+  amazonka-ses = hlib.dontCheck hsuper.amazonka-ses;
+  amazonka-sns = hlib.dontCheck hsuper.amazonka-sns;
+  amazonka-sqs = hlib.dontCheck hsuper.amazonka-sqs;
+  amazonka-sso = hlib.dontCheck hsuper.amazonka-sso;
+  amazonka-sts = hlib.dontCheck hsuper.amazonka-sts;
+  servant-server = hlib.dontCheck hsuper.servant-server;
 
   # Build toool dependencies of local packages
   types-common-journal = hlib.addBuildTool hsuper.types-common-journal protobuf;

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -465,7 +465,7 @@ executable brig-integration
     , HsOpenSSL
     , http-api-data
     , http-client
-    , http-client-tls        >=0.3.6.3
+    , http-client-tls        >=0.3
     , http-media
     , http-reverse-proxy
     , http-types

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -235,27 +235,19 @@ sendMail m = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-sendCatch :: (AWSRequest r, Typeable r, Typeable (AWSResponse r)) => r -> Amazon (Either AWS.Error (AWSResponse r))
+sendCatch :: AWSRequest r => r -> Amazon (Either AWS.Error (AWSResponse r))
 sendCatch req = do
   env <- view amazonkaEnv
   AWS.trying AWS._Error . AWS.send env $ req
 
-send ::
-  (AWSRequest r, Typeable r, Typeable (AWSResponse r)) =>
-  r ->
-  Amazon (AWSResponse r)
+send :: AWSRequest r => r -> Amazon (AWSResponse r)
 send r = throwA =<< sendCatch r
 
 throwA :: Either AWS.Error a -> Amazon a
 throwA = either (throwM . GeneralError) pure
 
 execCatch ::
-  ( AWSRequest a,
-    Typeable a,
-    MonadUnliftIO m,
-    Typeable (AWSResponse a),
-    MonadCatch m
-  ) =>
+  (AWSRequest a, MonadUnliftIO m, MonadCatch m) =>
   AWS.Env ->
   a ->
   m (Either AWS.Error (AWSResponse a))
@@ -265,12 +257,7 @@ execCatch e cmd =
       AWS.send e cmd
 
 exec ::
-  ( AWSRequest a,
-    Typeable a,
-    Typeable (AWSResponse a),
-    MonadCatch m,
-    MonadIO m
-  ) =>
+  (AWSRequest a, MonadCatch m, MonadIO m) =>
   AWS.Env ->
   a ->
   m (AWSResponse a)

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -112,7 +112,8 @@ import Control.Error
 import Control.Lens hiding (index, (.=))
 import Control.Monad.Catch
 import Control.Monad.Trans.Resource
-import Data.Domain (Domain)
+import Data.ByteString.Conversion
+import Data.Domain
 import Data.Metrics (Metrics)
 import Data.Metrics.Middleware qualified as Metrics
 import Data.Misc
@@ -172,7 +173,7 @@ data Env = Env
     _templateBranding :: TemplateBranding,
     _httpManager :: Manager,
     _http2Manager :: Http2Manager,
-    _extGetManager :: [Fingerprint Rsa] -> IO Manager,
+    _extGetManager :: (Manager, [Fingerprint Rsa] -> SSL.SSL -> IO ()),
     _settings :: Settings,
     _nexmoCreds :: Nexmo.Credentials,
     _twilioCreds :: Twilio.Credentials,
@@ -209,6 +210,7 @@ newEnv o = do
   cas <- initCassandra o lgr
   mgr <- initHttpManager
   h2Mgr <- initHttp2Manager
+  ext <- initExtGetManager
   utp <- loadUserTemplates o
   ptp <- loadProviderTemplates o
   ttp <- loadTeamTemplates o
@@ -267,7 +269,7 @@ newEnv o = do
         _templateBranding = branding,
         _httpManager = mgr,
         _http2Manager = h2Mgr,
-        _extGetManager = initExtGetManager,
+        _extGetManager = ext,
         _settings = sett,
         _nexmoCreds = nxm,
         _twilioCreds = twl,
@@ -359,28 +361,29 @@ initHttp2Manager = do
 -- faster. So, we reuse the context.
 
 -- TODO: somewhat duplicates Galley.App.initExtEnv
-initExtGetManager :: [Fingerprint Rsa] -> IO Manager
-initExtGetManager fingerprints = do
+initExtGetManager :: IO (Manager, [Fingerprint Rsa] -> SSL.SSL -> IO ())
+initExtGetManager = do
   ctx <- SSL.context
   SSL.contextAddOption ctx SSL_OP_NO_SSLv2
   SSL.contextAddOption ctx SSL_OP_NO_SSLv3
   SSL.contextSetCiphers ctx rsaCiphers
-  SSL.contextSetVerificationMode
-    ctx
-    SSL.VerifyPeer
-      { vpFailIfNoPeerCert = True,
-        vpClientOnce = False,
-        vpCallback = Just \_b -> extEnvCallback fingerprints
-      }
-
+  -- We use public key pinning with service providers and want to
+  -- support self-signed certificates as well, hence 'VerifyNone'.
+  SSL.contextSetVerificationMode ctx SSL.VerifyNone
   SSL.contextSetDefaultVerifyPaths ctx
-
-  newManager
-    (opensslManagerSettings (pure ctx)) -- see Note [SSL context]
-      { managerConnCount = 100,
-        managerIdleConnectionCount = 512,
-        managerResponseTimeout = responseTimeoutMicro 10000000
-      }
+  mgr <-
+    newManager
+      (opensslManagerSettings (pure ctx)) -- see Note [SSL context]
+        { managerConnCount = 100,
+          managerIdleConnectionCount = 512,
+          managerResponseTimeout = responseTimeoutMicro 10000000
+        }
+  Just sha <- getDigestByName "SHA256"
+  pure (mgr, mkVerify sha)
+  where
+    mkVerify sha fprs =
+      let pinset = map toByteString' fprs
+       in verifyRsaFingerprint sha pinset
 
 initCassandra :: Opts -> Logger -> IO Cas.ClientState
 initCassandra o g =

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -516,11 +516,11 @@ withOptLock u c ma = go (10 :: Int)
         Nothing -> reportFailureAndLogError >> pure a
         Just _ -> pure a
     version :: AWS.GetItemResponse -> Maybe Word32
-    version v = conv . HashMap.lookup ddbVersion =<< (view AWS.getItemResponse_item v)
+    version v = conv =<< HashMap.lookup ddbVersion (view AWS.getItemResponse_item v)
       where
-        conv :: Maybe AWS.AttributeValue -> Maybe Word32
+        conv :: AWS.AttributeValue -> Maybe Word32
         conv = \case
-          Just (AWS.N t) -> readMaybe $ Text.unpack t
+          AWS.N t -> readMaybe $ Text.unpack t
           _ -> Nothing
     get :: Text -> AWS.GetItem
     get t =
@@ -555,12 +555,7 @@ withOptLock u c ma = go (10 :: Int)
           . Log.field "client" (toByteString' c)
           . msg (val "PreKeys: Optimistic lock failed")
       Metrics.counterIncr (Metrics.path "client.opt_lock.optimistic_lock_failed") =<< view metrics
-    execDyn ::
-      forall r x.
-      (AWS.AWSRequest r, Typeable r, Typeable (AWS.AWSResponse r)) =>
-      (AWS.AWSResponse r -> Maybe x) ->
-      (Text -> r) ->
-      m (Maybe x)
+    execDyn :: forall r x. (AWS.AWSRequest r) => (AWS.AWSResponse r -> Maybe x) -> (Text -> r) -> m (Maybe x)
     execDyn cnv mkCmd = do
       cmd <- mkCmd <$> view (awsEnv . prekeyTable)
       e <- view (awsEnv . amazonkaEnv)
@@ -569,7 +564,7 @@ withOptLock u c ma = go (10 :: Int)
       where
         execDyn' ::
           forall y p.
-          (AWS.AWSRequest p, Typeable (AWS.AWSResponse p), Typeable p) =>
+          AWS.AWSRequest p =>
           AWS.Env ->
           Metrics.Metrics ->
           (AWS.AWSResponse p -> Maybe y) ->

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -272,7 +272,7 @@ executable cargohold-integration
     , federator
     , http-api-data
     , http-client            >=0.7
-    , http-client-tls        >=0.3.6.3
+    , http-client-tls        >=0.3
     , http-media
     , http-types             >=0.8
     , imports

--- a/services/cargohold/src/CargoHold/AWS.hs
+++ b/services/cargohold/src/CargoHold/AWS.hs
@@ -157,32 +157,17 @@ instance Exception Error
 --------------------------------------------------------------------------------
 -- Utilities
 
-sendCatch ::
-  (MonadCatch m, AWSRequest r, MonadResource m, Typeable r, Typeable (AWSResponse r)) =>
-  AWS.Env ->
-  r ->
-  m (Either AWS.Error (AWSResponse r))
+sendCatch :: (MonadCatch m, AWSRequest r, MonadResource m) => AWS.Env -> r -> m (Either AWS.Error (AWSResponse r))
 sendCatch env = AWS.trying AWS._Error . AWS.send env
 
-send ::
-  (AWSRequest r, Typeable r, Typeable (AWSResponse r)) =>
-  AWS.Env ->
-  r ->
-  Amazon (AWSResponse r)
+send :: AWSRequest r => AWS.Env -> r -> Amazon (AWSResponse r)
 send env r = throwA =<< sendCatch env r
 
 throwA :: Either AWS.Error a -> Amazon a
 throwA = either (throwM . GeneralError) pure
 
 exec ::
-  ( AWSRequest r,
-    Typeable r,
-    Typeable (AWSResponse r),
-    Show r,
-    MonadLogger m,
-    MonadIO m,
-    MonadThrow m
-  ) =>
+  (AWSRequest r, Show r, MonadLogger m, MonadIO m, MonadThrow m) =>
   Env ->
   (Text -> r) ->
   m (AWSResponse r)
@@ -201,11 +186,7 @@ exec env request = do
     Right r -> pure r
 
 execStream ::
-  ( AWSRequest r,
-    Typeable r,
-    Typeable (AWSResponse r),
-    Show r
-  ) =>
+  (AWSRequest r, Show r) =>
   Env ->
   (Text -> r) ->
   ResourceT IO (AWSResponse r)
@@ -224,13 +205,7 @@ execStream env request = do
     Right r -> pure r
 
 execCatch ::
-  ( AWSRequest r,
-    Typeable r,
-    Typeable (AWSResponse r),
-    Show r,
-    MonadLogger m,
-    MonadIO m
-  ) =>
+  (AWSRequest r, Show r, MonadLogger m, MonadIO m) =>
   Env ->
   (Text -> r) ->
   m (Maybe (AWSResponse r))

--- a/services/cargohold/src/CargoHold/S3.hs
+++ b/services/cargohold/src/CargoHold/S3.hs
@@ -350,24 +350,13 @@ parseAmzMeta k h = lookupCI k h >>= fromByteString . encodeUtf8
 octets :: MIME.Type
 octets = MIME.Type (MIME.Application "octet-stream") []
 
-exec ::
-  ( AWSRequest r,
-    Typeable r,
-    Typeable (AWSResponse r),
-    Show r
-  ) =>
-  (Text -> r) ->
-  ExceptT Error App (AWSResponse r)
+exec :: (AWSRequest r, Show r) => (Text -> r) -> ExceptT Error App (AWSResponse r)
 exec req = do
   env <- view aws
   AWS.exec env req
 
 execCatch ::
-  ( AWSRequest r,
-    Typeable r,
-    Typeable (AWSResponse r),
-    Show r
-  ) =>
+  (AWSRequest r, Show r) =>
   (Text -> r) ->
   ExceptT Error App (Maybe (AWSResponse r))
 execCatch req = do

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -25,7 +25,6 @@ common common-all
   default-extensions:
     AllowAmbiguousTypes
     BangPatterns
-    BlockArguments
     ConstraintKinds
     DataKinds
     DefaultSignatures

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -30,7 +30,9 @@ module Galley.App
     cstate,
     deleteQueue,
     createEnv,
+    extEnv,
     aEnv,
+    ExtEnv (..),
     extGetManager,
 
     -- * Running Galley effects
@@ -160,7 +162,7 @@ createEnv m o l = do
   codeURIcfg <- validateOptions o
   Env (RequestId "N/A") m o l mgr h2mgr (o ^. O.federator) (o ^. O.brig) cass
     <$> Q.new 16000
-    <*> pure initExtEnv
+    <*> initExtEnv
     <*> maybe (pure Nothing) (fmap Just . Aws.mkEnv l mgr) (o ^. journal)
     <*> loadAllMLSKeys (fold (o ^. settings . mlsPrivateKeyPaths))
     <*> traverse (mkRabbitMqChannelMVar l) (o ^. rabbitmq)

--- a/services/galley/src/Galley/Aws.hs
+++ b/services/galley/src/Galley/Aws.hs
@@ -176,14 +176,7 @@ enqueue e = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-sendCatch ::
-  ( AWS.AWSRequest r,
-    Typeable r,
-    Typeable (AWS.AWSResponse r)
-  ) =>
-  AWS.Env ->
-  r ->
-  Amazon (Either AWS.Error (AWS.AWSResponse r))
+sendCatch :: AWS.AWSRequest r => AWS.Env -> r -> Amazon (Either AWS.Error (AWS.AWSResponse r))
 sendCatch e = AWS.trying AWS._Error . AWS.send e
 
 canRetry :: MonadIO m => Either AWS.Error a -> m Bool

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -34,12 +34,12 @@ import Galley.Intra.User
 import Galley.Monad
 import Galley.Types.Bot.Service (Service, serviceEnabled, serviceFingerprints, serviceToken, serviceUrl)
 import Imports
-import Network.HTTP.Client (defaultRequest, withConnection)
 import Network.HTTP.Client qualified as Http
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status (status410)
 import Polysemy
 import Polysemy.Input
+import Ssl.Util (withVerifiedSslConnection)
 import System.Logger.Class qualified as Log
 import System.Logger.Message (field, msg, val, (~~))
 import URI.ByteString
@@ -151,10 +151,8 @@ urlPort (HttpsUrl u) = do
 
 sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> App ()
 sendMessage fprs reqBuilder = do
-  mkMgr <- view extGetManager
-  man <- liftIO $ mkMgr fprs
-  let req = reqBuilder defaultRequest
-  liftIO $ withConnection req man $ \_conn ->
+  (man, verifyFingerprints) <- view (extEnv . extGetManager)
+  liftIO . withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->
     Http.withResponse req man (const $ pure ())
 
 x3 :: RetryPolicy

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -131,7 +131,7 @@ library
     , gundeck-types          >=1.0
     , hedis                  >=0.14.0
     , http-client            >=0.7
-    , http-client-tls        >=0.3.6.3
+    , http-client-tls        >=0.3
     , http-types             >=0.8
     , imports
     , lens                   >=4.4

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -482,18 +482,10 @@ listen throttleMillis callback = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-sendCatch ::
-  (AWSRequest r, Typeable r, Typeable (AWSResponse r)) =>
-  AWS.Env ->
-  r ->
-  Amazon (Either AWS.Error (AWSResponse r))
+sendCatch :: AWSRequest r => AWS.Env -> r -> Amazon (Either AWS.Error (AWSResponse r))
 sendCatch env = AWS.trying AWS._Error . AWS.send env
 
-send ::
-  (AWSRequest r, Typeable r, Typeable (AWSResponse r)) =>
-  AWS.Env ->
-  r ->
-  Amazon (AWSResponse r)
+send :: AWSRequest r => AWS.Env -> r -> Amazon (AWSResponse r)
 send env r = either (throwM . GeneralError) pure =<< sendCatch env r
 
 is :: AWS.Abbrev -> Int -> AWS.Error -> Bool

--- a/services/proxy/proxy.cabal
+++ b/services/proxy/proxy.cabal
@@ -83,7 +83,7 @@ library
     , exceptions          >=0.8
     , extended
     , http-client         >=0.7
-    , http-client-tls     >=0.3.6.3
+    , http-client-tls     >=0.3
     , http-reverse-proxy  >=0.4
     , http-types          >=0.9
     , imports


### PR DESCRIPTION
Reverts wireapp/wire-server#3736 for now until we fix the LH certificate pinning error.