### PR TITLE
gundeck: Fix SNS endpoint parser (backport q1-2024)

### DIFF
--- a/changelog.d/3-bug-fixes/sns-arn-parsing
+++ b/changelog.d/3-bug-fixes/sns-arn-parsing
@@ -1,0 +1,3 @@
+The AWS SNS ARN was parsed by accumulating the environment name up to the first
+dash ('-') such that parts of this name spilled over into the app name. Now, we
+accumulate up to the last dash.

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -24,6 +24,7 @@
 , exceptions
 , extended
 , extra
+, foldl
 , gitignoreSource
 , gundeck-types
 , hedis
@@ -105,6 +106,7 @@ mkDerivation {
     exceptions
     extended
     extra
+    foldl
     gundeck-types
     hedis
     http-client
@@ -184,6 +186,7 @@ mkDerivation {
     aeson
     aeson-pretty
     amazonka
+    amazonka-core
     async
     base
     bytestring-conversion

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -128,6 +128,7 @@ library
     , exceptions             >=0.4
     , extended
     , extra                  >=1.1
+    , foldl
     , gundeck-types          >=1.0
     , hedis                  >=0.14.0
     , http-client            >=0.7
@@ -391,6 +392,7 @@ test-suite gundeck-tests
   type:               exitcode-stdio-1.0
   main-is:            Main.hs
   other-modules:
+    Aws.Arn
     DelayQueue
     Json
     MockGundeck
@@ -452,6 +454,7 @@ test-suite gundeck-tests
       aeson
     , aeson-pretty
     , amazonka
+    , amazonka-core
     , async
     , base
     , bytestring-conversion

--- a/services/gundeck/src/Gundeck/Aws/Arn.hs
+++ b/services/gundeck/src/Gundeck/Aws/Arn.hs
@@ -53,6 +53,7 @@ where
 
 import Amazonka (Region (..))
 import Amazonka.Data
+import Control.Foldl qualified as Foldl
 import Control.Lens
 import Data.Attoparsec.Text
 import Data.Text qualified as Text
@@ -149,9 +150,14 @@ endpointTopicParser :: Parser EndpointTopic
 endpointTopicParser = do
   _ <- string "endpoint"
   t <- char '/' *> transportParser
-  e <- char '/' *> takeTill (== '-')
-  a <- char '-' *> takeTill (== '/')
+  envAndName <- char '/' *> takeTill (== '/')
   i <- char '/' *> takeWhile1 (not . isSpace)
+  let xs = Text.split (== '-') envAndName
+      e = Text.intercalate (Text.pack "-") (init xs)
+  a <- case Foldl.fold Foldl.last xs of
+    Just x -> pure x
+    Nothing -> fail ("Cannot parse appName in " ++ show xs)
+
   pure $ mkEndpointTopic (ArnEnv e) t (AppName a) (EndpointId i)
 
 transportParser :: Parser Transport

--- a/services/gundeck/test/unit/Aws/Arn.hs
+++ b/services/gundeck/test/unit/Aws/Arn.hs
@@ -1,0 +1,57 @@
+module Aws.Arn where
+
+import Amazonka.Data.Text
+import Control.Lens
+import Gundeck.Aws.Arn
+import Gundeck.Types
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "Aws.Arn"
+    [ testGroup
+        "Parser"
+        [ testGroup
+            "EndpointArn"
+            [ testCaseSteps "real world round-trip" realWorldArnTest,
+              testCaseSteps "made-up round-trip" madeUpArnTest
+            ]
+        ]
+    ]
+
+realWorldArnTest :: HasCallStack => (String -> IO ()) -> Assertion
+realWorldArnTest step = do
+  step "Given an ARN from a test environment"
+  let arnText :: Text = "arn:aws:sns:eu-central-1:091205192927:endpoint/GCM/sven-test-782078216207/ded226c7-45b8-3f6c-9e89-f253340bbb60"
+  arnData <-
+    either (\e -> assertFailure ("Arn cannot be parsed: " ++ e)) pure (fromText @EndpointArn arnText)
+
+  step "Check that values were parsed correctly"
+  (arnData ^. snsRegion) @?= "eu-central-1"
+  (arnData ^. snsAccount . to fromAccount) @?= "091205192927"
+  (arnData ^. snsTopic . endpointTransport) @?= GCM
+  (arnData ^. snsTopic . endpointAppName) @?= "782078216207"
+  (arnData ^. snsTopic . endpointId . to (\(EndpointId eId) -> eId)) @?= "ded226c7-45b8-3f6c-9e89-f253340bbb60"
+
+  step "Expect values to be de-serialized correctly"
+  (toText arnData) @?= arnText
+
+madeUpArnTest :: HasCallStack => (String -> IO ()) -> Assertion
+madeUpArnTest step = do
+  step "Given an ARN with data to cover untested cases"
+  let arnText :: Text = "arn:aws:sns:us-east-2:000000000001:endpoint/APNS/nodash-000000000002/8ffd8d14-db06-4f3a-a3bb-08264b9dbfb0"
+  arnData <-
+    either (\e -> assertFailure ("Arn cannot be parsed: " ++ e)) pure (fromText @EndpointArn arnText)
+
+  step "Check that values were parsed correctly"
+  (arnData ^. snsRegion) @?= "us-east-2"
+  (arnData ^. snsAccount . to fromAccount) @?= "000000000001"
+  (arnData ^. snsTopic . endpointTransport) @?= APNS
+  (arnData ^. snsTopic . endpointAppName) @?= "000000000002"
+  (arnData ^. snsTopic . endpointId . to (\(EndpointId eId) -> eId)) @?= "8ffd8d14-db06-4f3a-a3bb-08264b9dbfb0"
+
+  step "Expect values to be de-serialized correctly"
+  (toText arnData) @?= arnText

--- a/services/gundeck/test/unit/Main.hs
+++ b/services/gundeck/test/unit/Main.hs
@@ -20,6 +20,7 @@ module Main
   )
 where
 
+import Aws.Arn qualified
 import Data.Metrics.Test (pathsConsistencyCheck)
 import Data.Metrics.WaiRoute (treeToPaths)
 import DelayQueue qualified
@@ -50,5 +51,6 @@ main =
         Native.tests,
         Push.tests,
         ThreadBudget.tests,
-        ParseExistsError.tests
+        ParseExistsError.tests,
+        Aws.Arn.tests
       ]


### PR DESCRIPTION
This commit contains two things:

1. Add fields to the log message such that mismatches between stored and app-provided data become more obvious.
2. Fix an AWS SNS Endpoint parsing bug: We parsed the environment up to the first dash. But, environment names may contain dashes themselves, thus we must accumulate them up to the last dash.

Tickets:
  * https://wearezeta.atlassian.net/browse/WPB-6650
  * https://wearezeta.atlassian.net/browse/WPB-6653


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
