### PR TITLE
Update helm charts to support k8s v1.28

### DIFF
--- a/changelog.d/5-internal/update-webapp-teams-accounts-helm-values
+++ b/changelog.d/5-internal/update-webapp-teams-accounts-helm-values
@@ -1,0 +1,1 @@
+replace runAsNonRoot with runAsUser and runAsGroup 1000

--- a/charts/account-pages/values.yaml
+++ b/charts/account-pages/values.yaml
@@ -55,6 +55,7 @@ podSecurityContext:
   capabilities:
     drop:
       - ALL
-  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -59,6 +59,7 @@ podSecurityContext:
   capabilities:
     drop:
       - ALL
-  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -56,6 +56,7 @@ podSecurityContext:
   capabilities:
     drop:
       - ALL
-  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
While trying to install wire-server on Kubernetes v1.28.2 in an on-premise test environment, got the warning/errors for the following things, and this pr includes fixes for them - 

1. for the accounts, team-setting and webapp, got into following error - 
Error: container has runAsNonRoot and image will run as root

While trying to debug the issue, came across similar issue here - https://github.com/jaegertracing/helm-charts/issues/105
the solution in this pr, uses `runAsUser: 1000` policy for these 3 deployments and with this no errors were seen while deploying this.


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
