### PR TITLE
WPB 7155 smallstep-accomp CRL-Proxy CORS

### DIFF
--- a/changelog.d/5-internal/WPB-7155
+++ b/changelog.d/5-internal/WPB-7155
@@ -1,0 +1,2 @@
+In order for the CRL-proxy to function correctly, it needs to have CORS headers set.
+We are now setting the CORS headers on the ingress level.

--- a/charts/smallstep-accomp/values.yaml
+++ b/charts/smallstep-accomp/values.yaml
@@ -16,7 +16,11 @@ nginx:
     #   - 
     #     hosts: [ "acme.alpha.example.com" ]
     #     secretName: "smallstep-step-certificates-ingress-cert"
-    #
+    
+    # annotations:
+    #     nginx.ingress.kubernetes.io/cors-allow-origin: https://webapp.acme.alpha.example.com
+    #     nginx.ingress.kubernetes.io/cors-expose-headers: Replay-Nonce, Location
+    #     nginx.ingress.kubernetes.io/enable-cors: 'true'
 
 upstreams:
   enabled: true


### PR DESCRIPTION
In order for the CRL-proxy to function correctly, it needs to have CORS headers set.
We are now setting the CORS headers on the ingress level.