### PR TITLE
Welcome notification bug

### DIFF
--- a/changelog.d/3-bug-fixes/welcome-notifications
+++ b/changelog.d/3-bug-fixes/welcome-notifications
@@ -1,0 +1,1 @@
+Fix bug where welcome notifications were generated for each client instead of for each user

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -128,6 +128,7 @@ library
     Test.MLS
     Test.MLS.KeyPackage
     Test.MLS.Message
+    Test.MLS.Notifications
     Test.MLS.One2One
     Test.MLS.SubConversation
     Test.MLS.Unreachable

--- a/integration/test/Test/MLS/Notifications.hs
+++ b/integration/test/Test/MLS/Notifications.hs
@@ -1,0 +1,30 @@
+module Test.MLS.Notifications where
+
+import API.Gundeck
+import MLS.Util
+import Notifications
+import SetupHelpers
+import Testlib.Prelude
+
+testWelcomeNotification :: HasCallStack => App ()
+testWelcomeNotification = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  [alice1, alice2, bob1, bob2] <- traverse (createMLSClient def) [alice, alice, bob, bob]
+  traverse_ uploadNewKeyPackage [alice2, bob1, bob2]
+
+  void $ createNewGroup alice1
+  notif <- withWebSocket bob $ \ws -> do
+    void $ createAddCommit alice1 [alice, bob] >>= sendAndConsumeCommitBundle
+    awaitMatch isWelcomeNotif ws
+
+  notifId <- notif %. "id" & asString
+
+  void $
+    getNotifications
+      bob
+      def
+        { since = Just notifId,
+          client = Just bob2.client,
+          size = Just 10000
+        }
+      >>= getJSON 200

--- a/integration/test/Test/MLS/Notifications.hs
+++ b/integration/test/Test/MLS/Notifications.hs
@@ -19,12 +19,12 @@ testWelcomeNotification = do
 
   notifId <- notif %. "id" & asString
 
-  void $
+  for_ [bob1, bob2] $ \cid ->
     getNotifications
       bob
       def
         { since = Just notifId,
-          client = Just bob2.client,
+          client = Just cid.client,
           size = Just 10000
         }
       >>= getJSON 200

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -96,7 +96,7 @@ sendLocalWelcomes qcnv qusr con now welcome lclients = do
         map (\(u, cs) -> Recipient u (RecipientClientsSome (List1 cs)))
           . Map.assocs
           . foldr
-            (uncurry (\u c -> Map.insertWith (<>) u (pure c)))
+            (\(u, c) -> Map.insertWith (<>) u (pure c))
             mempty
           $ tUnqualified lclients
   let e = Event qcnv Nothing qusr now $ EdMLSWelcome welcome.raw

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -26,12 +26,15 @@ import Data.Aeson qualified as A
 import Data.Domain
 import Data.Id
 import Data.Json.Util
+import Data.List1
+import Data.Map qualified as Map
 import Data.Qualified
 import Data.Time
 import Galley.API.Push
 import Galley.Effects.ExternalAccess
 import Galley.Effects.FederatorAccess
-import Imports
+import Gundeck.Types.Push.V2 (RecipientClients (..))
+import Imports hiding (cs)
 import Network.Wai.Utilities.JSONResponse
 import Polysemy
 import Polysemy.Input
@@ -49,7 +52,7 @@ import Wire.API.MLS.Serialisation
 import Wire.API.MLS.SubConversation
 import Wire.API.MLS.Welcome
 import Wire.API.Message
-import Wire.NotificationSubsystem (NotificationSubsystem)
+import Wire.NotificationSubsystem
 
 sendWelcomes ::
   ( Member FederatorAccess r,
@@ -88,9 +91,17 @@ sendLocalWelcomes ::
   Local [(UserId, ClientId)] ->
   Sem r ()
 sendLocalWelcomes qcnv qusr con now welcome lclients = do
+  -- only create one notification per user
+  let rcpts =
+        map (\(u, cs) -> Recipient u (RecipientClientsSome (List1 cs)))
+          . Map.assocs
+          . foldr
+            (uncurry (\u c -> Map.insertWith (<>) u (pure c)))
+            mempty
+          $ tUnqualified lclients
   let e = Event qcnv Nothing qusr now $ EdMLSWelcome welcome.raw
   runMessagePush lclients (Just qcnv) $
-    newMessagePush mempty con defMessageMetadata (tUnqualified lclients) e
+    newMessagePush mempty con defMessageMetadata rcpts e
 
 sendRemoteWelcomes ::
   ( Member FederatorAccess r,


### PR DESCRIPTION
This implements collecting welcome notifications by user before sending them to gundeck. Otherwise, gundeck would attempt to store one entry for each client, and one would overwrite the others.

We had already fixed a similar bug for MLS messages (https://github.com/wireapp/wire-server/pull/3610), but neglected to apply a similar fix to welcome messages.

https://wearezeta.atlassian.net/browse/WPB-6852

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
