### PR TITLE
[WPB-6073] cleanup haskell pins

### DIFF
--- a/changelog.d/5-internal/WPB-6073
+++ b/changelog.d/5-internal/WPB-6073
@@ -1,0 +1,4 @@
+cleanup the haskell-pins
+- remove many pins
+- remove many overrides
+- restructure the files such that it's easier to see what is going on

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -143,7 +143,8 @@ let
       };
     };
 
-    # missing upstream PR 
+    # missing upstream PR, this will get removed when completing
+    # servantification
     wai-predicates = {
       src = fetchgit {
         url = "https://gitlab.com/wireapp/forks/wai-predicates";
@@ -230,7 +231,7 @@ let
   };
   hackagePins = {
     # Major re-write upstream, we should get rid of this dependency rather than
-    # adapt to upstream.
+    # adapt to upstream, this will go away when completing servantification.
     wai-route = {
       version = "0.4.0";
       sha256 = "sha256-DSMckKIeVE/buSMg8Mq+mUm1bYPYB7veA11Ns7vTBbc=";

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -125,6 +125,15 @@ let
       };
     };
 
+    # PR: https://gitlab.com/twittner/cql/-/merge_requests/11
+    cql = {
+      src = fetchgit {
+        url = "https://gitlab.com/wireapp/forks/cql";
+        rev = "abbd2739969d17a909800f282d10d42a254c4e3b";
+        sha256 = "sha256-2MYwZKiTdwgjJdLNvECi7gtcIo+3H4z1nYzen5x0lgU=";
+      };
+    };
+
     # PR: https://gitlab.com/twittner/cql-io/-/merge_requests/20
     cql-io = {
       src = fetchgit {

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -59,27 +59,18 @@
 { lib, fetchgit, pkgs }: hself: hsuper:
 let
   gitPins = {
+    # ----------------
+    # maintained by us
+    # ----------------
+
     transitive-anns = {
       src = fetchgit {
         url = "https://github.com/wireapp/transitive-anns";
-        rev = "7caf82f8d1be0f994a557e0cdc87fde8e32d5420";
-        sha256 = "sha256-rDIAbYpNGMBDOOE1hqLneRSVkCnj3cCQVYGKkhw8t7w=";
+        rev = "95ee8b5f9c47fe04f8f0d1321f0ade261ab9af54";
+        sha256 = "sha256-8NEAHkCBlGO6xnG2K3Lllb2xiCHSYf/dSV1YrmBkOW8=";
       };
     };
-    amqp = {
-      src = fetchgit {
-        url = "https://github.com/hreinhardt/amqp";
-        rev = "b5dfe4362b14b58d51ec306d6871d347751f3d47";
-        sha256 = "sha256-ov85XFztGM0mEoj01lRZN9xYJttKa/crPnp0lh4A5DA=";
-      };
-    };
-    bloodhound = {
-      src = fetchgit {
-        url = "https://github.com/wireapp/bloodhound";
-        rev = "abf819a4a6ec7601f1e58cb8da13b2fdad377d9e";
-        sha256 = "sha256-m1O+F/mOJN5z5WNChmeyHP4dtmLRkl2YnLlTuwzRelk=";
-      };
-    };
+
     cryptobox-haskell = {
       src = fetchgit {
         url = "https://github.com/wireapp/cryptobox-haskell";
@@ -88,7 +79,27 @@ let
       };
     };
 
-    # https://github.com/dpwright/HaskellNet-SSL/pull/33
+    saml2-web-sso = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/saml2-web-sso";
+        rev = "d50bddadf9bd9a96dd6036dad0e2dda27567ec1a";
+        sha256 = "sha256-IKovI1h2Wkm3Y7Sz6XsxLOv654SgUasaWsDX6gi9hZw=";
+      };
+    };
+
+    # --------------------
+    # END maintained by us
+    # --------------------
+
+    bloodhound = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/bloodhound";
+        rev = "abf819a4a6ec7601f1e58cb8da13b2fdad377d9e";
+        sha256 = "sha256-m1O+F/mOJN5z5WNChmeyHP4dtmLRkl2YnLlTuwzRelk=";
+      };
+    };
+
+    # PR: https://github.com/dpwright/HaskellNet-SSL/pull/33
     HaskellNet-SSL = {
       src = fetchgit {
         url = "https://github.com/MangoIV/HaskellNet-SSL";
@@ -96,28 +107,25 @@ let
         sha256 = "sha256-1mu/yEAWr3POY4MHRomum0DDvs5Qty1JvP3v5GS2u64=";
       };
     };
+
     hsaml2 = {
       src = fetchgit {
         url = "https://github.com/wireapp/hsaml2";
-        rev = "51d1fcecebf2417e658b9a78943c84a76a0ed347";
-        sha256 = "sha256-jYJBhXBQ1MTLPI8JsiF2XUtgDxK+eniavNB2B1zaSQg=";
+        rev = "723b377fcd759c8be9ad4b2e159a6a06df0d17c9";
+        sha256 = "sha256-rPfztTu+NR/5FuoYWGMCfJFhrMn4o09bMcEKoerNX4A=";
       };
     };
+
+    # PR: https://github.com/hspec/hspec-wai/pull/49
     hspec-wai = {
       src = fetchgit {
         url = "https://github.com/wireapp/hspec-wai";
-        rev = "6984a06b0c6294677c49d59382d48f975a8733d4";
-        sha256 = "sha256-6FLTMMqvL0xFa5zsMnjVAmdpghmdeBl813bWcOyQo5E=";
+        rev = "08176f07fa893922e2e78dcaf996c33d79d23ce2";
+        sha256 = "sha256-Nc5POjA+mJt7Vi3drczEivGsv9PXeVOCSwp21lLmz58=";
       };
     };
-    saml2-web-sso = {
-      src = fetchgit {
-        url = "https://github.com/wireapp/saml2-web-sso";
-        rev = "ac46ea888026711860cf784b5bda206873c87333";
-        sha256 = "sha256-IKovI1h2Wkm3Y7Sz6XsxLOv654SgUasaWsDX6gi9hZw=";
-      };
-    };
-    # MR: https://gitlab.com/twittner/cql-io/-/merge_requests/20
+
+    # PR: https://gitlab.com/twittner/cql-io/-/merge_requests/20
     cql-io = {
       src = fetchgit {
         url = "https://gitlab.com/wireapp/forks/cql-io";
@@ -125,13 +133,17 @@ let
         sha256 = "sha256-DMRWUq4yorG5QFw2ZyF/DWnRjfnzGupx0njTiOyLzPI=";
       };
     };
+
+    # missing upstream PR 
     wai-predicates = {
       src = fetchgit {
-        url = "https://gitlab.com/wireapp/forks/wai-predicates.git";
+        url = "https://gitlab.com/wireapp/forks/wai-predicates";
         rev = "ff95282a982ab45cced70656475eaf2cefaa26ea";
         sha256 = "sha256-x2XSv2+/+DG9FXN8hfUWGNIO7V4iBhlzYz19WWKaLKQ=";
       };
     };
+
+    # we use upstream, but has not been uploaded to hackage since 2016
     wai-routing = {
       src = fetchgit {
         url = "https://gitlab.com/twittner/wai-routing";
@@ -139,6 +151,7 @@ let
         sha256 = "18icwks9jc6sy42vcvj2ysaip2s0dsrpvm9sy608b6nq6kk1ahlk";
       };
     };
+
     # PR: https://github.com/UnkindPartition/tasty/pull/351
     tasty = {
       src = fetchgit {
@@ -150,46 +163,25 @@ let
         tasty-hunit = "hunit";
       };
     };
-    jose = {
-      src = fetchgit {
-        url = "https://github.com/frasertweedale/hs-jose";
-        rev = "a7f919b19f667dfbb4d5c989ce620d3e75af8247";
-        sha256 = "sha256-SKEE9ZqhjBxHYUKQaoB4IpN4/Ui3tS4S98FgZqj7WlY=";
-      };
-    };
+
+    # sets the required flag for HTTP request bodies.
+    # PR: https://github.com/biocad/servant-openapi3/pull/49
     servant-openapi3 = {
       src = fetchgit {
-        # This is a patched version of the library that sets the required flag for HTTP request bodies.
-        # A PR for these changes has been made for the upstream library. biocad/servant-openapi3#49
         url = "https://github.com/lepsa/servant-openapi3";
         rev = "5cdb2783f15058f753c41b800415d4ba1149a78b";
         sha256 = "sha256-8FM3IAA3ewCuv9Mar8aWmzbyfKK9eLXIJPMHzmYb1zE=";
       };
     };
-    # This can be removed once postie with TLS 1.9 is on nixpkgs.
-    # https://github.com/alexbiehl/postie/pull/4
+
     postie = {
       src = fetchgit {
         url = "https://github.com/wireapp/postie.git";
-        rev = "43b6d1d21d56e567077c194d49efb92e777e7628";
+        rev = "7321b977a2b427e0be782b7239901e4edfbb027f";
         sha256 = "sha256-DKugy4EpRsSgaGvybdh2tLa7HCtoxId+7RAAAw43llA=";
       };
     };
-    # Not tested/relased yet
-    # https://github.com/dylex/invertible/commit/e203c6a729fde87b1f903c3f468f739a085fb446
-    invertible = {
-      src = fetchgit {
-        url = "https://github.com/dylex/invertible.git";
-        rev = "e203c6a729fde87b1f903c3f468f739a085fb446";
-        sha256 = "sha256-G6PX5lpU18oWLkwIityN4Hs0HuwQrq9T51kxbsdpK3M=";
-      };
-    };
-    tls = {
-      src = fetchTarball {
-        url = "https://hackage.haskell.org/package/tls-1.9.0/tls-1.9.0.tar.gz";
-        sha256 = "sha256:1gyc6yfygswg4pjj9hxw3pashq56viivf8m321b4f0bsd2yf372s";
-      };
-    };
+
     tinylog = {
       src = fetchgit {
         url = "https://gitlab.com/wireapp/forks/tinylog.git";
@@ -197,6 +189,7 @@ let
         sha256 = "sha256-htEIJY+LmIMACVZrflU60+X42/g14NxUyFM7VJs4E6w=";
       };
     };
+
     # PR: https://github.com/ocharles/tasty-ant-xml/pull/32
     tasty-ant-xml = {
       src = fetchgit {
@@ -212,24 +205,6 @@ let
         repo = "text-icu-translit";
         rev = "317bbd27ea5ae4e7f93836ee9ca664f9bde7c583";
         hash = "sha256-E35PVxi/4iJFfWts3td52KKZKQt4dj9KFP3SvWG77Cc=";
-      };
-    };
-
-    # PR at https://github.com/google/ghc-source-gen/pull/102
-    ghc-source-gen = {
-      version = "0.4.4.0";
-      src = pkgs.fetchFromGitHub {
-        owner = "circuithub";
-        repo = "ghc-source-gen";
-        rev = "7a6aac047b706508e85ba2054b5bedbecfd7eb7a";
-        hash = "sha256-DZu3XAOYLKcSpOYhjpb6IuXMvRHtGohTkL0nsCb/dT0=";
-      };
-    };
-    hoogle = {
-      src = fetchgit {
-        url = "https://github.com/ndmitchell/hoogle";
-        rev = "0be38ee5e078e31ef7eabeaba255aed12ce7055d";
-        sha256 = "sha256-xcGZ11ocdlB8ks20QAhtPZ+4ggmV4Om4CPHH/M6NjXk=";
       };
     };
     # PR: https://github.com/yesodweb/wai/pull/958
@@ -251,37 +226,20 @@ let
       version = "0.4.0";
       sha256 = "sha256-DSMckKIeVE/buSMg8Mq+mUm1bYPYB7veA11Ns7vTBbc=";
     };
-    polysemy = {
-      version = "1.8.0.0";
-      sha256 = "sha256-AdxxKWXdUjZiHLDj6iswMWpycs7mFB8eKhBR4ljF6kk=";
+
+    # these are not yet in nixpkgs
+    ghc-source-gen = {
+      version = "0.4.4.0";
+      sha256 = "sha256-ZSJGF4sdr7tOCv6IUCjIiTrFYL+5gF4W3U6adjBODrE=";
     };
-    hpack = {
-      version = "0.36.0";
-      sha256 = "sha256-a8jKkzO3CWIoBg+Uaw5TtpDwmeajWCTW1zJNrlpBKPU=";
+    hoogle = {
+      version = "5.0.18.4";
+      sha256 = "sha256-gIc4hpdUfTS33rZPfzwLfVcXkQaglmsljqViyYdihdk=";
     };
-    HsOpenSSL = {
-      version = "0.11.7.5";
-      sha256 = "sha256-CfH1YJSGuF4O1aUfdJwUZKRrVzv5nSPhwoI7mf9ewEg=";
-    };
-    http2 = {
-      version = "4.1.0";
-      sha256 = "sha256-D6RWYBguoj+W1LwNeX04h4csXV69rrs0tZpeNr7ZBqE=";
-    };
-    network-conduit-tls = {
-      version = "1.4.0";
-      sha256 = "sha256-zPT/FMxAiR94NReqNIDa/RS7dtiNWCRe3SZi8P11GDk=";
-    };
-    warp-tls = {
-      version = "3.4.3";
-      sha256 = "sha256-6MjlCKGC8v+7OiSuMFGwO8sgcA3gp0OfOnneI2wSpWI=";
-    };
-    optparse-generic = {
-      version = "1.5.1";
-      sha256 = "sha256-TS3T6AtYfdzmPkG6SwvN/tr2Vdr4eTdGRRH2Xbd8fzM=";
-    };
-    crypton-connection = {
-      version = "0.3.1";
-      sha256 = "sha256-TrRdD56cNIXMlDrHBO0VxQYkJ30pRXe4yVkEILsbMro=";
+    # dependency of hoogle 
+    safe = {
+      version = "0.3.20";
+      sha256 = "sha256-PGwjhrRnkH8cLhd7fHTZFd6ts9abp0w5sLlV8ke1yXU=";
     };
   };
   # Name -> Source -> Maybe Subpath -> Drv

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -2,94 +2,70 @@
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
+  # ----------------
+  # tests don't pass
+  # (these are in general not fine they need to be investigated)
+  # FUTUREWORK: investigate whether all of these tests need to fail
+  # ----------------
+  amqp = hlib.dontCheck hsuper.amqp_0_22_2;
+  # test suite doesn't compile and needs network access
+  bloodhound = hlib.dontCheck hsuper.bloodhound;
+  # tests need network access, cabal2nix disables haddocks
+  cql-io = hlib.doHaddock (hlib.dontCheck hsuper.cql-io);
+  # PR with fix: https://github.com/freckle/hspec-junit-formatter/pull/23
+  # the PR has been merged, but has not arrived in nixpkgs
+  hspec-junit-formatter = hlib.markUnbroken (hlib.dontCheck hsuper.hspec-junit-formatter);
+  markov-chain-usage-model = hlib.markUnbroken (hlib.dontCheck hsuper.markov-chain-usage-model);
+  openapi3 = hlib.markUnbroken (hlib.dontCheck hsuper.openapi3);
+  quickcheck-state-machine = hlib.dontCheck hsuper.quickcheck-state-machine;
+  saml2-web-sso = hlib.dontCheck hsuper.saml2-web-sso;
+  warp = hlib.dontCheck hsuper.warp;
+
+  # ---------------------
+  # need to be jailbroken
+  # (these need to be fixed upstream eventually)
+  # ---------------------
   binary-parsers = hlib.markUnbroken (hlib.doJailbreak hsuper.binary-parsers);
   bytestring-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.bytestring-arbitrary);
-  bytestring-conversion = hlib.markUnbroken (hsuper.bytestring-conversion);
-  openapi3 = hlib.markUnbroken (hlib.dontCheck hsuper.openapi3);
+  lens-datetime = hlib.markUnbroken (hlib.doJailbreak hsuper.lens-datetime);
+  network-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.network-arbitrary);
+  proto-lens-protoc = hlib.doJailbreak hsuper.proto-lens-protoc;
+  proto-lens-setup = hlib.doJailbreak hsuper.proto-lens-setup;
+  th-desugar = hlib.doJailbreak hsuper.th-desugar;
+
+  # ------------------------------------
+  # okay but marked broken (nixpkgs bug)
+  # (we can unfortunately not do anything here but update nixpkgs)
+  # ------------------------------------
+  bytestring-conversion = hlib.markUnbroken hsuper.bytestring-conversion;
+  template = hlib.markUnbroken hsuper.template;
+
+  # -----------------
+  # version overrides
+  # (these are fine but will probably need to be adjusted in a future nixpkgs update)
+  # -----------------
+  hpack = hsuper.hpack_0_36_0;
+  http-client-tls = hsuper.http-client-tls_0_3_6_3;
+  linear-generics = hsuper.linear-generics_0_2_2;
+  network-conduit-tls = hsuper.network-conduit-tls_1_4_0;
+  optparse-generic = hsuper.optparse-generic_1_5_2;
+  th-abstraction = hsuper.th-abstraction_0_5_0_0;
+  tls = hsuper.tls_1_9_0;
+  warp-tls = hsuper.warp-tls_3_4_3;
+
+  # -----------------
+  # flags and patches
+  # (these are fine)
+  # -----------------
+  # Make hoogle static to reduce size of the hoogle image
   cql = hlib.appendPatch (hlib.markUnbroken hsuper.cql) (fetchpatch {
     url = "https://gitlab.com/twittner/cql/-/merge_requests/11.patch";
     sha256 = "sha256-qfcCRkKjSS1TEqPRVBU9Ox2DjsdGsYG/F3DrZ5JGoEI=";
   });
-  ghc-source-gen = hlib.markUnbroken (hlib.doJailbreak hsuper.ghc-source-gen);
-  proto-lens-protoc = hlib.doJailbreak hsuper.proto-lens-protoc;
-  proto-lens-setup = hlib.doJailbreak hsuper.proto-lens-setup;
-  hashtables = hsuper.hashtables_1_3;
-  # in case everything breaks with the hashable update, use this 
-  # hashable = hsuper.callHackage "hashable" "1.4.2.0" {};
-  invertible = hlib.markUnbroken hsuper.invertible;
-  lens-datetime = hlib.markUnbroken (hlib.doJailbreak hsuper.lens-datetime);
-  monoidal-containers = hlib.doJailbreak hsuper.monoidal-containers;
-  network-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.network-arbitrary);
-  one-liner = hlib.doJailbreak hsuper.one-liner;
-  linear-generics = hsuper.linear-generics_0_2_2;
-  polysemy = hlib.doJailbreak hsuper.polysemy;
-  polysemy-check = hlib.markUnbroken (hlib.doJailbreak hsuper.polysemy-check);
-  polysemy-plugin = hlib.doJailbreak hsuper.polysemy-plugin;
-  quickcheck-state-machine = hlib.dontCheck hsuper.quickcheck-state-machine;
-  servant = hlib.doJailbreak hsuper.servant;
-  servant-client = hlib.doJailbreak hsuper.servant-client;
-  servant-client-core = hlib.doJailbreak hsuper.servant-client-core;
-  servant-foreign = hlib.doJailbreak hsuper.servant-foreign;
-  servant-multipart = hlib.doJailbreak hsuper.servant-multipart;
-  servant-swagger-ui = hlib.doJailbreak hsuper.servant-swagger-ui;
-  servant-swagger-ui-core = hlib.doJailbreak hsuper.servant-swagger-ui-core;
-  singletons-th = hlib.doJailbreak hsuper.singletons-th;
-  singletons-base = hlib.dontCheck (hlib.doJailbreak hsuper.singletons-base);
-  sodium-crypto-sign = hlib.addPkgconfigDepend hsuper.sodium-crypto-sign libsodium.dev;
-  text-icu-translit = hlib.markUnbroken (hlib.dontCheck hsuper.text-icu-translit);
-  text-short = hlib.dontCheck hsuper.text-short;
-  template = hlib.markUnbroken (hlib.doJailbreak hsuper.template);
-  type-errors = hlib.dontCheck hsuper.type-errors;
-  th-abstraction = hsuper.th-abstraction_0_5_0_0;
-  th-desugar = hlib.doJailbreak hsuper.th-desugar;
-  wai-middleware-prometheus = hlib.doJailbreak hsuper.wai-middleware-prometheus;
-  wai-predicates = hlib.markUnbroken hsuper.wai-predicates;
-  # transitive-anns has flaky tests
-  transitive-anns = hlib.dontCheck hsuper.transitive-anns;
+  hoogle = hlib.justStaticExecutables hsuper.hoogle;
   http2-manager = hlib.enableCabalFlag hsuper.http2-manager "-f-test-trailing-dot";
-
-  crypton-connection = hlib.markUnbroken hsuper.crypton-connection;
-  # Patched dependency on crypton-connection
-  HaskellNet-SSL = hsuper.HaskellNet-SSL;
-  warp = hlib.dontCheck hsuper.warp;
-
-  # PR with fix: https://github.com/freckle/hspec-junit-formatter/pull/23
-  hspec-junit-formatter = hlib.markUnbroken (hlib.dontCheck hsuper.hspec-junit-formatter);
-
-  # fails doctest
-  markov-chain-usage-model = hlib.markUnbroken (hlib.dontCheck hsuper.markov-chain-usage-model);
-
-  # Some test seems to be broken
-  hsaml2 = hlib.dontCheck hsuper.hsaml2;
-  saml2-web-sso = hlib.dontCheck hsuper.saml2-web-sso;
-  http2 = hlib.dontCheck hsuper.http2;
-  http-client-tls = hsuper.http-client-tls_0_3_6_3;
-  http-client = hsuper.http-client;
-
-
-  # Disable tests because they need network access to a running cassandra
-  #
-  # Explicitly enable haddock because cabal2nix disables it for packages with
-  # internal libraries
-  cql-io = hlib.doHaddock (hlib.dontCheck hsuper.cql-io);
-  amqp = hlib.dontCheck hsuper.amqp;
-
-  # Needs network access to running ES
-  # also the test suite doesn't compile https://github.com/NixOS/nixpkgs/pull/167957
-  # due to related broken quickcheck-arbitrary-template
-  bloodhound = hlib.dontCheck hsuper.bloodhound;
-
-  # Build toool dependencies of local packages
+  sodium-crypto-sign = hlib.addPkgconfigDepend hsuper.sodium-crypto-sign libsodium.dev;
   types-common-journal = hlib.addBuildTool hsuper.types-common-journal protobuf;
   wire-api = hlib.addBuildTool hsuper.wire-api mls-test-cli;
   wire-message-proto-lens = hlib.addBuildTool hsuper.wire-message-proto-lens protobuf;
-
-  # Make hoogle static to reduce size of the hoogle image
-  hoogle = hlib.justStaticExecutables hsuper.hoogle;
-
-  # Postie has been fixed upstream (master)
-  postie = hlib.markUnbroken (hlib.doJailbreak hsuper.postie);
-
-  # This would not be necessary if we could pull revision -r1 from 0.2.2.3
-  kind-generics-th = hlib.doJailbreak hsuper.kind-generics-th;
 }

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -1,4 +1,4 @@
-{ libsodium, protobuf, hlib, mls-test-cli, fetchpatch, ... }:
+{ libsodium, protobuf, hlib, mls-test-cli, ... }:
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
@@ -19,6 +19,8 @@ hself: hsuper: {
   openapi3 = hlib.markUnbroken (hlib.dontCheck hsuper.openapi3);
   quickcheck-state-machine = hlib.dontCheck hsuper.quickcheck-state-machine;
   saml2-web-sso = hlib.dontCheck hsuper.saml2-web-sso;
+  # one of the tests is flaky
+  transitive-anns = hlib.dontCheck hsuper.transitive-anns;
   warp = hlib.dontCheck hsuper.warp;
 
   # ---------------------
@@ -58,10 +60,6 @@ hself: hsuper: {
   # (these are fine)
   # -----------------
   # Make hoogle static to reduce size of the hoogle image
-  cql = hlib.appendPatch (hlib.markUnbroken hsuper.cql) (fetchpatch {
-    url = "https://gitlab.com/twittner/cql/-/merge_requests/11.patch";
-    sha256 = "sha256-qfcCRkKjSS1TEqPRVBU9Ox2DjsdGsYG/F3DrZ5JGoEI=";
-  });
   hoogle = hlib.justStaticExecutables hsuper.hoogle;
   http2-manager = hlib.enableCabalFlag hsuper.http2-manager "-f-test-trailing-dot";
   sodium-crypto-sign = hlib.addPkgconfigDepend hsuper.sodium-crypto-sign libsodium.dev;

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -26,6 +26,7 @@ hself: hsuper: {
   # ---------------------
   # need to be jailbroken
   # (these need to be fixed upstream eventually)
+  # FUTUREWORK: fix the dependency bounds upstream
   # ---------------------
   binary-parsers = hlib.markUnbroken (hlib.doJailbreak hsuper.binary-parsers);
   bytestring-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.bytestring-arbitrary);


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-6073

# libraries that need investigating 

I have tried to sort these roughly by importance

- bloodhound (immense divergence, tests don't pass)
- warp (tests don't pass)
- saml2-web-sso (tests don't pass) 
- amqp (tests don't pass)
- cql-io (tests don't pass) 
- hspec-junit-formatter (tests don't pass) 
- markov-chain-usage-model (tests don't pass) 
- openapi3 (tests don't pass) 
- quickcheck-state-machine (tests don't pass) 
- transitive-anns (tests are flaky) 
- wai-route (it has been noted to get rid of it for a while and we depend on a quite old version) 
- tasty (immense divergence) 
- there's an entire family of libraries that are made by thoralf wittner that we still have in use, commonly as a fork that may also already be years old, it doesn't seem like any of these libraries get any maintenance. Perhaps we can consider taking over maintenance for those


# removed/ updated pins

- amqp: has landed in nixpkgs
- invertible: has landed in nixpkgs
- tls: has landed in nixpkgs
- hoogle/ ghc-source-gen: directly from hackage, has not landed in nixpkgs
- polysemy: newer version on hackage
- hpack: landed in nixpkgs
- hsopenssl: newer version on hackage 
- http2: newer version on hackage 
- network-conduit-tls: landed in nixpkgs
- warp-tls: landed in nixpkgs

# removed overrides 

- kind-generics-th
- http-client
- hsaml2 
- crypton-connection
- transitive-anns
- wai-predicates
- wai-middleware-prometheus
- type-errors
- text-short
- text-icu-translit
- singletons-base
- singletons-th
- servant
- servant-client
- servant-client-core
- servant-foreign
- servant-multipart 
- servant-swagger-ui-core
- servant-swagger-ui 
- polysemy
- polysemy-plugin
- polysemy-check
- monoidal-containers
- invertible
- hashtables
- ghc-source-gen

# remaining pins and their current state

- transitive-anns: we maintain this library by ourselves 
- cryptobox-haskell: we maintain this library by ourselves
- saml2-web-sso: we maintain this library ourselves 
- bloodhound: has diverged wildly, should probably be rebased on upstream and/or merged to it, see [WPB-6168: bloodhound - switch to upstream Todo](https://wearezeta.atlassian.net/browse/WPB-6168) 
- HaskellNet-SSL: PR open, upstream seems abandoned
- hsaml2: actively maintained, should probably  be upstreamed
- hspec-wai: PR open, upstream seems abandoned 
- cql: PR open, upstream seems abandoned, maintainer (thoralf wittner) searches for other maintainers 
- cql-io: PR open, upstream seems abandoned, maintainer (thoralf wittner) searches for other maintainers 
- wai-predicates: missing upstream PR, seems likely abandoned, though
- wai-routing: we use upstream but it appears abandoned as well, mr wittner doesn’t upstream anything to hackage anymore (latest update on hackage 2016, latest commit (the one we use) 2018)
- tasty: [our PR ](https://github.com/UnkindPartition/tasty/pull/351)will not get accepted, we should consolidate also implementing our change to HUnit as requested or think about whether we want to continue maintaining our fork which has diverged a lot
- servant-openapi3: we have a PR open and the project seems to me more or less maintained, there hasn’t been an answer from the maintainers yet, though. Not much we can do here
- postie: PR open, our PR is missing a hackage release
- tinylog: part of the thoralf wittner zoo of libraries, probably abandoned, no PR open to test it, though
- tasty-ant-xml: PR open, the maintainer is occasionally seen, so probably not abandoned. I bumped the PR 
- text-icu-translit: project seems to be abandoned
- warp: PR is somewhat recent (1 month) and project doesn’t seem to be abandoned
- wai-route: note says we should get rid of it, currently only brig and metrics-wai depend on it
- ghc-source-gen, hoogle, safe are not yet in nixpkgs but already released on hackage

# new pins 
- safe, dependency on hoogle which we now pull from hackage instead of from the upstream git repo 

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
