### PR TITLE
Merge branch 'q1-2024' into develop

### DIFF
--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-releases=$(helm list -A -f 'test-' -o json |
+releases=$(helm list -A -f '^test-' -o json |
     jq -r -f "$DIR/filter-old-releases.jq")
 
 if [ -n "$releases" ]; then


### PR DESCRIPTION
- Block changes to some user data in mlsE2EId teams (WPB-6189)
- Revert "Block changes to some user data in mlsE2EId teams (WPB-6189)"
- Block changes to some user data in mlsE2EId teams (WPB-6189) (#3833)
- refactor: use GitHub forks (#3841)
- Move repository from GitLab to GitHub (#3843)
- fix: use correct url (#3840)
- [Q1-2024] WPB-4657 disable development API version (#3832)
- [feat] update documentation on how to build `wire-server` (#3867)
- [Q1-2024] WPB-6351 fix: diya elna return 500 on register endpoint zulu (#3864)
- fix Helm pretty-printer for disabledAPIVersions (#3877)
- fix integration-cleanup.sh to match prefix only (#3885)
