### PR TITLE
Update coturn default image

### DIFF
--- a/changelog.d/3-bug-fixes/coturn-pre-stop-hook
+++ b/changelog.d/3-bug-fixes/coturn-pre-stop-hook
@@ -1,0 +1,1 @@
+Update coturn image with bugfix to its prestop-hook from https://github.com/wireapp/coturn/pull/10 to allow coturn pods to terminate once their traffic has drained.

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.2-federation-wireapp.10
+appVersion: 4.6.2-federation-wireapp.12


### PR DESCRIPTION
Update coturn image with bugfix to its pre-stop-hook from https://github.com/wireapp/coturn/pull/10 to allow coturn pods to terminate once their traffic has drained, instead of waiting for its terminationGracePeriod (up to 24 hours).

Part of https://wearezeta.atlassian.net/browse/WPB-5328

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
