### PR TITLE
WPB-6351 Use max available version for internal API calls

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-6351
+++ b/changelog.d/3-bug-fixes/WPB-6351
@@ -1,0 +1,1 @@
+Intra-service calls from brig to galley's public API are now aware of disabled API versions

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -37,6 +37,7 @@ module Wire.API.Routes.Version
     isDevelopmentVersion,
     developmentVersions,
     expandVersionExp,
+    maxAvailableVersion,
 
     -- * Servant combinators
     Until,
@@ -58,12 +59,13 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Domain
 import Data.OpenApi qualified as S
 import Data.Schema
+import Data.Set ((\\))
 import Data.Set qualified as Set
 import Data.Singletons.Base.TH
 import Data.Text qualified as Text
 import Data.Text.Encoding as Text
 import GHC.TypeLits
-import Imports
+import Imports hiding ((\\))
 import Servant
 import Servant.API.Extended.RawM
 import Wire.API.Deprecated
@@ -102,6 +104,9 @@ versionInt V6 = 6
 
 supportedVersions :: [Version]
 supportedVersions = [minBound .. maxBound]
+
+maxAvailableVersion :: Set Version -> Maybe Version
+maxAvailableVersion disabled = Set.lookupMax $ Set.fromList supportedVersions \\ disabled
 
 ----------------------------------------------------------------------
 

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
@@ -3,6 +3,7 @@ module Test.Wire.API.Routes.Version where
 import Data.Aeson as Aeson
 import Data.Binary.Builder
 import Data.ByteString.Conversion
+import Data.Set as Set
 import Imports
 import Servant.API
 import Test.Tasty
@@ -34,6 +35,13 @@ tests =
           testCase "toEncodedUrlPiece" $ tail . show . fromVersionNumber <$> allVersionNumbers @=? cs . toLazyByteString . toEncodedUrlPiece <$> allVersionNumbers,
           testCase "toHeader" $ tail . show . fromVersionNumber <$> allVersionNumbers @=? cs . toHeader <$> allVersionNumbers,
           testCase "toQueryParam" $ tail . show . fromVersionNumber <$> allVersionNumbers @=? cs . toQueryParam <$> allVersionNumbers
+        ],
+      testGroup "Version: maxAvailableVersion" $
+        [ testCase "no version disable" $ maxAvailableVersion mempty @=? Just (maximum allVersions),
+          testCase "all versions disabled" $ maxAvailableVersion (Set.fromList allVersions) @=? Nothing,
+          testCase "all but the min version disabled" $ maxAvailableVersion (Set.fromList (tail allVersions)) @=? Just (minimum allVersions),
+          testCase "all but the max version disabled" $ maxAvailableVersion (Set.fromList (init allVersions)) @=? Just (maximum allVersions),
+          testCase "highest version disabled" $ maxAvailableVersion (Set.singleton (last allVersions)) @=? Just (maximum (init allVersions))
         ]
     ]
 

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -73,7 +73,7 @@ runBrigToIO e (AppT ma) = do
               . interpretClientToIO (e ^. casClient)
               . interpretRpcToIO (e ^. httpManager) (e ^. requestId)
               . interpretServiceRpcToRpc @'Galley "galley" (e ^. galley)
-              . interpretGalleyProviderToRPC
+              . interpretGalleyProviderToRPC (e ^. disabledVersions)
               . codeStoreToCassandra @Cas.Client
               . nowToIOAction (e ^. currentTime)
               . userPendingActivationStoreToCassandra

--- a/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
@@ -103,7 +103,7 @@ createSelfConv v u = do
   void $ ServiceRPC.request @'Galley POST req
   where
     req =
-      paths [toHeader v, "self"]
+      paths [toHeader v, "conversations", "self"]
         . zUser u
         . expect2xx
 

--- a/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
@@ -103,7 +103,7 @@ createSelfConv v u = do
   void $ ServiceRPC.request @'Galley POST req
   where
     req =
-      paths [toHeader v, "", "self"]
+      paths [toHeader v, "self"]
         . zUser u
         . expect2xx
 

--- a/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
@@ -62,44 +62,48 @@ interpretGalleyProviderToRPC ::
     Member (ServiceRPC 'Galley) r,
     Member (Logger (Msg -> Msg)) r
   ) =>
+  Set Version ->
   Sem (GalleyProvider ': r) a ->
   Sem r a
-interpretGalleyProviderToRPC = interpret $ \case
-  CreateSelfConv id' -> createSelfConv id'
-  GetConv id' id'' -> getConv id' id''
-  GetTeamConv id' id'' id'2 -> getTeamConv id' id'' id'2
-  NewClient id' ci -> newClient id' ci
-  CheckUserCanJoinTeam id' -> checkUserCanJoinTeam id'
-  AddTeamMember id' id'' x0 -> addTeamMember id' id'' x0
-  CreateTeam id' bnt id'' -> createTeam id' bnt id''
-  GetTeamMember id' id'' -> getTeamMember id' id''
-  GetTeamMembers id' -> getTeamMembers id'
-  GetTeamId id' -> getTeamId id'
-  GetTeam id' -> getTeam id'
-  GetTeamName id' -> getTeamName id'
-  GetTeamLegalHoldStatus id' -> getTeamLegalHoldStatus id'
-  GetTeamSearchVisibility id' -> getTeamSearchVisibility id'
-  ChangeTeamStatus id' ts m_al -> changeTeamStatus id' ts m_al
-  MemberIsTeamOwner id' id'' -> memberIsTeamOwner id' id''
-  GetAllFeatureConfigsForUser m_id' -> getAllFeatureConfigsForUser m_id'
-  GetVerificationCodeEnabled id' -> getVerificationCodeEnabled id'
-  GetExposeInvitationURLsToTeamAdmin id' -> getTeamExposeInvitationURLsToTeamAdmin id'
+interpretGalleyProviderToRPC disabledVersions =
+  let v = fromMaybe (error "service can't run with undefined API version") $ maxAvailableVersion disabledVersions
+   in interpret $ \case
+        CreateSelfConv id' -> createSelfConv v id'
+        GetConv id' id'' -> getConv v id' id''
+        GetTeamConv id' id'' id'2 -> getTeamConv v id' id'' id'2
+        NewClient id' ci -> newClient id' ci
+        CheckUserCanJoinTeam id' -> checkUserCanJoinTeam id'
+        AddTeamMember id' id'' x0 -> addTeamMember id' id'' x0
+        CreateTeam id' bnt id'' -> createTeam id' bnt id''
+        GetTeamMember id' id'' -> getTeamMember id' id''
+        GetTeamMembers id' -> getTeamMembers id'
+        GetTeamId id' -> getTeamId id'
+        GetTeam id' -> getTeam id'
+        GetTeamName id' -> getTeamName id'
+        GetTeamLegalHoldStatus id' -> getTeamLegalHoldStatus id'
+        GetTeamSearchVisibility id' -> getTeamSearchVisibility id'
+        ChangeTeamStatus id' ts m_al -> changeTeamStatus id' ts m_al
+        MemberIsTeamOwner id' id'' -> memberIsTeamOwner id' id''
+        GetAllFeatureConfigsForUser m_id' -> getAllFeatureConfigsForUser m_id'
+        GetVerificationCodeEnabled id' -> getVerificationCodeEnabled id'
+        GetExposeInvitationURLsToTeamAdmin id' -> getTeamExposeInvitationURLsToTeamAdmin id'
 
 -- | Calls 'Galley.API.createSelfConversationH'.
 createSelfConv ::
   ( Member (ServiceRPC 'Galley) r,
     Member (Logger (Msg -> Msg)) r
   ) =>
+  Version ->
   UserId ->
   Sem r ()
-createSelfConv u = do
+createSelfConv v u = do
   debug $
     remote "galley"
       . msg (val "Creating self conversation")
   void $ ServiceRPC.request @'Galley POST req
   where
     req =
-      paths [toHeader (maxBound :: Version), "conversations", "self"]
+      paths [toHeader v, "", "self"]
         . zUser u
         . expect2xx
 
@@ -109,10 +113,11 @@ getConv ::
     Member (ServiceRPC 'Galley) r,
     Member (Logger (Msg -> Msg)) r
   ) =>
+  Version ->
   UserId ->
   Local ConvId ->
   Sem r (Maybe Conversation)
-getConv usr lcnv = do
+getConv v usr lcnv = do
   debug $
     remote "galley"
       . field "domain" (toByteString (tDomain lcnv))
@@ -125,7 +130,7 @@ getConv usr lcnv = do
   where
     req =
       paths
-        [ toHeader (maxBound :: Version),
+        [ toHeader v,
           "conversations",
           toByteString' (tDomain lcnv),
           toByteString' (tUnqualified lcnv)
@@ -139,11 +144,12 @@ getTeamConv ::
     Member (ServiceRPC 'Galley) r,
     Member (Logger (Msg -> Msg)) r
   ) =>
+  Version ->
   UserId ->
   TeamId ->
   ConvId ->
   Sem r (Maybe Conv.TeamConversation)
-getTeamConv usr tid cnv = do
+getTeamConv v usr tid cnv = do
   debug $
     remote "galley"
       . field "conv" (toByteString cnv)
@@ -155,7 +161,7 @@ getTeamConv usr tid cnv = do
   where
     req =
       paths
-        [ toHeader (maxBound :: Version),
+        [ toHeader v,
           "teams",
           toByteString' tid,
           "conversations",


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-6351

The problem only occurs for intra service calls to public APIs if the latest version(s) are disabled. Internal APIs are not versioned, so everything is fine there.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
