### PR TITLE
Move repository from GitLab to GitHub

### DIFF
--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -147,7 +147,7 @@ let
     # servantification
     wai-predicates = {
       src = fetchgit {
-        url = "https://gitlab.com/wireapp/forks/wai-predicates";
+        url = "https://github.com/wireapp/wai-predicates";
         rev = "ff95282a982ab45cced70656475eaf2cefaa26ea";
         sha256 = "sha256-x2XSv2+/+DG9FXN8hfUWGNIO7V4iBhlzYz19WWKaLKQ=";
       };


### PR DESCRIPTION
Updated references to git repositories to wireapp forks

This is a follow up to https://github.com/wireapp/wire-server/pull/3841, which missed one repository