### PR TITLE
[WPB-6783] Support unblocking an MLS 1-to-1 conversation

### DIFF
--- a/changelog.d/2-features/WPB-6783
+++ b/changelog.d/2-features/WPB-6783
@@ -1,0 +1,1 @@
+Support unblocking a user in an MLS 1-to-1 conversation

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -68,7 +68,7 @@ testMLSOne2OneBlocked otherDomain = do
 testMLSOne2OneBlockedAfterConnected :: HasCallStack => One2OneScenario -> App ()
 testMLSOne2OneBlockedAfterConnected scenario = do
   alice <- randomUser OwnDomain def
-  let otherDomain = one2OneScenarioDomain scenario
+  let otherDomain = one2OneScenarioUserDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
   conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
@@ -107,7 +107,7 @@ testMLSOne2OneBlockedAfterConnected scenario = do
 testMLSOne2OneUnblocked :: HasCallStack => One2OneScenario -> App ()
 testMLSOne2OneUnblocked scenario = do
   alice <- randomUser OwnDomain def
-  let otherDomain = one2OneScenarioDomain scenario
+  let otherDomain = one2OneScenarioUserDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
   conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
@@ -168,9 +168,9 @@ instance TestCases One2OneScenario where
       MkTestCase "[domain=other;conv=other]" One2OneScenarioRemoteConv
     ]
 
-one2OneScenarioDomain :: One2OneScenario -> Domain
-one2OneScenarioDomain One2OneScenarioLocal = OwnDomain
-one2OneScenarioDomain _ = OtherDomain
+one2OneScenarioUserDomain :: One2OneScenario -> Domain
+one2OneScenarioUserDomain One2OneScenarioLocal = OwnDomain
+one2OneScenarioUserDomain _ = OtherDomain
 
 one2OneScenarioConvDomain :: One2OneScenario -> Domain
 one2OneScenarioConvDomain One2OneScenarioLocal = OwnDomain
@@ -180,7 +180,7 @@ one2OneScenarioConvDomain One2OneScenarioRemoteConv = OtherDomain
 testMLSOne2One :: HasCallStack => One2OneScenario -> App ()
 testMLSOne2One scenario = do
   alice <- randomUser OwnDomain def
-  let otherDomain = one2OneScenarioDomain scenario
+  let otherDomain = one2OneScenarioUserDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
   [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -149,12 +149,13 @@ testMLSOne2OneUnblocked scenario = do
   void $ createExternalCommit alice1 Nothing >>= sendAndConsumeCommitBundle
 
   -- Check that an application message can get to Bob
-  withWebSocket bob1 $ \ws -> do
+  withWebSockets [bob1, bob2] $ \wss -> do
     mp <- createApplicationMessage alice1 "hello, I've always been here"
     void $ sendAndConsumeMessage mp
     let isMessage n = nPayload n %. "type" `isEqual` "conversation.mls-message-add"
-    n <- awaitMatch isMessage ws
-    nPayload n %. "data" `shouldMatch` B8.unpack (Base64.encode mp.message)
+    forM_ wss $ \ws -> do
+      n <- awaitMatch isMessage ws
+      nPayload n %. "data" `shouldMatch` B8.unpack (Base64.encode mp.message)
 
 testGetMLSOne2OneSameTeam :: App ()
 testGetMLSOne2OneSameTeam = do

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -517,7 +517,7 @@ type IConversationAPI =
     -- - MemberJoin event to other, if the conversation existed and only the other was member
     --   before
     :<|> Named
-           "conversation-unblock"
+           "conversation-unblock-unqualified"
            ( CanThrow 'InvalidOperation
                :> CanThrow 'ConvNotFound
                :> ZLocalUser
@@ -526,6 +526,21 @@ type IConversationAPI =
                :> Capture "cnv" ConvId
                :> "unblock"
                :> Put '[Servant.JSON] Conversation
+           )
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberJoin event to you, if the conversation existed and had < 2 members before
+    -- - MemberJoin event to other, if the conversation existed and only the other was member
+    --   before
+    :<|> Named
+           "conversation-unblock"
+           ( CanThrow 'InvalidOperation
+               :> CanThrow 'ConvNotFound
+               :> ZLocalUser
+               :> ZOptConn
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> "unblock"
+               :> Put '[Servant.JSON] ()
            )
     :<|> Named
            "conversation-meta"

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -560,6 +560,17 @@ type IConversationAPI =
                :> QualifiedCapture "user" UserId
                :> Get '[Servant.JSON] Conversation
            )
+    :<|> Named
+           "conversation-mls-one-to-one-established"
+           ( CanThrow 'NotConnected
+               :> CanThrow 'MLSNotEnabled
+               :> ZLocalUser
+               :> "conversations"
+               :> "mls-one2one"
+               :> QualifiedCapture "user" UserId
+               :> "established"
+               :> Get '[Servant.JSON] Bool
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -111,8 +111,8 @@ getFederationStatus _ request = do
 
 sendConnectionAction ::
   ( Member FederationConfigStore r,
-    Member NotificationSubsystem r,
-    Member GalleyProvider r
+    Member GalleyProvider r,
+    Member NotificationSubsystem r
   ) =>
   Domain ->
   NewConnectionRequest ->

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -677,7 +677,8 @@ revokeIdentityH Nothing (Just phone) = lift $ NoContent <$ API.revokeIdentity (R
 revokeIdentityH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
 
 updateConnectionInternalH ::
-  ( Member NotificationSubsystem r,
+  ( Member GalleyProvider r,
+    Member NotificationSubsystem r,
     Member TinyLog r,
     Member (Embed HttpClientIO) r
   ) =>

--- a/services/brig/src/Brig/Effects/GalleyProvider.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider.hs
@@ -36,6 +36,12 @@ import Wire.API.Team.Member qualified as Team
 import Wire.API.Team.Role
 import Wire.API.Team.SearchVisibility
 
+data MLSOneToOneEstablished
+  = Established
+  | NotEstablished
+  | NotAMember
+  deriving (Eq, Show)
+
 data GalleyProvider m a where
   CreateSelfConv ::
     UserId ->
@@ -109,7 +115,7 @@ data GalleyProvider m a where
   IsMLSOne2OneEstablished ::
     Local UserId ->
     Qualified UserId ->
-    GalleyProvider m Bool
+    GalleyProvider m MLSOneToOneEstablished
   UnblockConversation ::
     Local UserId ->
     Maybe ConnId ->

--- a/services/brig/src/Brig/Effects/GalleyProvider.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider.hs
@@ -110,5 +110,10 @@ data GalleyProvider m a where
     Local UserId ->
     Qualified UserId ->
     GalleyProvider m Bool
+  UnblockConversation ::
+    Local UserId ->
+    Maybe ConnId ->
+    Qualified ConvId ->
+    GalleyProvider m Conversation
 
 makeSem ''GalleyProvider

--- a/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
@@ -19,7 +19,7 @@ module Brig.Effects.GalleyProvider.RPC where
 
 import Bilge hiding (head, options, requestId)
 import Brig.API.Types
-import Brig.Effects.GalleyProvider (GalleyProvider (..))
+import Brig.Effects.GalleyProvider (GalleyProvider (..), MLSOneToOneEstablished (..))
 import Brig.RPC hiding (galleyRequest)
 import Brig.Team.Types (ShowOrHideInvitationUrl (..))
 import Control.Error (hush)
@@ -48,7 +48,6 @@ import Servant.API (toHeader)
 import System.Logger (field, msg, val)
 import Util.Options
 import Wire.API.Conversation hiding (Member)
-import Wire.API.Conversation.Protocol
 import Wire.API.Routes.Internal.Galley.TeamsIntra qualified as Team
 import Wire.API.Routes.Version
 import Wire.API.Team
@@ -538,22 +537,17 @@ checkMLSOne2OneEstablished ::
   ) =>
   Local UserId ->
   Qualified UserId ->
-  Sem r Bool
+  Sem r MLSOneToOneEstablished
 checkMLSOne2OneEstablished self (Qualified other otherDomain) = do
   debug $ remote "galley" . msg (val "Get the MLS one-to-one conversation")
-  response <- galleyRequest req
-  case HTTP.statusCode (HTTP.responseStatus response) of
-    403 -> pure False
-    400 -> pure False
-    _ {- 200 is assumed -} -> do
-      conv <- decodeBodyOrThrow @Conversation "galley" response
-      let mEpoch = case cnvProtocol conv of
-            ProtocolProteus -> Nothing
-            ProtocolMLS meta -> Just . cnvmlsEpoch $ meta
-            ProtocolMixed meta -> Just . cnvmlsEpoch $ meta
-      pure $ case mEpoch of
-        Nothing -> False
-        Just (Epoch e) -> e > 0
+  responseSelf <- galleyRequest req
+  case HTTP.statusCode (HTTP.responseStatus responseSelf) of
+    200 -> do
+      established <- decodeBodyOrThrow @Bool "galley" responseSelf
+      pure $ if established then Established else NotEstablished
+    403 -> pure NotAMember
+    400 -> pure NotEstablished
+    _ -> pure NotEstablished
   where
     req =
       method GET
@@ -562,7 +556,8 @@ checkMLSOne2OneEstablished self (Qualified other otherDomain) = do
             "conversations",
             "mls-one2one",
             toByteString' otherDomain,
-            toByteString' other
+            toByteString' other,
+            "established"
           ]
         . zUser (tUnqualified self)
 

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -669,28 +669,6 @@ blockConv lusr qcnv = do
         . zUser (tUnqualified lusr)
         . expect2xx
 
--- | Calls 'Galley.API.unblockConvH'.
-unblockLocalConv ::
-  ( Member (Embed HttpClientIO) r,
-    Member TinyLog r
-  ) =>
-  Local UserId ->
-  Maybe ConnId ->
-  ConvId ->
-  Sem r Conversation
-unblockLocalConv lusr conn cnv = do
-  Log.debug $
-    remote "galley"
-      . field "conv" (toByteString cnv)
-      . msg (val "Unblocking conversation")
-  embed $ galleyRequest PUT req >>= decodeBody "galley"
-  where
-    req =
-      paths ["/i/conversations", toByteString' cnv, "unblock"]
-        . zUser (tUnqualified lusr)
-        . maybe id (header "Z-Connection" . fromConnId) conn
-        . expect2xx
-
 unblockConv ::
   ( Member (Embed HttpClientIO) r,
     Member TinyLog r
@@ -698,12 +676,25 @@ unblockConv ::
   Local UserId ->
   Maybe ConnId ->
   Qualified ConvId ->
-  AppT r Conversation
-unblockConv luid conn =
-  foldQualified
-    luid
-    (liftSem . unblockLocalConv luid conn . tUnqualified)
-    (const (throwM federationNotImplemented))
+  Sem r Conversation
+unblockConv lusr conn (Qualified cnv cdom) = do
+  Log.debug $
+    remote "galley"
+      . field "conv" (toByteString cnv)
+      . field "domain" (toByteString cdom)
+      . msg (val "Unblocking conversation")
+  void . embed $ galleyRequest PUT putReq
+  embed $ galleyRequest GET getReq >>= decodeBody "galley"
+  where
+    putReq =
+      paths ["i", "conversations", toByteString' cdom, toByteString' cnv, "unblock"]
+        . zUser (tUnqualified lusr)
+        . maybe id (header "Z-Connection" . fromConnId) conn
+        . expect2xx
+    getReq =
+      paths ["conversations", toByteString' cdom, toByteString' cnv]
+        . zUser (tUnqualified lusr)
+        . expect2xx
 
 upsertOne2OneConversation ::
   ( MonadReader Env m,

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -127,6 +127,7 @@ conversationAPI =
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
     <@> mkNamedAPI @"conversation-block-unqualified" Update.blockConvUnqualified
     <@> mkNamedAPI @"conversation-block" Update.blockConv
+    <@> mkNamedAPI @"conversation-unblock-unqualified" Update.unblockConvUnqualified
     <@> mkNamedAPI @"conversation-unblock" Update.unblockConv
     <@> mkNamedAPI @"conversation-meta" Query.getConversationMeta
     <@> mkNamedAPI @"conversation-mls-one-to-one" Query.getMLSOne2OneConversation

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -131,6 +131,7 @@ conversationAPI =
     <@> mkNamedAPI @"conversation-unblock" Update.unblockConv
     <@> mkNamedAPI @"conversation-meta" Query.getConversationMeta
     <@> mkNamedAPI @"conversation-mls-one-to-one" Query.getMLSOne2OneConversation
+    <@> mkNamedAPI @"conversation-mls-one-to-one-established" Query.isMLSOne2OneEstablished
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -226,7 +226,7 @@ unblockConv lusr conn =
   foldQualified
     lusr
     (void . unblockConvUnqualified lusr conn . tUnqualified)
-    (unblockRemoteConv lusr conn)
+    (unblockRemoteConv lusr)
 
 unblockConvUnqualified ::
   ( Member ConversationStore r,
@@ -254,10 +254,9 @@ unblockRemoteConv ::
   ( Member MemberStore r
   ) =>
   Local UserId ->
-  Maybe ConnId ->
   Remote ConvId ->
   Sem r ()
-unblockRemoteConv lusr _conn rcnv = do
+unblockRemoteConv lusr rcnv = do
   E.createMembersInRemoteConversation rcnv [tUnqualified lusr]
 
 -- conversation updates

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -175,8 +175,8 @@ blockConv ::
 blockConv lusr qcnv =
   foldQualified
     lusr
-    (\lcnv -> blockConvUnqualified (tUnqualified lusr) (tUnqualified lcnv))
-    (\rcnv -> blockRemoteConv lusr rcnv)
+    (blockConvUnqualified (tUnqualified lusr) . tUnqualified)
+    (blockRemoteConv lusr)
     qcnv
 
 blockConvUnqualified ::

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -23,6 +23,7 @@ module Galley.API.Update
     blockConv,
     blockConvUnqualified,
     unblockConv,
+    unblockConvUnqualified,
     checkReusableCode,
     joinConversationByReusableCode,
     joinConversationById,
@@ -219,15 +220,45 @@ unblockConv ::
   ) =>
   Local UserId ->
   Maybe ConnId ->
+  Qualified ConvId ->
+  Sem r ()
+unblockConv lusr conn =
+  foldQualified
+    lusr
+    (void . unblockConvUnqualified lusr conn . tUnqualified)
+    (unblockRemoteConv lusr conn)
+
+unblockConvUnqualified ::
+  ( Member ConversationStore r,
+    Member (Error InternalError) r,
+    Member (ErrorS 'ConvNotFound) r,
+    Member (ErrorS 'InvalidOperation) r,
+    Member NotificationSubsystem r,
+    Member (Input UTCTime) r,
+    Member MemberStore r,
+    Member TinyLog r
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
   ConvId ->
   Sem r Conversation
-unblockConv lusr conn cnv = do
+unblockConvUnqualified lusr conn cnv = do
   conv <-
     E.getConversation cnv >>= noteS @'ConvNotFound
   unless (Data.convType conv `elem` [ConnectConv, One2OneConv]) $
     throwS @'InvalidOperation
   conv' <- acceptOne2One lusr conv conn
   conversationView lusr conv'
+
+unblockRemoteConv ::
+  ( Member MemberStore r
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  Remote ConvId ->
+  Sem r ()
+unblockRemoteConv lusr _conn rcnv = do
+  E.createMembersInRemoteConversation rcnv [tUnqualified lusr]
 
 -- conversation updates
 


### PR DESCRIPTION
The PR adds support for unblocking a user in an MLS 1-to-1 conversation.

Tracked by https://wearezeta.atlassian.net/browse/WPB-6783.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
