### PR TITLE
Handle async exceptions so Control-C works as expected

### DIFF
--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -386,7 +386,7 @@ retryRequestUntil :: HasCallStack => App Bool -> String -> App ()
 retryRequestUntil reqAction err = do
   isUp <-
     retrying
-      (limitRetriesByCumulativeDelay (7 * 1000 * 1000) (fibonacciBackoff (300 * 1000)))
+      (limitRetriesByCumulativeDelay (4 * 1000 * 1000) (fibonacciBackoff (200 * 1000)))
       (\_ isUp -> pure (not isUp))
       (const reqAction)
   unless isUp $

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -386,7 +386,7 @@ retryRequestUntil :: HasCallStack => App Bool -> String -> App ()
 retryRequestUntil reqAction err = do
   isUp <-
     retrying
-      (limitRetriesByCumulativeDelay (4 * 1000 * 1000) (fibonacciBackoff (200 * 1000)))
+      (limitRetriesByCumulativeDelay (7 * 1000 * 1000) (fibonacciBackoff (300 * 1000)))
       (\_ isUp -> pure (not isUp))
       (const reqAction)
   unless isUp $

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -40,7 +40,7 @@ runTest ge action = lowerCodensity $ do
     (Right <$> runAppWithEnv env action)
       `E.catches` [ E.Handler $ \(e :: SomeAsyncException) -> do
                       -- AsyncExceptions need rethrowing
-                      -- to prevend the last handler from handling async exceptions.
+                      -- to prevent the last handler from handling async exceptions.
                       -- This ensures things like UserInterrupt are properly handled.
                       E.throw e,
                     E.Handler -- AssertionFailure

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -146,6 +146,8 @@ runTests tests mXMLOutput cfg = do
 
   runCodensity (createGlobalEnv cfg) $ \genv ->
     withAsync displayOutput $ \displayThread -> do
+      cap <- getNumCapabilities
+      print $ "Cap: " <> show cap
       report <- fmap mconcat $ pooledForConcurrently tests $ \(qname, _, _, action) -> do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -39,7 +39,12 @@ runTest ge action = lowerCodensity $ do
   env <- mkEnv ge
   liftIO $
     (Right <$> runAppWithEnv env action)
-      `E.catches` [ E.Handler -- AssertionFailure
+      `E.catches` [ E.Handler $ \(e :: SomeAsyncException) -> do
+                      -- AsyncExceptions need rethrowing
+                      -- to prevend the last handler from handling async exceptions.
+                      -- This ensures things like UserInterrupt are properly handled.
+                      E.throw e,
+                    E.Handler -- AssertionFailure
                       (fmap Left . printFailureDetails),
                     E.Handler
                       (fmap Left . printExceptionDetails)

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -16,6 +16,7 @@ import Data.Functor
 import Data.List
 import Data.PEM
 import Data.Time.Clock
+import Data.Traversable (for)
 import RunAllTests
 import System.Directory
 import System.Environment
@@ -146,8 +147,7 @@ runTests tests mXMLOutput cfg = do
 
   runCodensity (createGlobalEnv cfg) $ \genv ->
     withAsync displayOutput $ \displayThread -> do
-      cap <- getNumCapabilities
-      report <- fmap mconcat $ pooledForConcurrentlyN (min 6 cap) tests $ \(qname, _, _, action) -> do
+      report <- fmap mconcat $ for tests $ \(qname, _, _, action) -> do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of
           Left err -> do

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -147,8 +147,7 @@ runTests tests mXMLOutput cfg = do
   runCodensity (createGlobalEnv cfg) $ \genv ->
     withAsync displayOutput $ \displayThread -> do
       cap <- getNumCapabilities
-      print $ "Cap: " <> show cap
-      report <- fmap mconcat $ pooledForConcurrently tests $ \(qname, _, _, action) -> do
+      report <- fmap mconcat $ pooledForConcurrentlyN (min 6 cap) tests $ \(qname, _, _, action) -> do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of
           Left err -> do

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -16,7 +16,6 @@ import Data.Functor
 import Data.List
 import Data.PEM
 import Data.Time.Clock
-import Data.Traversable (for)
 import RunAllTests
 import System.Directory
 import System.Environment
@@ -147,7 +146,8 @@ runTests tests mXMLOutput cfg = do
 
   runCodensity (createGlobalEnv cfg) $ \genv ->
     withAsync displayOutput $ \displayThread -> do
-      report <- fmap mconcat $ for tests $ \(qname, _, _, action) -> do
+      cap <- getNumCapabilities
+      report <- fmap mconcat $ pooledForConcurrentlyN (min 4 cap) tests $ \(qname, _, _, action) -> do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of
           Left err -> do

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -16,6 +16,7 @@ import Data.Functor
 import Data.List
 import Data.PEM
 import Data.Time.Clock
+import Data.Traversable (for)
 import RunAllTests
 import System.Directory
 import System.Environment
@@ -146,8 +147,7 @@ runTests tests mXMLOutput cfg = do
 
   runCodensity (createGlobalEnv cfg) $ \genv ->
     withAsync displayOutput $ \displayThread -> do
-      cap <- getNumCapabilities
-      report <- fmap mconcat $ pooledForConcurrentlyN (min 4 cap) tests $ \(qname, _, _, action) -> do
+      report <- fmap mconcat $ for tests $ \(qname, _, _, action) -> do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of
           Left err -> do


### PR DESCRIPTION
Integration tests weren't being killed on control-c, when investigating a proposed fix we realised that tests were running sequentially on the main thread, causing the issue with exception handling. Since running them in parallel increases flakiness, I'm holding off on correcting this until we do some of the mitigation work we have planned.