### PR TITLE
[WPB-6144] Don't remove MLS clients from a 1-1 conversation

### DIFF
--- a/changelog.d/3-bug-fixes/wpb-6144-messaging-blocked-user
+++ b/changelog.d/3-bug-fixes/wpb-6144-messaging-blocked-user
@@ -1,1 +1,1 @@
-Do not deliver MLS one-to-one conversation messages to a user that blocked the sender
+Do not deliver MLS one-to-one conversation messages to a user that blocked the sender (#3889, #3906)

--- a/services/galley/src/Galley/API/One2One.hs
+++ b/services/galley/src/Galley/API/One2One.hs
@@ -35,7 +35,6 @@ import Galley.Types.UserList
 import Imports
 import Polysemy
 import Wire.API.Conversation hiding (Member)
-import Wire.API.Conversation.Protocol
 import Wire.API.Routes.Internal.Galley.ConversationsIntra
 import Wire.API.User
 
@@ -86,11 +85,6 @@ iUpsertOne2OneConversation UpsertOne2OneConversationRequest {..} = do
                 deleteMembers
                   (tUnqualified lconvId)
                   (UserList [tUnqualified uooLocalUser] [])
-                let mGroupId = case convProtocol conv of
-                      ProtocolProteus -> Nothing
-                      ProtocolMLS meta -> Just . cnvmlsGroupId $ meta
-                      ProtocolMixed meta -> Just . cnvmlsGroupId $ meta
-                for_ mGroupId $ flip removeAllMLSClientsOfUser (tUntagged uooLocalUser)
               (RemoteActor, Included) -> do
                 void $ createMembers (tUnqualified lconvId) (UserList [] [uooRemoteUser])
                 unless (null (convLocalMembers conv)) $

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -384,11 +384,6 @@ removeMLSClients groupId (Qualified usr domain) cs = retry x5 . batch $ do
   for_ cs $ \c ->
     addPrepQuery Cql.removeMLSClient (groupId, domain, usr, c)
 
-removeAllMLSClientsOfUser :: GroupId -> Qualified UserId -> Client ()
-removeAllMLSClientsOfUser groupId (Qualified usr domain) =
-  retry x5 $
-    write Cql.removeAllMLSClientsOfUser (params LocalQuorum (groupId, domain, usr))
-
 removeAllMLSClients :: GroupId -> Client ()
 removeAllMLSClients groupId = do
   retry x5 $ write Cql.removeAllMLSClients (params LocalQuorum (Identity groupId))
@@ -421,7 +416,6 @@ interpretMemberStoreToCassandra = interpret $ \case
   AddMLSClients lcnv quid cs -> embedClient $ addMLSClients lcnv quid cs
   PlanClientRemoval lcnv cids -> embedClient $ planMLSClientRemoval lcnv cids
   RemoveMLSClients lcnv quid cs -> embedClient $ removeMLSClients lcnv quid cs
-  RemoveAllMLSClientsOfUser lcnv quid -> embedClient $ removeAllMLSClientsOfUser lcnv quid
   RemoveAllMLSClients gid -> embedClient $ removeAllMLSClients gid
   LookupMLSClients lcnv -> embedClient $ lookupMLSClients lcnv
   LookupMLSClientLeafIndices lcnv -> embedClient $ lookupMLSClientLeafIndices lcnv

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -493,9 +493,6 @@ planMLSClientRemoval = "update mls_group_member_client set removal_pending = tru
 removeMLSClient :: PrepQuery W (GroupId, Domain, UserId, ClientId) ()
 removeMLSClient = "delete from mls_group_member_client where group_id = ? and user_domain = ? and user = ? and client = ?"
 
-removeAllMLSClientsOfUser :: PrepQuery W (GroupId, Domain, UserId) ()
-removeAllMLSClientsOfUser = "delete from mls_group_member_client where group_id = ? and user_domain = ? and user = ?"
-
 removeAllMLSClients :: PrepQuery W (Identity GroupId) ()
 removeAllMLSClients = "DELETE FROM mls_group_member_client WHERE group_id = ?"
 

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -44,7 +44,6 @@ module Galley.Effects.MemberStore
     addMLSClients,
     planClientRemoval,
     removeMLSClients,
-    removeAllMLSClientsOfUser,
     removeAllMLSClients,
     lookupMLSClients,
     lookupMLSClientLeafIndices,
@@ -89,7 +88,6 @@ data MemberStore m a where
   AddMLSClients :: GroupId -> Qualified UserId -> Set (ClientId, LeafIndex) -> MemberStore m ()
   PlanClientRemoval :: Foldable f => GroupId -> f ClientIdentity -> MemberStore m ()
   RemoveMLSClients :: GroupId -> Qualified UserId -> Set ClientId -> MemberStore m ()
-  RemoveAllMLSClientsOfUser :: GroupId -> Qualified UserId -> MemberStore m ()
   RemoveAllMLSClients :: GroupId -> MemberStore m ()
   LookupMLSClients :: GroupId -> MemberStore m ClientMap
   LookupMLSClientLeafIndices :: GroupId -> MemberStore m (ClientMap, IndexMap)


### PR DESCRIPTION
As part of PR #3889, we used to remove MLS clients from a 1-to-1 conversation only on the backend side (i.e., not updating the group state). However, that's problematic as the state of the group on the backend side and on the client side is out of sync. This PR changes that by not removing the clients from the conversation; only the user is removed.

This PR adds no new tests, but it does rely on the `Test.MLS.One2One.testMLSOne2OneBlockedAfterConnected` test from PR #3889.

Tracked by https://wearezeta.atlassian.net/browse/WPB-6144.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
