### PR TITLE
Revert "Improve usage of http-manager (fixes for fingerprint verification)"

### DIFF
--- a/changelog.d/5-internal/reuse-manager
+++ b/changelog.d/5-internal/reuse-manager
@@ -1,4 +1,0 @@
-- reuse the http manager wherever possible
-- don't reuse the http manager in legalhold scenarios
-- don't concurrently modify the ssl context in such ways that
-  it can create race conditions 

--- a/libs/ssl-util/src/Ssl/Util.hs
+++ b/libs/ssl-util/src/Ssl/Util.hs
@@ -182,18 +182,17 @@ verifyRsaFingerprint d = verifyFingerprint $ \pk ->
 
 -- | this is used as a 'OpenSSL.Session.vpCallback' in 'Brig.App.initExtGetManager'
 --   and 'Galley.Env.initExtEnv'
-extEnvCallback :: IORef [Fingerprint Rsa] -> X509StoreCtx -> IO Bool
+extEnvCallback :: [Fingerprint Rsa] -> X509StoreCtx -> IO Bool
 extEnvCallback fingerprints store = do
   Just sha <- getDigestByName "SHA256"
   cert <- getStoreCtxCert store
   pk <- getPublicKey cert
-  fprs <- readIORef fingerprints
   case toPublicKey @RSAPubKey pk of
     Nothing -> pure False
     Just k -> do
       fp <- rsaFingerprint sha k
       -- find at least one matching fingerprint to continue
-      if not (any (constEqBytes fp . fingerprintBytes) fprs)
+      if not (any (constEqBytes fp . fingerprintBytes) fingerprints)
         then pure False
         else do
           -- Check if the certificate is self-signed.

--- a/services/brig/src/Brig/Provider/RPC.hs
+++ b/services/brig/src/Brig/Provider/RPC.hs
@@ -35,7 +35,7 @@ import Brig.App
 import Brig.Provider.DB (ServiceConn (..))
 import Brig.RPC
 import Control.Error
-import Control.Lens (set, (^.))
+import Control.Lens (set, view, (^.))
 import Control.Monad.Catch
 import Control.Retry (recovering)
 import Data.Aeson
@@ -71,9 +71,8 @@ data ServiceError
 createBot :: ServiceConn -> NewBotRequest -> ExceptT ServiceError (AppT r) NewBotResponse
 createBot scon new = do
   let fprs = toList (sconFingerprints scon)
-  -- fresh http manager
-  man <- liftIO do
-    initExtGetManager =<< newIORef fprs
+  manF <- view extGetManager
+  man <- liftIO $ manF fprs
   extHandleAll onExc $ do
     let req = reqBuilder Http.defaultRequest
     rs <- lift $

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -158,11 +158,9 @@ createEnv m o l = do
   mgr <- initHttpManager o
   h2mgr <- initHttp2Manager
   codeURIcfg <- validateOptions o
-  fprVar <- newIORef []
-  extEnv <- initExtEnv fprVar
   Env (RequestId "N/A") m o l mgr h2mgr (o ^. O.federator) (o ^. O.brig) cass
     <$> Q.new 16000
-    <*> pure (extEnv, fprVar)
+    <*> pure initExtEnv
     <*> maybe (pure Nothing) (fmap Just . Aws.mkEnv l mgr) (o ^. journal)
     <*> loadAllMLSKeys (fold (o ^. settings . mlsPrivateKeyPaths))
     <*> traverse (mkRabbitMqChannelMVar l) (o ^. rabbitmq)

--- a/services/galley/src/Galley/Cassandra/LegalHold.hs
+++ b/services/galley/src/Galley/Cassandra/LegalHold.hs
@@ -73,9 +73,6 @@ interpretLegalHoldStoreToCassandra lh = interpret $ \case
   SetTeamLegalholdWhitelisted tid -> embedClient $ setTeamLegalholdWhitelisted tid
   UnsetTeamLegalholdWhitelisted tid -> embedClient $ unsetTeamLegalholdWhitelisted tid
   IsTeamLegalholdWhitelisted tid -> embedClient $ isTeamLegalholdWhitelisted lh tid
-  -- FUTUREWORK: should this action be part of a separate effect?
-  MakeVerifiedRequestFreshManager fpr url r ->
-    embedApp $ makeVerifiedRequestFreshManager fpr url r
   MakeVerifiedRequest fpr url r ->
     embedApp $ makeVerifiedRequest fpr url r
   ValidateServiceKey sk -> embed @IO $ validateServiceKey sk

--- a/services/galley/src/Galley/Effects/LegalHoldStore.hs
+++ b/services/galley/src/Galley/Effects/LegalHoldStore.hs
@@ -36,7 +36,6 @@ module Galley.Effects.LegalHoldStore
 
     -- * Intra actions
     makeVerifiedRequest,
-    makeVerifiedRequestFreshManager,
   )
 where
 
@@ -62,12 +61,7 @@ data LegalHoldStore m a where
   SetTeamLegalholdWhitelisted :: TeamId -> LegalHoldStore m ()
   UnsetTeamLegalholdWhitelisted :: TeamId -> LegalHoldStore m ()
   IsTeamLegalholdWhitelisted :: TeamId -> LegalHoldStore m Bool
-  -- intra actions
-  MakeVerifiedRequestFreshManager ::
-    Fingerprint Rsa ->
-    HttpsUrl ->
-    (Http.Request -> Http.Request) ->
-    LegalHoldStore m (Http.Response LC8.ByteString)
+  -- -- intra actions
   MakeVerifiedRequest ::
     Fingerprint Rsa ->
     HttpsUrl ->

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -54,11 +54,11 @@ data Env = Env
     _applog :: Logger,
     _manager :: Manager,
     _http2Manager :: Http2Manager,
-    _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type ----- LegalHold.testLHClaimKeys01 FAIL (34.01 s) -----here? E.g. to avoid fresh connections all the time?
+    _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type here? E.g. to avoid fresh connections all the time?
     _brig :: Endpoint, -- FUTUREWORK: see _federator
     _cstate :: ClientState,
     _deleteQueue :: Q.Queue DeleteItem,
-    _extGetManager :: (Manager, IORef [Fingerprint Rsa]),
+    _extGetManager :: [Fingerprint Rsa] -> IO Manager,
     _aEnv :: Maybe Aws.Env,
     _mlsKeys :: SignaturePurpose -> MLSKeys,
     _rabbitmqChannel :: Maybe (MVar Q.Channel),
@@ -68,7 +68,7 @@ data Env = Env
 makeLenses ''Env
 
 -- TODO: somewhat duplicates Brig.App.initExtGetManager
-initExtEnv :: IORef [Fingerprint Rsa] -> IO Manager
+initExtEnv :: [Fingerprint Rsa] -> IO Manager
 initExtEnv fingerprints = do
   ctx <- Ssl.context
   Ssl.contextAddOption ctx SSL_OP_NO_SSLv2

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -151,8 +151,8 @@ urlPort (HttpsUrl u) = do
 
 sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> App ()
 sendMessage fprs reqBuilder = do
-  (man, fprVar) <- view extGetManager
-  modifyIORef' fprVar (nub . (<> fprs))
+  mkMgr <- view extGetManager
+  man <- liftIO $ mkMgr fprs
   let req = reqBuilder defaultRequest
   liftIO $ withConnection req man $ \_conn ->
     Http.withResponse req man (const $ pure ())

--- a/services/galley/src/Galley/External/LegalHoldService.hs
+++ b/services/galley/src/Galley/External/LegalHoldService.hs
@@ -60,7 +60,7 @@ checkLegalHoldServiceStatus ::
   HttpsUrl ->
   Sem r ()
 checkLegalHoldServiceStatus fpr url = do
-  resp <- makeVerifiedRequestFreshManager fpr url reqBuilder
+  resp <- makeVerifiedRequest fpr url reqBuilder
   if Bilge.statusCode resp < 400
     then pure ()
     else do

--- a/services/galley/src/Galley/External/LegalHoldService/Internal.hs
+++ b/services/galley/src/Galley/External/LegalHoldService/Internal.hs
@@ -17,7 +17,6 @@
 
 module Galley.External.LegalHoldService.Internal
   ( makeVerifiedRequest,
-    makeVerifiedRequestFreshManager,
   )
 where
 
@@ -78,19 +77,6 @@ makeVerifiedRequest ::
   (Http.Request -> Http.Request) ->
   App (Http.Response LC8.ByteString)
 makeVerifiedRequest fpr url reqBuilder = do
-  (mgr, fprVar) <- view extGetManager
-  modifyIORef' fprVar (nub . (fpr :))
-  makeVerifiedRequestWithManager mgr url reqBuilder
-
--- | NOTE: Use this function wisely - this creates a new manager _every_ time it is called.
---   We should really _only_ use it in `checkLegalHoldServiceStatus` for the time being because
---   this is where we check for signatures, etc. If we reuse the manager, we are likely to reuse
---   an existing connection which will _not_ cause the new public key to be verified.
-makeVerifiedRequestFreshManager ::
-  Fingerprint Rsa ->
-  HttpsUrl ->
-  (Http.Request -> Http.Request) ->
-  App (Http.Response LC8.ByteString)
-makeVerifiedRequestFreshManager fpr url reqBuilder = do
-  mgr <- liftIO . initExtEnv =<< newIORef [fpr]
+  mkMgr <- view extGetManager
+  mgr <- liftIO $ mkMgr [fpr]
   makeVerifiedRequestWithManager mgr url reqBuilder


### PR DESCRIPTION
Reverts wireapp/wire-server#3825

I have looked at our logs and for ~ 8 hours we get tons of name resolution errors. there's exactly one PR whose logs haven't been reaped yet and that one doesn't have the name resolution errors, I do have to assume that it's this PR. 

The CI was green for 4 runs in a row but didn't catch this...  