### PR TITLE
fix integration-cleanup.sh to match prefix only

### DIFF
--- a/changelog.d/5-internal/integration-cleanup-sh
+++ b/changelog.d/5-internal/integration-cleanup-sh
@@ -1,0 +1,2 @@
+Fix integration-cleanup.sh, now only cleans up releases with `test-` prefixes in
+their names.

--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-releases=$(helm list -A -f 'test-' -o json |
+releases=$(helm list -A -f '^test-' -o json |
     jq -r -f "$DIR/filter-old-releases.jq")
 
 if [ -n "$releases" ]; then


### PR DESCRIPTION
The `-f` filter is a regex and should match the prefix `test-`, thus,
the regex should be `^test-`. Without `^`, the search string is looked
up in the entire release name.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
