### PR TITLE
charts/nginz: Fixup Rate limit for claiming MLS key-pacakges by requesting and target user

### DIFF
--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -280,6 +280,10 @@ http {
         limit_req zone={{ $location.specific_user_rate_limit }}{{ if hasKey $location "specific_user_rate_limit_burst" }} burst={{ $location.specific_user_rate_limit_burst }}{{ end }} nodelay;
             {{- end }}
 
+            {{- range $specific_limit := $location.specific_rate_limits }}
+        limit_req zone={{ $specific_limit.zone }}{{ if hasKey $specific_limit "burst" }} burst={{ $specific_limit.burst }}{{ end }} nodelay;
+            {{- end }}
+
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Methods' "GET, POST, PUT, DELETE, OPTIONS";
             add_header 'Access-Control-Allow-Headers' "$http_access_control_request_headers, DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type";

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -67,7 +67,8 @@ nginx_conf:
   user_rate_limit_request_zones:
     - limit_req_zone $rate_limited_by_addr zone=reqs_per_addr_sso:12m rate=50r/s;
     - limit_req_zone $rate_limited_by_zuser zone=reqs_per_user_signatures:12m rate=10r/m;
-    - limit_req_zone $rate_limited_by_zuser_path zone=key_package_claims:12m rate=100r/m;
+    - limit_req_zone $rate_limited_by_zuser zone=key_package_claims_per_user:12m rate=3000r/m;
+    - limit_req_zone $rate_limited_by_zuser_path zone=key_package_claims_per_user_per_target:12m rate=100r/m;
     - limit_req_zone $rate_limited_by_zuser zone=one2one_conv:12m rate=3000r/m;
 
   # The origins from which we allow CORS requests. These are combined with
@@ -214,8 +215,17 @@ nginx_conf:
     - path: /mls/key-packages/claim
       envs:
       - all
-      specific_user_rate_limit: key_package_claims
-      specific_user_rate_limit_burst: 100
+      specific_rate_limits:
+      # This endpoint gets called for every user that will get added to a
+      # conversation. A lot of these are expected during conversation
+      # creation.
+      - zone: key_package_claims_per_user
+        burst: 600
+      - zone: key_package_claims_per_user_per_target
+        burst: 100
+      # The name is a little misleading, this just disables default rate
+      # limiting in favour of the specific one defined above.
+      unlimited_requests_endpoint: true
     - path: /mls/key-packages
       envs:
       - all


### PR DESCRIPTION
Previous logic limited how many keys could be claimed for one user, but continued limiting claims on multiple users. This causes problems while creating conversations when a lot of key package claims are needed.

This commit introduces a concept of specific_rate_limits which allow setting multiple rate limit zones in nginz. Here we use one for limiting how many key packages can be claimed by a user per target and another for limiting how many key packages claimed by a user for any target.

Fixup #3918

https://wearezeta.atlassian.net/browse/WPB-6979

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
