### PR TITLE
 charts/background-worker: Fix name of the service monitor  (#3913)

### DIFF
--- a/changelog.d/3-bug-fixes/bw-service-monitor
+++ b/changelog.d/3-bug-fixes/bw-service-monitor
@@ -1,0 +1,1 @@
+charts/background-worker: Fix name of the service monitor

--- a/charts/background-worker/templates/servicemonitor.yaml
+++ b/charts/background-worker/templates/servicemonitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: brig
+  name: background-worker
   labels:
-    app: brig
+    app: background-worker
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
Backport of #3913 

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
