### PR TITLE
WPB-5845 fix: guests can be added to a conversation thats under legal hold

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-5845
+++ b/changelog.d/3-bug-fixes/WPB-5845
@@ -1,1 +1,1 @@
-Guests cannot be added to conversations that are under legalhold
+Guests should not be added to conversations that are under legalhold

--- a/changelog.d/3-bug-fixes/WPB-5845
+++ b/changelog.d/3-bug-fixes/WPB-5845
@@ -1,0 +1,1 @@
+Guests cannot be added to conversations that are under legalhold

--- a/integration/test/Test/LegalHold.hs
+++ b/integration/test/Test/LegalHold.hs
@@ -35,8 +35,8 @@ import Testlib.MockIntegrationService
 import Testlib.Prekeys
 import Testlib.Prelude
 
-testLHPreventAddingGuests :: App ()
-testLHPreventAddingGuests = do
+testLHPreventAddingNonConsentingUsers :: App ()
+testLHPreventAddingNonConsentingUsers = do
   startDynamicBackends [mempty] $ \[dom] -> do
     withMockServer lhMockApp $ \lhPort _chan -> do
       (owner, tid, [alice, alex]) <- createTeam dom 3

--- a/integration/test/Test/LegalHold.hs
+++ b/integration/test/Test/LegalHold.hs
@@ -35,6 +35,56 @@ import Testlib.MockIntegrationService
 import Testlib.Prekeys
 import Testlib.Prelude
 
+testLHPreventAddingGuests :: App ()
+testLHPreventAddingGuests = do
+  startDynamicBackends [mempty] $ \[dom] -> do
+    withMockServer lhMockApp $ \lhPort _chan -> do
+      (owner, tid, [mem1, mem2]) <- createTeam dom 3
+
+      void $ legalholdWhitelistTeam owner tid >>= assertSuccess
+      void $ legalholdIsTeamInWhitelist owner tid >>= assertSuccess
+      void $ postLegalHoldSettings owner tid (mkLegalHoldSettings lhPort) >>= getJSON 201
+
+      guest <- randomUser dom def
+      guestQId <- guest %. "qualified_id"
+      connectUsers =<< forM [mem1, guest] make
+      conv <- postConversation mem1 (defProteus {qualifiedUsers = [mem2], team = Just tid}) >>= getJSON 201
+
+      -- the guest should be added to the conversation
+      bindResponse (addMembers mem1 conv def {users = [guestQId]}) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        resp.json %. "type" `shouldMatch` "conversation.member-join"
+
+      -- assert that the guest is in the conversation
+      bindResponse (getConversation mem1 conv) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        mems <-
+          resp.json %. "members.others" & asList >>= traverse \m -> do
+            m %. "qualified_id"
+        mems `shouldMatchSet` forM [mem2, guest] (\m -> m %. "qualified_id")
+
+      -- now enable legal hold for members of the conversation
+      requestLegalHoldDevice tid owner mem1 >>= assertSuccess
+      requestLegalHoldDevice tid owner mem2 >>= assertSuccess
+      approveLegalHoldDevice tid (mem1 %. "qualified_id") defPassword >>= assertSuccess
+      approveLegalHoldDevice tid (mem2 %. "qualified_id") defPassword >>= assertSuccess
+
+      -- the guest should be removed from the conversation
+      bindResponse (getConversation mem1 conv) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        mems <-
+          resp.json %. "members.others" & asList >>= traverse \m -> do
+            m %. "qualified_id"
+        mems `shouldMatchSet` forM [mem2] (\m -> m %. "qualified_id")
+
+      -- it should not be possible to add another guest
+      guest2 <- randomUser dom def
+      guest2QId <- guest2 %. "qualified_id"
+      connectUsers =<< forM [mem1, guest2] make
+      bindResponse (addMembers mem1 conv def {users = [guest2QId]}) $ \resp -> do
+        resp.status `shouldMatchInt` 403
+        resp.json %. "label" `shouldMatch` "missing-legalhold-consent"
+
 abstractTestLHMessageExchange :: HasCallStack => String -> Int -> Bool -> Bool -> Bool -> Bool -> App ()
 abstractTestLHMessageExchange dom lhPort clients1New clients2New consentFrom1 consentFrom2 = do
   (owner, tid, [mem1, mem2]) <- createTeam dom 3

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -986,8 +986,11 @@ allLegalholdConsentGiven uids = do
       -- a whitelisted team is equivalent to have given consent to be in a
       -- conversation with user under legalhold.
       flip allM (chunksOf 32 uids) $ \uidsPage -> do
-        teamsPage <- nub . Map.elems <$> getUsersTeams uidsPage
-        allM isTeamLegalholdWhitelisted teamsPage
+        teamsPage <- getUsersTeams uidsPage
+        allM (eitherTeamMemberAndLHAllowedOrDefLHStatus teamsPage) uidsPage
+      where
+        eitherTeamMemberAndLHAllowedOrDefLHStatus teamsPage uid = do
+          fromMaybe (consentGiven defUserLegalHoldStatus == ConsentGiven) <$> (for (Map.lookup uid teamsPage) isTeamLegalholdWhitelisted)
 
 -- | Add to every uid the legalhold status
 getLHStatusForUsers ::


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5845

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
