### PR TITLE
update annotation key for k8s 1.27+

### DIFF
--- a/changelog.d/5-internal/update-k8s-annotation-for-topology-aware-routing
+++ b/changelog.d/5-internal/update-k8s-annotation-for-topology-aware-routing
@@ -1,0 +1,1 @@
+updated annotation for enabling Topology Aware Routing to service.kubernetes.io/topology-mode for k8s 1.27+

--- a/charts/background-worker/templates/service.yaml
+++ b/charts/background-worker/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/background-worker/templates/service.yaml
+++ b/charts/background-worker/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/backoffice/templates/service.yaml
+++ b/charts/backoffice/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/backoffice/templates/service.yaml
+++ b/charts/backoffice/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/brig/templates/service.yaml
+++ b/charts/brig/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/brig/templates/service.yaml
+++ b/charts/brig/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/cannon/templates/headless-service.yaml
+++ b/charts/cannon/templates/headless-service.yaml
@@ -14,7 +14,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   # This is what makes it a Headless Service

--- a/charts/cannon/templates/headless-service.yaml
+++ b/charts/cannon/templates/headless-service.yaml
@@ -14,7 +14,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   # This is what makes it a Headless Service

--- a/charts/cannon/templates/nginz-service.yaml
+++ b/charts/cannon/templates/nginz-service.yaml
@@ -18,7 +18,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
     {{- if .Values.service.nginz.externalDNS.enabled }}
     external-dns.alpha.kubernetes.io/ttl: {{ .Values.service.nginz.externalDNS.ttl | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ required "Please provide .service.nginz.hostname when .service.nginz.enabled and .service.nginz.externalDNS.enabled are True" .Values.service.nginz.hostname | quote }}

--- a/charts/cannon/templates/nginz-service.yaml
+++ b/charts/cannon/templates/nginz-service.yaml
@@ -18,7 +18,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
     {{- if .Values.service.nginz.externalDNS.enabled }}
     external-dns.alpha.kubernetes.io/ttl: {{ .Values.service.nginz.externalDNS.ttl | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ required "Please provide .service.nginz.hostname when .service.nginz.enabled and .service.nginz.externalDNS.enabled are True" .Values.service.nginz.hostname | quote }}

--- a/charts/cargohold/templates/service.yaml
+++ b/charts/cargohold/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/cargohold/templates/service.yaml
+++ b/charts/cargohold/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/federator/templates/service.yaml
+++ b/charts/federator/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/federator/templates/service.yaml
+++ b/charts/federator/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/galley/templates/service.yaml
+++ b/charts/galley/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/galley/templates/service.yaml
+++ b/charts/galley/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/gundeck/templates/service.yaml
+++ b/charts/gundeck/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/gundeck/templates/service.yaml
+++ b/charts/gundeck/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/legalhold/templates/service.yaml
+++ b/charts/legalhold/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "{{ .Release.Name }}-hold"
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   selector:

--- a/charts/legalhold/templates/service.yaml
+++ b/charts/legalhold/templates/service.yaml
@@ -3,7 +3,11 @@ kind: Service
 metadata:
   name: "{{ .Release.Name }}-hold"
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/nginz/templates/service.yaml
+++ b/charts/nginz/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/nginz/templates/service.yaml
+++ b/charts/nginz/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/proxy/templates/service.yaml
+++ b/charts/proxy/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/proxy/templates/service.yaml
+++ b/charts/proxy/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/spar/templates/service.yaml
+++ b/charts/spar/templates/service.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if ge (.Capabilities.KubeVersion.Minor|int) 26 }}
     service.kubernetes.io/topology-mode: Auto
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: auto
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/spar/templates/service.yaml
+++ b/charts/spar/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: Auto
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Annotation for enabling Topology Aware Routing has been changed to `service.kubernetes.io/topology-mode` for k8s 1.27+
https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
