### PR TITLE
coturn cert-reloader sidecar config: process name should not contain the path (helm chart)

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-6567
+++ b/changelog.d/3-bug-fixes/WPB-6567
@@ -1,0 +1,1 @@
+coturn cert-reloader sidecar config: process name should not contain the path (helm chart)

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -186,7 +186,7 @@ spec:
             - name: CONFIG_DIR
               value: /secrets-tls
             - name: PROCESS_NAME
-              value: /usr/bin/turnserver
+              value: turnserver
             - name: RELOAD_SIGNAL
               value: SIGUSR2
           volumeMounts:


### PR DESCRIPTION
The sidecar only looks for the process name.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
