### PR TITLE
Revert brig memory setup back to 512mb

### DIFF
--- a/changelog.d/5-internal/restored-brig-memory-quota
+++ b/changelog.d/5-internal/restored-brig-memory-quota
@@ -1,0 +1,1 @@
+Restored Brig memory quota to 512mb down from 1gb. (prev bump #3751)

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -45,7 +45,7 @@ brig:
   resources:
     requests: {}
     limits:
-      memory: 1Gi
+      memory: 512Mi
   config:
     externalUrls:
       nginz: https://kube-staging-nginz-https.zinfra.io


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5676

After some local and CI based testing, it seems that whatever was causing the OOM issue for bring after upgrading GHC to 9.4 is no longer present. Considering the sheer scope of changes since then and the dependencies we updated or swapped since then, and as discussed within the team, I'm setting this up to revert the memory quota back to the previous value, so we can see how it behaves on staging.