### PR TITLE
Bump hscim version and deps

### DIFF
--- a/libs/hscim/CHANGELOG
+++ b/libs/hscim/CHANGELOG
@@ -1,3 +1,6 @@
+0.4.0:
+  - update dependencies
+
 0.3.6:
   - fix serialization: json attributes in scim are case-insensitive
 

--- a/libs/hscim/default.nix
+++ b/libs/hscim/default.nix
@@ -47,7 +47,7 @@
 }:
 mkDerivation {
   pname = "hscim";
-  version = "0.3.6";
+  version = "0.4.0.2";
   src = gitignoreSource ./.;
   isLibrary = true;
   isExecutable = true;
@@ -86,6 +86,7 @@ mkDerivation {
     uuid
     wai
     wai-extra
+    warp
   ];
   executableHaskellDepends = [
     base

--- a/libs/hscim/default.nix
+++ b/libs/hscim/default.nix
@@ -86,7 +86,6 @@ mkDerivation {
     uuid
     wai
     wai-extra
-    warp
   ];
   executableHaskellDepends = [
     base

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -117,7 +117,6 @@ library
     , uuid                 >=1.3.15  && <1.4
     , wai                  >=3.2.3   && <3.3
     , wai-extra            >=3.1.13  && <3.2
-    , warp                 >=3.3.30  && <3.4
 
   default-language:   Haskell2010
 

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -81,7 +81,7 @@ library
     TypeOperators
     TypeSynonymInstances
 
-  ghc-options:        -Wall -Werror -Wredundant-constraints -Wunused-packages
+  ghc-options:        -Wall -Wredundant-constraints -Wunused-packages
   build-depends:
       aeson                >=2.1.2   && <2.2
     , aeson-qq             >=0.8.4   && <0.9
@@ -144,8 +144,8 @@ executable hscim-server
     TypeSynonymInstances
 
   ghc-options:
-    -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-    -Wredundant-constraints -Wunused-packages
+    -Wall -threaded -rtsopts -with-rtsopts=-N -Wredundant-constraints
+    -Wunused-packages
 
   build-depends:
       base
@@ -199,8 +199,8 @@ test-suite spec
     TypeSynonymInstances
 
   ghc-options:
-    -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
-    -Wredundant-constraints -Wunused-packages
+    -Wall -threaded -rtsopts -with-rtsopts=-N -Wredundant-constraints
+    -Wunused-packages
 
   build-tool-depends: hspec-discover:hspec-discover
   build-depends:

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               hscim
-version:            0.3.6
+version:            0.4.0.2
 synopsis:           hscim json schema and server implementation
 description:
   The README file will answer all the questions you might have
@@ -83,40 +83,41 @@ library
 
   ghc-options:        -Wall -Werror -Wredundant-constraints -Wunused-packages
   build-depends:
-      aeson
-    , aeson-qq
-    , attoparsec
-    , base
-    , bytestring
-    , case-insensitive
-    , email-validate
-    , hashable
-    , hspec
-    , hspec-expectations
-    , hspec-wai
-    , http-api-data
-    , http-media
-    , http-types
-    , list-t
-    , microlens
-    , mmorph
-    , mtl
-    , network-uri
-    , retry
-    , scientific
-    , servant
-    , servant-client
-    , servant-client-core
-    , servant-server
-    , stm
-    , stm-containers
-    , string-conversions
-    , template-haskell
-    , text
-    , time
-    , uuid
-    , wai
-    , wai-extra
+      aeson                >=2.1.2   && <2.2
+    , aeson-qq             >=0.8.4   && <0.9
+    , attoparsec           >=0.14.4  && <0.15
+    , base                 >=4.17.2  && <4.18
+    , bytestring           >=0.10.4  && <0.12
+    , case-insensitive     >=1.2.1   && <1.3
+    , email-validate       >=2.3.2   && <2.4
+    , hashable             >=1.4.3   && <1.5
+    , hspec                >=2.10.10 && <2.11
+    , hspec-expectations   >=0.8.2   && <0.9
+    , hspec-wai            >=0.11.1  && <0.12
+    , http-api-data        >=0.5     && <0.6
+    , http-media           >=0.8.1   && <0.9
+    , http-types           >=0.12.3  && <0.13
+    , list-t               >=1.0.5   && <1.1
+    , microlens            >=0.4.13  && <0.5
+    , mmorph               >=1.2.0   && <1.3
+    , mtl                  >=2.2.2   && <2.3
+    , network-uri          >=2.6.4   && <2.7
+    , retry                >=0.9.3   && <0.10
+    , scientific           >=0.3.7   && <0.4
+    , servant              >=0.19.1  && <0.20
+    , servant-client       >=0.19    && <0.20
+    , servant-client-core  >=0.19    && <0.20
+    , servant-server       >=0.19.2  && <0.20
+    , stm                  >=2.5.1   && <2.6
+    , stm-containers       >=1.2.0   && <1.3
+    , string-conversions   >=0.4.0   && <0.5
+    , template-haskell     >=2.19.0  && <2.20
+    , text                 >=2.0.2   && <2.1
+    , time                 >=1.12.2  && <1.13
+    , uuid                 >=1.3.15  && <1.4
+    , wai                  >=3.2.3   && <3.3
+    , wai-extra            >=3.1.13  && <3.2
+    , warp                 >=3.3.30  && <3.4
 
   default-language:   Haskell2010
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-7176

prerequisite for https://wearezeta.atlassian.net/browse/WPB-2970

https://hackage.haskell.org/package/hscim-0.4.0.2 has been published, this PR is to keep track of that version in wire-server.
