### PR TITLE
Fix openapi docs of UTCTime and UTCTimeMillis

### DIFF
--- a/changelog.d/4-docs/utctime-swagger
+++ b/changelog.d/4-docs/utctime-swagger
@@ -1,0 +1,1 @@
+Distinguish UTCTime and UTCTimeMillis in swagger

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -104,21 +104,21 @@ instance ToSchema UTCTimeMillis where
   schema =
     UTCTimeMillis
       <$> showUTCTimeMillis
-        .= ( utcTimeTextSchema
+        .= ( utcTimeTextSchema "UTCTimeMillis"
                & doc . S.schema
                  %~ (S.format ?~ "yyyy-mm-ddThh:MM:ss.qqqZ")
                    . (S.example ?~ "2021-05-12T10:52:02.671Z")
            )
 
-utcTimeTextSchema :: ValueSchemaP NamedSwaggerDoc Text UTCTime
-utcTimeTextSchema =
-  parsedText "UTCTime" (Atto.parseOnly (Atto.utcTime <* Atto.endOfInput))
+utcTimeTextSchema :: Text -> ValueSchemaP NamedSwaggerDoc Text UTCTime
+utcTimeTextSchema name =
+  parsedText name (Atto.parseOnly (Atto.utcTime <* Atto.endOfInput))
     & doc . S.schema
       %~ (S.format ?~ "yyyy-mm-ddThh:MM:ssZ")
         . (S.example ?~ "2021-05-12T10:52:02Z")
 
 utcTimeSchema :: ValueSchema NamedSwaggerDoc UTCTime
-utcTimeSchema = showUTCTime .= utcTimeTextSchema
+utcTimeSchema = showUTCTime .= utcTimeTextSchema "UTCTime"
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: UTCTime -> UTCTimeMillis

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -101,14 +101,21 @@ newtype UTCTimeMillis = UTCTimeMillis {fromUTCTimeMillis :: UTCTime}
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema UTCTimeMillis
 
 instance ToSchema UTCTimeMillis where
-  schema = UTCTimeMillis <$> showUTCTimeMillis .= utcTimeTextSchema
+  schema =
+    UTCTimeMillis
+      <$> showUTCTimeMillis
+        .= ( utcTimeTextSchema
+               & doc . S.schema
+                 %~ (S.format ?~ "yyyy-mm-ddThh:MM:ss.qqqZ")
+                   . (S.example ?~ "2021-05-12T10:52:02.671Z")
+           )
 
 utcTimeTextSchema :: ValueSchemaP NamedSwaggerDoc Text UTCTime
 utcTimeTextSchema =
   parsedText "UTCTime" (Atto.parseOnly (Atto.utcTime <* Atto.endOfInput))
     & doc . S.schema
-      %~ (S.format ?~ "yyyy-mm-ddThh:MM:ss.qqq")
-        . (S.example ?~ "2021-05-12T10:52:02.671Z")
+      %~ (S.format ?~ "yyyy-mm-ddThh:MM:ssZ")
+        . (S.example ?~ "2021-05-12T10:52:02Z")
 
 utcTimeSchema :: ValueSchema NamedSwaggerDoc UTCTime
 utcTimeSchema = showUTCTime .= utcTimeTextSchema


### PR DESCRIPTION
Fix openapi docs inconsistency with datetime fields. We have two kinds of datetime fields: with and without a millisecond component. They were both documented as having the millisecond component.

https://wearezeta.atlassian.net/browse/WPB-6529

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
 - [x] Add note to "API changes" page
