### PR TITLE
gundeck: Make notificationTTL configurable

### DIFF
--- a/changelog.d/2-features/gundeck-configure-notificationTTL
+++ b/changelog.d/2-features/gundeck-configure-notificationTTL
@@ -1,0 +1,3 @@
+Make gundeck's notificationTTL configurable. The value defines how long
+notifications are (at most) stored in the database. Decreasing this value e.g.
+helps to safe database space on test environments.

--- a/charts/gundeck/templates/configmap.yaml
+++ b/charts/gundeck/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
 
     settings:
       httpPoolSize: 1024
-      notificationTTL: 2419200
+      notificationTTL: {{ required "config.notificationTTL" .notificationTTL }}
       bulkPush: {{ .bulkPush }}
       {{- if hasKey . "perNativePushConcurrency" }}
       perNativePushConcurrency: {{ .perNativePushConcurrency }}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -57,7 +57,8 @@ config:
   # the database if notifications have inlined payloads.
   internalPageSize: 100
 
-  # TTL of stored notifications in Seconds.
+  # TTL of stored notifications in Seconds. After this period, notifications
+  # will be deleted and thus not delivered.
   # The default is 28 days.
   notificationTTL: 2419200
 

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -57,6 +57,10 @@ config:
   # the database if notifications have inlined payloads.
   internalPageSize: 100
 
+  # TTL of stored notifications in Seconds.
+  # The default is 28 days.
+  notificationTTL: 2419200
+
 serviceAccount:
   # When setting this to 'false', either make sure that a service account named
   # 'gundeck' exists or change the 'name' field to 'default'


### PR DESCRIPTION
Decreasing the notification TTL can e.g. safe database space on test environments.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
