### PR TITLE
Lazily attempt to get rabbitmq channel

### DIFF
--- a/changelog.d/3-bug-fixes/enqueue-lazy
+++ b/changelog.d/3-bug-fixes/enqueue-lazy
@@ -1,0 +1,1 @@
+Fix crash when enqueing an empty list of notifications and federation is disabled

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -864,3 +864,10 @@ testConversationWithFedV0 = do
   withWebSocket bob $ \ws -> do
     void $ changeConversationName alice conv "foobar" >>= getJSON 200
     void $ awaitMatch isConvNameChangeNotif ws
+
+testConversationWithoutFederation :: HasCallStack => App ()
+testConversationWithoutFederation = withModifiedBackend
+  (def {galleyCfg = removeField "federator" >=> removeField "rabbitmq"})
+  $ \domain -> do
+    [alice, bob] <- createAndConnectUsers [domain, domain]
+    void $ postConversation alice (defProteus {qualifiedUsers = [bob]}) >>= getJSON 201


### PR DESCRIPTION
When sending an empty list of notification, we don't want to fail if federation is disabled.

https://wearezeta.atlassian.net/browse/WPB-7072

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
