### PR TITLE
Patch hole in scim docs regarding wire team role manipulation.

### DIFF
--- a/changelog.d/4-docs/wpb-6780-patch-hole-in-scim-docs
+++ b/changelog.d/4-docs/wpb-6780-patch-hole-in-scim-docs
@@ -1,0 +1,1 @@
+Patch hole in scim docs regarding wire team role manipulation.

--- a/docs/src/understand/single-sign-on/trouble-shooting.md
+++ b/docs/src/understand/single-sign-on/trouble-shooting.md
@@ -313,7 +313,16 @@ in your wire team:
       mapped on wire's email address, and provisioning works like in
       the team management app with invitation emails.
 
-This means that if you use email/password authentication, you **must**
+5. SCIM's `roles` is mapped to team role.  Only lists of length 0 or 1
+   are allowed.  Valid values are:
+
+   - `[member]` (same as `[]`, `null`, or missing field)
+   - `[admin]`
+   - `[owner]`
+   - `[partner]`
+
+The mapping of `externalId` implies that if you use email/password
+authentication, you **must**
 map an email address to `externalId` on your side.  With `userName`
 and `displayName`, you are more flexible.
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-6780

![Untitled](https://github.com/wireapp/wire-server/assets/10210727/8cc4a0ee-5fbd-4aec-8d8a-e6818704156e)

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
