### PR TITLE
gundeck: Fix SNS endpoint parser

### DIFF
--- a/changelog.d/3-bug-fixes/sns-arn-parsing
+++ b/changelog.d/3-bug-fixes/sns-arn-parsing
@@ -1,0 +1,3 @@
+The AWS SNS ARN was parsed by accumulating the environment name up to the first
+dash ('-') such that parts of this name spilled over into the app name. Now, we
+accumulate up to the last dash.

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -24,6 +24,7 @@
 , exceptions
 , extended
 , extra
+, foldl
 , gitignoreSource
 , gundeck-types
 , hedis
@@ -105,6 +106,7 @@ mkDerivation {
     exceptions
     extended
     extra
+    foldl
     gundeck-types
     hedis
     http-client

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -186,6 +186,7 @@ mkDerivation {
     aeson
     aeson-pretty
     amazonka
+    amazonka-core
     async
     base
     bytestring-conversion

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -128,6 +128,7 @@ library
     , exceptions             >=0.4
     , extended
     , extra                  >=1.1
+    , foldl
     , gundeck-types          >=1.0
     , hedis                  >=0.14.0
     , http-client            >=0.7

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -392,6 +392,7 @@ test-suite gundeck-tests
   type:               exitcode-stdio-1.0
   main-is:            Main.hs
   other-modules:
+    Aws.Arn
     DelayQueue
     Json
     MockGundeck
@@ -453,6 +454,7 @@ test-suite gundeck-tests
       aeson
     , aeson-pretty
     , amazonka
+    , amazonka-core
     , async
     , base
     , bytestring-conversion

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -527,21 +527,21 @@ updateEndpoint uid t arn e = do
   env <- view awsEnv
   unless (equalTransport && equalApp) $ do
     -- TODO: This log entry is lacking the requestId
-    Log.err $ logMessage uid arn (t ^. token) "Transport or app mismatch"
+    Log.err $ logMessage (t ^. token) "Transport or app mismatch"
     throwM $ mkError status500 "server-error" "Server Error"
-  Log.info $ logMessage uid arn (t ^. token) "Upserting push token."
+  Log.info $ logMessage (t ^. token) "Upserting push token."
   let users = Set.insert uid (e ^. endpointUsers)
   Aws.execute env $ Aws.updateEndpoint users (t ^. token) arn
   where
     equalTransport = t ^. tokenTransport == arn ^. snsTopic . endpointTransport
     equalApp = t ^. tokenApp == arn ^. snsTopic . endpointAppName
-    logMessage a r tk m =
+    logMessage tk m =
       "user"
-        .= UUID.toASCIIBytes (toUUID a)
+        .= UUID.toASCIIBytes (toUUID uid)
         ~~ "token"
           .= Text.take 16 (tokenText tk)
         ~~ "arn"
-          .= toText r
+          .= toText arn
         ~~ msg (val m)
 
 deleteToken :: UserId -> Token -> Gundeck (Maybe ())

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -527,8 +527,11 @@ updateEndpoint uid t arn e = do
   env <- view awsEnv
   unless (equalTransport && equalApp) $ do
     -- TODO: This log entry is lacking the requestId
-    Log.err $ logMessage "Transport or app mismatch"
-    throwM $ mkError status500 "server-error" "Server Error"
+    Log.err $ logMessage "PushToken does not fit to user_push data: Transport or app mismatch"
+  -- We can safely continue after this sanity check: A new entry to
+  -- `user_push` will be written later. And, the old (now invalid) data will
+  -- be cleaned up.
+
   Log.info $ logMessage "Upserting push token."
   let users = Set.insert uid (e ^. endpointUsers)
   Aws.execute env $ Aws.updateEndpoint users (t ^. token) arn

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -526,6 +526,7 @@ updateEndpoint :: UserId -> PushToken -> EndpointArn -> Aws.SNSEndpoint -> Gunde
 updateEndpoint uid t arn e = do
   env <- view awsEnv
   unless (equalTransport && equalApp) $ do
+    -- TODO: This log entry is lacking the requestId
     Log.err $ logMessage uid arn (t ^. token) "Transport or app mismatch"
     throwM $ mkError status500 "server-error" "Server Error"
   Log.info $ logMessage uid arn (t ^. token) "Upserting push token."

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -526,11 +526,12 @@ updateEndpoint :: UserId -> PushToken -> EndpointArn -> Aws.SNSEndpoint -> Gunde
 updateEndpoint uid t arn e = do
   env <- view awsEnv
   unless (equalTransport && equalApp) $ do
+    -- We can safely continue after this sanity check: A new entry to
+    -- `user_push` will be written later. And, the old (now invalid) data will
+    -- be cleaned up.
+
     -- TODO: This log entry is lacking the requestId
     Log.err $ logMessage "PushToken does not fit to user_push data: Transport or app mismatch"
-  -- We can safely continue after this sanity check: A new entry to
-  -- `user_push` will be written later. And, the old (now invalid) data will
-  -- be cleaned up.
 
   Log.info $ logMessage "Upserting push token."
   let users = Set.insert uid (e ^. endpointUsers)

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -540,6 +540,10 @@ updateEndpoint uid t arn e = do
         .= UUID.toASCIIBytes (toUUID uid)
         ~~ "token"
           .= Text.take 16 (t ^. token . to tokenText)
+        ~~ "tokenTransport"
+          .= show (t ^. tokenTransport)
+        ~~ "tokenApp"
+          .= show (t ^. tokenApp)
         ~~ "arn"
           .= toText arn
         ~~ msg (val m)

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -545,7 +545,7 @@ updateEndpoint uid t arn e = do
         ~~ "tokenTransport"
           .= show (t ^. tokenTransport)
         ~~ "tokenApp"
-          .= show (t ^. tokenApp . to appNameText)
+          .= (t ^. tokenApp . to appNameText)
         ~~ "arn"
           .= toText arn
         ~~ "endpointTransport"

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -547,9 +547,13 @@ updateEndpoint uid t arn e = do
         ~~ "tokenTransport"
           .= show (t ^. tokenTransport)
         ~~ "tokenApp"
-          .= show (t ^. tokenApp)
+          .= show (t ^. tokenApp . to appNameText)
         ~~ "arn"
           .= toText arn
+        ~~ "endpointTransport"
+          .= show (arn ^. snsTopic . endpointTransport)
+        ~~ "endpointAppName"
+          .= (arn ^. snsTopic . endpointAppName . to appNameText)
         ~~ "request"
           .= unRequestId requestId
         ~~ msg (val m)

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -528,10 +528,8 @@ updateEndpoint uid t arn e = do
   requestId <- view reqId
 
   unless (equalTransport && equalApp) $ do
-    -- We can safely continue after this sanity check: A new entry to
-    -- `user_push` will be written later. And, the old (now invalid) data will
-    -- be cleaned up.
     Log.err $ logMessage requestId "PushToken does not fit to user_push data: Transport or app mismatch"
+    throwM $ mkError status500 "server-error" "Server Error"
 
   Log.info $ logMessage requestId "Upserting push token."
   let users = Set.insert uid (e ^. endpointUsers)

--- a/services/gundeck/test/unit/Aws/Arn.hs
+++ b/services/gundeck/test/unit/Aws/Arn.hs
@@ -1,0 +1,39 @@
+module Aws.Arn where
+
+import Amazonka.Data.Text
+import Control.Lens
+import Gundeck.Aws.Arn
+import Gundeck.Types
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "Aws.Arn"
+    [ testGroup
+        "Parser"
+        [ testGroup
+            "EndpointArn"
+            [ testCaseSteps "real world round-trip" realWorldArnTest
+            ]
+        ]
+    ]
+
+realWorldArnTest :: HasCallStack => (String -> IO ()) -> Assertion
+realWorldArnTest step = do
+  step "Given an ARN from a test environment"
+  let arnText :: Text = "arn:aws:sns:eu-central-1:091205192927:endpoint/GCM/sven-test-782078216207/ded226c7-45b8-3f6c-9e89-f253340bbb60"
+  arnData <-
+    either (\e -> assertFailure ("Arn cannot be parsed: " ++ e)) pure (fromText @EndpointArn arnText)
+
+  step "Check that values were parsed correctly"
+  (arnData ^. snsRegion) @?= "eu-central-1"
+  (arnData ^. snsAccount . to fromAccount) @?= "091205192927"
+  (arnData ^. snsTopic . endpointTransport) @?= GCM
+  (arnData ^. snsTopic . endpointAppName) @?= "782078216207"
+  (arnData ^. snsTopic . endpointId . to (\(EndpointId eId) -> eId)) @?= "ded226c7-45b8-3f6c-9e89-f253340bbb60"
+
+  step "Expect values to be de-serialized correctly"
+  (toText arnData) @?= arnText

--- a/services/gundeck/test/unit/Main.hs
+++ b/services/gundeck/test/unit/Main.hs
@@ -20,6 +20,7 @@ module Main
   )
 where
 
+import Aws.Arn qualified
 import Data.Metrics.Test (pathsConsistencyCheck)
 import Data.Metrics.WaiRoute (treeToPaths)
 import DelayQueue qualified
@@ -50,5 +51,6 @@ main =
         Native.tests,
         Push.tests,
         ThreadBudget.tests,
-        ParseExistsError.tests
+        ParseExistsError.tests,
+        Aws.Arn.tests
       ]


### PR DESCRIPTION
This PR contains two things:
1. Add fields to the log message such that mismatches between stored and app-provided data become more obvious.
2. Fix an AWS SNS Endpoint parsing bug: We parsed the environment up to the first dash. But, environment names may contain dashes themselves, thus we must accumulate them up to the last dash.

Tickets:
- https://wearezeta.atlassian.net/browse/WPB-6650
- https://wearezeta.atlassian.net/browse/WPB-6653

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
