### PR TITLE
webapp: Upgrade to 2023-12-11-production.0-v0.31.17-0-1e91445

### DIFF
--- a/changelog.d/0-release-notes/upgrade-webapp
+++ b/changelog.d/0-release-notes/upgrade-webapp
@@ -1,0 +1,4 @@
+Upgrade webapp to 2023-12-11-production.0-v0.31.17-0-1e91445
+
+Beside using up-to-date versions in Helm charts is generally beneficial,
+this version also provides multi-ingress support.

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2023-07-13-production.0-v0.31.16-0-a9b67c6"
+  tag: "2023-12-11-production.0-v0.31.17-0-1e91445"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Beside using up-to-date versions in Helm charts is generally beneficial, this version also provides multi-ingress support.

The version has been discussed with the web-team.

Ticket: https://wearezeta.atlassian.net/browse/WPB-6077

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
