### PR TITLE
smallstep-accomp: Resolve proxy target on request (#3946)

### DIFF
--- a/changelog.d/5-internal/smallstep-accomp-target-resolving
+++ b/changelog.d/5-internal/smallstep-accomp-target-resolving
@@ -1,0 +1,4 @@
+Ensure that targets of the smallstep nginx proxy are resolved at runtime via the
+configured DNS server. This has two benefits: The target gets adjusted when it's
+changed at the DNS server. And, nginx doesn't fail to start when the target
+doesn't exist yet.

--- a/charts/smallstep-accomp/templates/server-block-configmap.yaml
+++ b/charts/smallstep-accomp/templates/server-block-configmap.yaml
@@ -17,12 +17,16 @@ data:
       {{- range .Values.upstreams.proxiedHosts }}
 
       location /proxyCrl/{{ . }} {
+        # This indirection is required to make the resolver check the domain.
+        # Otherwise, broken upstreams lead to broken deployments.
+        set $backend "{{ . }}";
+
         proxy_redirect off;
         proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header Host {{ . }};
+        proxy_set_header Host $backend;
         proxy_hide_header Content-Type;
         add_header Content-Type application/pkix-crl;
-        proxy_pass "https://{{ . }}/crl";
+        proxy_pass "https://$backend/crl";
       }
 
       {{- end }}


### PR DESCRIPTION
Usually, proxy targets are resolved when nginx is started. This can lead to strange behavior if the target either doesn't exist (yet) or the DNS entry changes while nginx is running.

This little trick with the indirection via a variable should trigger the lookup(s) while nginx is running. The default behavior of the `resolver` directive is to update the target according to its TTL in the configured DNS server.

N.B. this a cherry-pick / backport of https://github.com/wireapp/wire-server/pull/3946
Ticket: https://wearezeta.atlassian.net/browse/WPB-6822

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
