### PR TITLE
hack/ingress-nginx-controller/values: Set ingressClassResource.controllerValue

### DIFF
--- a/hack/helm_vars/ingress-nginx-controller/values.yaml.gotmpl
+++ b/hack/helm_vars/ingress-nginx-controller/values.yaml.gotmpl
@@ -5,6 +5,7 @@ ingress-nginx:
         name: "nginx-{{ .Release.Namespace }}"
         # -- Is this ingressClass enabled or not
         enabled: true
+        controllerValue: "k8s.io/{{ .Release.Namespace }}-nginx-ingress"
     ingressClass: "nginx-{{ .Release.Namespace }}"
     kind: Deployment
     replicaCount: 1


### PR DESCRIPTION
This is required for the controller to only watch this class

https://wearezeta.atlassian.net/browse/WPB-6902

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
