### PR TITLE
increase nginz memory limit

### DIFF
--- a/changelog.d/3-bug-fixes/adjust-nginz-memory-limits
+++ b/changelog.d/3-bug-fixes/adjust-nginz-memory-limits
@@ -1,0 +1,1 @@
+Adjust the requested memory and upper bound limit of `nginz` pods in the related Helm chart. (We experienced OOM errors with the old settings.)

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -4,7 +4,7 @@ resources:
     memory: "256Mi"
     cpu: "100m"
   limits:
-    memory: "800Mi"
+    memory: "1800Mi"
 metrics:
   serviceMonitor:
     enabled: false

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 3
 resources:
   requests:
-    memory: "256Mi"
+    memory: "850Mi"
     cpu: "100m"
   limits:
     memory: "1800Mi"

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -4,7 +4,7 @@ resources:
     memory: "850Mi"
     cpu: "100m"
   limits:
-    memory: "1800Mi"
+    memory: "1200Mi"
 metrics:
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Adjust the requested memory and upper bound limit of `nginz` pods in the related Helm chart. (We experienced OOM errors with the old settings.)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
