### PR TITLE
smallstep-accomp: Disable client-side caching (#3952)

### DIFF
--- a/changelog.d/5-internal/smallstep-accomp-no-client-side-caching
+++ b/changelog.d/5-internal/smallstep-accomp-no-client-side-caching
@@ -1,0 +1,2 @@
+To ensure certificate revocations get active in a short time frame, disable
+caching of proxy results on client side by setting respective HTTP headers.

--- a/charts/smallstep-accomp/templates/server-block-configmap.yaml
+++ b/charts/smallstep-accomp/templates/server-block-configmap.yaml
@@ -26,6 +26,11 @@ data:
         proxy_set_header Host $backend;
         proxy_hide_header Content-Type;
         add_header Content-Type application/pkix-crl;
+        # Prevent caching on client side
+        add_header Cache-Control 'no-cache, no-store, must-revalidate';
+        add_header Pragma 'no-cache';
+        add_header Expires '0';
+
         proxy_pass "https://$backend/crl";
       }
 


### PR DESCRIPTION
To ensure certificate revocations get active in a short time frame, disable caching of proxy results on client side by setting respective HTTP headers.

This is syncing in https://github.com/wireapp/wire-server/pull/3952
Ticket: https://wearezeta.atlassian.net/browse/WPB-6904

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
