### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2024-01-22-production.1-v0.31.17-0-7f83dbe

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2023-12-11-production.0-v0.31.17-0-1e91445"
+  tag: "2024-01-22-production.1-v0.31.17-0-7f83dbe"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2024-01-22-production.1-v0.31.17-0-7f83dbe`
Release: [`2024-01-22-production.1`](https://github.com/wireapp/wire-webapp/releases/tag/2024-01-22-production.1)