### PR TITLE
[WPB-6442] Migrate team feature tests - part #1

### DIFF
--- a/changelog.d/5-internal/WPB-6442-port-tests
+++ b/changelog.d/5-internal/WPB-6442-port-tests
@@ -1,0 +1,1 @@
+Move team feature integration tests between packages: from galley-integration to integration

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -53,6 +53,7 @@
 , regex-base
 , regex-tdfa
 , retry
+, schema-profunctor
 , scientific
 , split
 , stm
@@ -138,6 +139,7 @@ mkDerivation {
     regex-base
     regex-tdfa
     retry
+    schema-profunctor
     scientific
     split
     stm

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -44,6 +44,7 @@
 , mtl
 , network
 , network-uri
+, openapi3
 , optparse-applicative
 , pem
 , process
@@ -130,6 +131,7 @@ mkDerivation {
     mtl
     network
     network-uri
+    openapi3
     optparse-applicative
     pem
     process

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -213,6 +213,7 @@ library
     , regex-base
     , regex-tdfa
     , retry
+    , schema-profunctor
     , scientific
     , split
     , stm

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -204,6 +204,7 @@ library
     , mtl
     , network
     , network-uri
+    , openapi3
     , optparse-applicative
     , pem
     , process

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -95,6 +95,7 @@ library
     API.Common
     API.Federator
     API.Galley
+    API.GalleyCommon
     API.GalleyInternal
     API.Gundeck
     API.GundeckInternal

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -4,6 +4,7 @@
 module API.Galley where
 
 import API.Common
+import API.GalleyCommon
 import Control.Lens hiding ((.=))
 import Control.Monad.Reader
 import Control.Retry
@@ -536,6 +537,21 @@ getTeamFeature featureName user tid = do
     baseRequest user Galley Versioned $
       joinHttpPath ["teams", tidStr, "features", featureName]
   submit "GET" req
+
+setTeamFeature ::
+  (HasCallStack, MakesValue tid, MakesValue user) =>
+  String ->
+  user ->
+  tid ->
+  WithStatusNoLock ->
+  App Response
+setTeamFeature featureName user tid status = do
+  tidStr <- asString tid
+  st <- make status
+  req <-
+    baseRequest user Galley Versioned $
+      joinHttpPath ["teams", tidStr, "features", featureName]
+  submit "PUT" $ addJSON st req
 
 extractTeamFeatureFromAll ::
   (HasCallStack, MakesValue user) =>

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -524,6 +524,33 @@ data AppLockSettings = AppLockSettings
 instance Default AppLockSettings where
   def = AppLockSettings "disabled" False 60
 
+getTeamFeature ::
+  (HasCallStack, MakesValue tid, MakesValue user) =>
+  String ->
+  user ->
+  tid ->
+  App Response
+getTeamFeature featureName user tid = do
+  tidStr <- asString tid
+  req <-
+    baseRequest user Galley Versioned $
+      joinHttpPath ["teams", tidStr, "features", featureName]
+  submit "GET" req
+
+extractTeamFeatureFromAll ::
+  (HasCallStack, MakesValue user) =>
+  String ->
+  user ->
+  App Value
+extractTeamFeatureFromAll featureName user = do
+  cfgs <- getAllFeatureConfigs user >>= getJSON 200
+  cfgs %. featureName
+
+getAllFeatureConfigs :: (HasCallStack, MakesValue user) => user -> App Response
+getAllFeatureConfigs user = do
+  req <- baseRequest user Galley Versioned "feature-configs"
+  submit "GET" req
+
 -- | https://staging-nginz-https.zinfra.io/v6/api/swagger-ui/#/default/put_teams__tid__features_appLock
 putAppLockSettings ::
   (HasCallStack, MakesValue tid, MakesValue caller) =>

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -539,11 +539,15 @@ getTeamFeature featureName user tid = do
   submit "GET" req
 
 setTeamFeature ::
-  (HasCallStack, MakesValue tid, MakesValue user) =>
+  ( HasCallStack,
+    MakesValue tid,
+    MakesValue user,
+    ToJSON cfg
+  ) =>
   String ->
   user ->
   tid ->
-  WithStatusNoLock ->
+  WithStatusNoLock cfg ->
   App Response
 setTeamFeature featureName user tid status = do
   tidStr <- asString tid

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -557,17 +557,21 @@ setTeamFeature featureName user tid status = do
       joinHttpPath ["teams", tidStr, "features", featureName]
   submit "PUT" $ addJSON st req
 
-extractTeamFeatureFromAll ::
+-- | A function where only the user info is used for authentication, and no team
+-- association.
+extractTeamFeatureFromAllPersonal ::
   (HasCallStack, MakesValue user) =>
   String ->
   user ->
   App Value
-extractTeamFeatureFromAll featureName user = do
-  cfgs <- getAllFeatureConfigs user >>= getJSON 200
+extractTeamFeatureFromAllPersonal featureName user = do
+  cfgs <- getAllFeatureConfigsPersonal user >>= getJSON 200
   cfgs %. featureName
 
-getAllFeatureConfigs :: (HasCallStack, MakesValue user) => user -> App Response
-getAllFeatureConfigs user = do
+-- | An endpoint where only the user info is used for authentication, and no
+-- team association.
+getAllFeatureConfigsPersonal :: (HasCallStack, MakesValue user) => user -> App Response
+getAllFeatureConfigsPersonal user = do
   req <- baseRequest user Galley Versioned "feature-configs"
   submit "GET" req
 

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -538,6 +538,18 @@ getTeamFeature featureName user tid = do
       joinHttpPath ["teams", tidStr, "features", featureName]
   submit "GET" req
 
+getAllTeamFeatures ::
+  (HasCallStack, MakesValue tid, MakesValue user) =>
+  user ->
+  tid ->
+  App Response
+getAllTeamFeatures user tid = do
+  tidStr <- asString tid
+  req <-
+    baseRequest user Galley Versioned $
+      joinHttpPath ["teams", tidStr, "features"]
+  submit "GET" req
+
 setTeamFeature ::
   ( HasCallStack,
     MakesValue tid,

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -3,6 +3,7 @@ module API.GalleyCommon where
 import qualified Data.Aeson as Aeson
 import Data.Kind
 import qualified Data.Text as T
+import qualified Data.Vector as Vector
 import Testlib.JSON
 import Testlib.Prelude
 
@@ -39,3 +40,16 @@ instance ToJSON FeatureStatus where
 oppositeStatus :: FeatureStatus -> FeatureStatus
 oppositeStatus Disabled = Enabled
 oppositeStatus Enabled = Disabled
+
+--------------------------------------------------------------------------------
+-- Feature configurations
+
+data ClassifiedDomainsConfig = ClassifiedDomainsConfig
+  { classifiedDomainsDomains :: [T.Text]
+  }
+  deriving stock (Show, Eq)
+
+instance ToJSON ClassifiedDomainsConfig where
+  toJSON (ClassifiedDomainsConfig ds) =
+    Aeson.object $
+      ["domains" .= Aeson.Array (Vector.fromList (Aeson.String <$> ds))]

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -147,6 +147,15 @@ class IsFeatureConfig cfg where
     -- omitted/ignored in the JSON encoder / parser.
     Schema.ObjectSchema Schema.SwaggerDoc cfg
 
+data TrivialConfig = TrivialConfig
+  deriving (ToJSON) via (Schema.Schema TrivialConfig)
+
+instance Schema.ToSchema TrivialConfig where
+  schema = Schema.object "TrivialConfig" objectSchema
+
+instance IsFeatureConfig TrivialConfig where
+  objectSchema = pure TrivialConfig
+
 data ClassifiedDomainsConfig = ClassifiedDomainsConfig
   { classifiedDomainsDomains :: [T.Text]
   }

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -14,18 +14,36 @@ import Testlib.Prelude
 
 data FeatureStatus = Disabled | Enabled
   deriving (Eq, Generic)
+  deriving (ToJSON) via (Schema.Schema FeatureStatus)
+
+instance Schema.ToSchema FeatureStatus where
+  schema =
+    Schema.enum @T.Text (T.pack "FeatureStatus") $
+      mconcat
+        [ Schema.element (T.pack "enabled") Enabled,
+          Schema.element (T.pack "disabled") Disabled
+        ]
 
 instance Show FeatureStatus where
   show = \case
     Disabled -> "disabled"
     Enabled -> "enabled"
 
-instance ToJSON FeatureStatus where
-  toJSON = Aeson.String . T.pack . show
-
 oppositeStatus :: FeatureStatus -> FeatureStatus
 oppositeStatus Disabled = Enabled
 oppositeStatus Enabled = Disabled
+
+data LockStatus = LockStatusLocked | LockStatusUnlocked
+  deriving stock (Eq, Show)
+  deriving (ToJSON, FromJSON) via (Schema.Schema LockStatus)
+
+instance Schema.ToSchema LockStatus where
+  schema =
+    Schema.enum @T.Text (T.pack "LockStatus") $
+      mconcat
+        [ Schema.element (T.pack "locked") LockStatusLocked,
+          Schema.element (T.pack "unlocked") LockStatusUnlocked
+        ]
 
 -- Using Word to avoid dealing with negative numbers.
 -- Ideally we would also not support zero.
@@ -97,14 +115,5 @@ instance ToJSON ClassifiedDomainsConfig where
     Aeson.object $
       ["domains" .= Aeson.Array (Vector.fromList (Aeson.String <$> ds))]
 
-data LockStatus = LockStatusLocked | LockStatusUnlocked
-  deriving stock (Eq, Show)
-  deriving (ToJSON, FromJSON) via (Schema.Schema LockStatus)
 
-instance Schema.ToSchema LockStatus where
   schema =
-    Schema.enum @T.Text (T.pack "LockStatus") $
-      mconcat
-        [ Schema.element (T.pack "locked") LockStatusLocked,
-          Schema.element (T.pack "unlocked") LockStatusUnlocked
-        ]

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -109,10 +109,10 @@ instance ToJSON cfg => ToJSON (WithStatusNoLock cfg) where
         <> ["config" .= toJSON cfg]
 
 data WithStatus (cfg :: Type) = WithStatus
-  { wsbStatus :: FeatureStatus,
-    wsbLockStatus :: LockStatus,
-    wsbConfig :: cfg,
-    wsbTTL :: FeatureTTL
+  { wsStatus :: FeatureStatus,
+    wsLockStatus :: LockStatus,
+    wsConfig :: cfg,
+    wsTTL :: FeatureTTL
   }
 
 deriving instance (Eq cfg) => Eq (WithStatus cfg)
@@ -125,13 +125,13 @@ instance (Schema.ToSchema cfg, IsFeatureConfig cfg) => Schema.ToSchema (WithStat
   schema =
     Schema.object sn $
       WithStatus
-        <$> wsbStatus
+        <$> wsStatus
         Schema..= Schema.field "status" Schema.schema
-        <*> wsbLockStatus
+        <*> wsLockStatus
         Schema..= Schema.field "lockStatus" Schema.schema
-        <*> wsbConfig
+        <*> wsConfig
         Schema..= objectSchema @cfg
-        <*> wsbTTL
+        <*> wsTTL
         Schema..= (fromMaybe FeatureTTLUnlimited <$> Schema.optField "ttl" Schema.schema)
     where
       inner = Schema.schema @cfg

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -60,7 +60,7 @@ data FeatureTTL
     FeatureTTLSeconds Word
   | FeatureTTLUnlimited
   deriving stock (Eq, Show, Generic)
-  deriving (ToJSON) via (Schema.Schema FeatureTTL)
+  deriving (FromJSON, ToJSON) via (Schema.Schema FeatureTTL)
 
 instance Schema.ToSchema FeatureTTL where
   schema = Schema.mkSchema ttlDoc toTTL fromTTL

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -170,3 +170,13 @@ instance Schema.ToSchema SelfDeletingMessagesConfig where
 
 instance IsFeatureConfig SelfDeletingMessagesConfig where
   objectSchema = Schema.field (T.pack "config") Schema.schema
+
+data GuestLinksConfig = GuestLinksConfig
+  deriving stock (Show, Eq)
+  deriving (ToJSON) via (Schema.Schema GuestLinksConfig)
+
+instance IsFeatureConfig GuestLinksConfig where
+  objectSchema = pure GuestLinksConfig
+
+instance Schema.ToSchema GuestLinksConfig where
+  schema = Schema.object (T.pack "GuestLinksConfig") objectSchema

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -1,31 +1,16 @@
 module API.GalleyCommon where
 
+import Control.Lens ((?~))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
 import Data.Kind
+import Data.OpenApi
 import qualified Data.Schema as Schema
+import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as T
 import qualified Data.Vector as Vector
 import Testlib.JSON
 import Testlib.Prelude
-
-data WithStatusNoLock (cfg :: Type) = WithStatusNoLock
-  { status :: FeatureStatus,
-    config :: cfg,
-    ttl :: Word
-  }
-
-instance ToJSON cfg => MakesValue (WithStatusNoLock cfg) where
-  make = pure . toJSON
-
-instance ToJSON cfg => ToJSON (WithStatusNoLock cfg) where
-  toJSON (WithStatusNoLock s cfg t) =
-    Aeson.object $
-      [ "status" .= s,
-        "ttl" .= case t of
-          0 -> "unlimited"
-          n -> show n
-      ] -- NOTE(md): The "config" part should probably be absent in case of a trivial config
-        <> ["config" .= toJSON cfg]
 
 data FeatureStatus = Disabled | Enabled
   deriving (Eq, Generic)
@@ -41,6 +26,63 @@ instance ToJSON FeatureStatus where
 oppositeStatus :: FeatureStatus -> FeatureStatus
 oppositeStatus Disabled = Enabled
 oppositeStatus Enabled = Disabled
+
+-- Using Word to avoid dealing with negative numbers.
+-- Ideally we would also not support zero.
+-- Currently a TTL=0 is ignored on the cassandra side.
+data FeatureTTL
+  = -- | actually, unit depends on phantom type.
+    FeatureTTLSeconds Word
+  | FeatureTTLUnlimited
+  deriving stock (Eq, Show, Generic)
+  deriving (ToJSON) via (Schema.Schema FeatureTTL)
+
+instance Schema.ToSchema FeatureTTL where
+  schema = Schema.mkSchema ttlDoc toTTL fromTTL
+    where
+      ttlDoc :: Schema.NamedSwaggerDoc
+      ttlDoc = Schema.swaggerDoc @Word & schema . example ?~ (Aeson.String . T.pack $ "unlimited")
+
+      toTTL :: Aeson.Value -> Aeson.Parser FeatureTTL
+      toTTL v = parseUnlimited v <|> parseSeconds v
+
+      parseUnlimited :: Aeson.Value -> Aeson.Parser FeatureTTL
+      parseUnlimited =
+        Aeson.withText "FeatureTTL" $
+          \t ->
+            if t == (T.pack "unlimited") || t == (T.pack "0")
+              then pure FeatureTTLUnlimited
+              else Aeson.parseFail "Expected ''unlimited' or '0'."
+
+      parseSeconds :: Aeson.Value -> Aeson.Parser FeatureTTL
+      parseSeconds = Aeson.withScientific "FeatureTTL" $
+        \s -> case toBoundedInteger s of
+          Just 0 -> error "impossible (this would have parsed in `parseUnlimited` above)."
+          Just i -> pure . FeatureTTLSeconds $ i
+          Nothing -> Aeson.parseFail "Expected an positive integer."
+
+      fromTTL :: FeatureTTL -> Maybe Aeson.Value
+      fromTTL FeatureTTLUnlimited = Just . Aeson.String . T.pack $ "unlimited"
+      fromTTL (FeatureTTLSeconds 0) = Nothing -- Should be unlimited
+      fromTTL (FeatureTTLSeconds s) = Just $ Aeson.toJSON s
+
+data WithStatusNoLock (cfg :: Type) = WithStatusNoLock
+  { status :: FeatureStatus,
+    config :: cfg,
+    ttl :: FeatureTTL
+  }
+
+instance ToJSON cfg => MakesValue (WithStatusNoLock cfg) where
+  make = pure . toJSON
+
+instance ToJSON cfg => ToJSON (WithStatusNoLock cfg) where
+  toJSON (WithStatusNoLock s cfg t) =
+    Aeson.object $
+      [ "status" .= s,
+        "ttl" .= toJSON t
+      ] -- NOTE(md): The "config" part should probably be absent in case of a trivial config
+        <> ["config" .= toJSON cfg]
+
 
 --------------------------------------------------------------------------------
 -- Feature configurations

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -16,7 +16,7 @@ import Testlib.Prelude
 
 data FeatureStatus = Disabled | Enabled
   deriving (Eq, Generic)
-  deriving (ToJSON) via (Schema.Schema FeatureStatus)
+  deriving (FromJSON, ToJSON) via (Schema.Schema FeatureStatus)
 
 instance Schema.ToSchema FeatureStatus where
   schema =

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -2,6 +2,7 @@ module API.GalleyCommon where
 
 import qualified Data.Aeson as Aeson
 import Data.Kind
+import qualified Data.Schema as Schema
 import qualified Data.Text as T
 import qualified Data.Vector as Vector
 import Testlib.JSON
@@ -53,3 +54,15 @@ instance ToJSON ClassifiedDomainsConfig where
   toJSON (ClassifiedDomainsConfig ds) =
     Aeson.object $
       ["domains" .= Aeson.Array (Vector.fromList (Aeson.String <$> ds))]
+
+data LockStatus = LockStatusLocked | LockStatusUnlocked
+  deriving stock (Eq, Show)
+  deriving (ToJSON, FromJSON) via (Schema.Schema LockStatus)
+
+instance Schema.ToSchema LockStatus where
+  schema =
+    Schema.enum @T.Text (T.pack "LockStatus") $
+      mconcat
+        [ Schema.element (T.pack "locked") LockStatusLocked,
+          Schema.element (T.pack "unlocked") LockStatusUnlocked
+        ]

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module API.GalleyCommon where
 
 import Control.Lens ((?~))
@@ -18,10 +20,10 @@ data FeatureStatus = Disabled | Enabled
 
 instance Schema.ToSchema FeatureStatus where
   schema =
-    Schema.enum @T.Text (T.pack "FeatureStatus") $
+    Schema.enum @T.Text "FeatureStatus" $
       mconcat
-        [ Schema.element (T.pack "enabled") Enabled,
-          Schema.element (T.pack "disabled") Disabled
+        [ Schema.element "enabled" Enabled,
+          Schema.element "disabled" Disabled
         ]
 
 instance Show FeatureStatus where
@@ -44,10 +46,10 @@ instance Show LockStatus where
 
 instance Schema.ToSchema LockStatus where
   schema =
-    Schema.enum @T.Text (T.pack "LockStatus") $
+    Schema.enum @T.Text "LockStatus" $
       mconcat
-        [ Schema.element (T.pack "locked") LockStatusLocked,
-          Schema.element (T.pack "unlocked") LockStatusUnlocked
+        [ Schema.element "locked" LockStatusLocked,
+          Schema.element "unlocked" LockStatusUnlocked
         ]
 
 -- Using Word to avoid dealing with negative numbers.
@@ -73,7 +75,7 @@ instance Schema.ToSchema FeatureTTL where
       parseUnlimited =
         Aeson.withText "FeatureTTL" $
           \t ->
-            if t == (T.pack "unlimited") || t == (T.pack "0")
+            if t == "unlimited" || t == "0"
               then pure FeatureTTLUnlimited
               else Aeson.parseFail "Expected ''unlimited' or '0'."
 
@@ -124,16 +126,16 @@ instance (Schema.ToSchema cfg, IsFeatureConfig cfg) => Schema.ToSchema (WithStat
     Schema.object sn $
       WithStatus
         <$> wsbStatus
-        Schema..= Schema.field (T.pack "status") Schema.schema
+        Schema..= Schema.field "status" Schema.schema
         <*> wsbLockStatus
-        Schema..= Schema.field (T.pack "lockStatus") Schema.schema
+        Schema..= Schema.field "lockStatus" Schema.schema
         <*> wsbConfig
         Schema..= objectSchema @cfg
         <*> wsbTTL
-        Schema..= (fromMaybe FeatureTTLUnlimited <$> Schema.optField (T.pack "ttl") Schema.schema)
+        Schema..= (fromMaybe FeatureTTLUnlimited <$> Schema.optField "ttl" Schema.schema)
     where
       inner = Schema.schema @cfg
-      sn = fromMaybe (T.pack "") (Schema.getName (Schema.schemaDoc inner)) <> (T.pack ".WithStatus")
+      sn = fromMaybe "" (Schema.getName (Schema.schemaDoc inner)) <> ".WithStatus"
 
 --------------------------------------------------------------------------------
 -- Feature configurations
@@ -163,13 +165,13 @@ newtype SelfDeletingMessagesConfig = SelfDeletingMessagesConfig
 
 instance Schema.ToSchema SelfDeletingMessagesConfig where
   schema =
-    Schema.object (T.pack "SelfDeletingMessagesConfig") $
+    Schema.object "SelfDeletingMessagesConfig" $
       SelfDeletingMessagesConfig
         <$> sdmEnforcedTimeoutSeconds
-        Schema..= Schema.field (T.pack "enforcedTimeoutSeconds") Schema.schema
+        Schema..= Schema.field "enforcedTimeoutSeconds" Schema.schema
 
 instance IsFeatureConfig SelfDeletingMessagesConfig where
-  objectSchema = Schema.field (T.pack "config") Schema.schema
+  objectSchema = Schema.field "config" Schema.schema
 
 data GuestLinksConfig = GuestLinksConfig
   deriving stock (Show, Eq)
@@ -179,4 +181,4 @@ instance IsFeatureConfig GuestLinksConfig where
   objectSchema = pure GuestLinksConfig
 
 instance Schema.ToSchema GuestLinksConfig where
-  schema = Schema.object (T.pack "GuestLinksConfig") objectSchema
+  schema = Schema.object "GuestLinksConfig" objectSchema

--- a/integration/test/API/GalleyCommon.hs
+++ b/integration/test/API/GalleyCommon.hs
@@ -1,0 +1,38 @@
+module API.GalleyCommon where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
+import Testlib.JSON
+import Testlib.Prelude
+
+data WithStatusNoLock = WithStatusNoLock
+  { status :: FeatureStatus,
+    ttl :: Word
+  }
+
+instance MakesValue WithStatusNoLock where
+  make = pure . toJSON
+
+instance ToJSON WithStatusNoLock where
+  toJSON (WithStatusNoLock s t) =
+    Aeson.object
+      [ "status" .= s,
+        "ttl" .= case t of
+          0 -> "unlimited"
+          n -> show n
+      ]
+
+data FeatureStatus = Disabled | Enabled
+  deriving (Eq, Generic)
+
+instance Show FeatureStatus where
+  show = \case
+    Disabled -> "disabled"
+    Enabled -> "enabled"
+
+instance ToJSON FeatureStatus where
+  toJSON = Aeson.String . T.pack . show
+
+oppositeStatus :: FeatureStatus -> FeatureStatus
+oppositeStatus Disabled = Enabled
+oppositeStatus Enabled = Disabled

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -80,13 +80,13 @@ setTeamFeatureLockStatus ::
   domain ->
   team ->
   String ->
-  String ->
+  LockStatus ->
   App Response
 setTeamFeatureLockStatus domain team featureName lockStatus = do
   tid <- asString team
   req <-
     baseRequest domain Galley Unversioned $
-      joinHttpPath ["i", "teams", tid, "features", featureName, lockStatus]
+      joinHttpPath ["i", "teams", tid, "features", featureName, show lockStatus]
   submit "PUT" req
 
 -- | An alias for 'patchTeamFeatureStatus'

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -132,9 +132,8 @@ putTeamFeatureStatus ::
   WithStatusNoLock cfg ->
   App ()
 putTeamFeatureStatus domain team featureName status =
-  void $
-    putTeamFeatureStatusRaw domain team featureName status
-      >>= getBody 200
+  putTeamFeatureStatusRaw domain team featureName status
+    >>= assertStatus 200
 
 failToPutTeamFeatureStatus ::
   ( HasCallStack,

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -100,11 +100,16 @@ setTeamFeatureStatus ::
 setTeamFeatureStatus = patchTeamFeatureStatus
 
 putTeamFeatureStatus ::
-  (HasCallStack, MakesValue domain, MakesValue team) =>
+  forall cfg domain team.
+  ( HasCallStack,
+    MakesValue domain,
+    MakesValue team,
+    ToJSON cfg
+  ) =>
   domain ->
   team ->
   String ->
-  WithStatusNoLock ->
+  WithStatusNoLock cfg ->
   App ()
 putTeamFeatureStatus domain team featureName status = do
   tid <- asString team
@@ -116,11 +121,15 @@ putTeamFeatureStatus domain team featureName status = do
   res.status `shouldMatchInt` 200
 
 failToPutTeamFeatureStatus ::
-  (HasCallStack, MakesValue domain, MakesValue team) =>
+  ( HasCallStack,
+    MakesValue domain,
+    MakesValue team,
+    ToJSON cfg
+  ) =>
   domain ->
   team ->
   String ->
-  WithStatusNoLock ->
+  WithStatusNoLock cfg ->
   App ()
 failToPutTeamFeatureStatus domain team featureName status = do
   tid <- asString team

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -60,6 +60,21 @@ patchTeamFeatureStatus domain team featureName status = do
   res <- submit "PATCH" $ addJSONObject ["status" .= show status] req
   res.status `shouldMatchInt` 200
 
+failToPatchTeamFeatureStatus ::
+  (HasCallStack, MakesValue domain, MakesValue team) =>
+  domain ->
+  team ->
+  String ->
+  FeatureStatus ->
+  App ()
+failToPatchTeamFeatureStatus domain team featureName status = do
+  tid <- asString team
+  req <-
+    baseRequest domain Galley Unversioned $
+      joinHttpPath ["i", "teams", tid, "features", featureName]
+  res <- submit "PATCH" $ addJSONObject ["status" .= show status] req
+  res.status `shouldMatchRange` (400, 499)
+
 -- | An alias for 'patchTeamFeatureStatus'
 setTeamFeatureStatus ::
   (HasCallStack, MakesValue domain, MakesValue team) =>
@@ -85,6 +100,22 @@ putTeamFeatureStatus domain team featureName status = do
       joinHttpPath ["i", "teams", tid, "features", featureName]
   res <- submit "PUT" $ addJSON body req
   res.status `shouldMatchInt` 200
+
+failToPutTeamFeatureStatus ::
+  (HasCallStack, MakesValue domain, MakesValue team) =>
+  domain ->
+  team ->
+  String ->
+  WithStatusNoLock ->
+  App ()
+failToPutTeamFeatureStatus domain team featureName status = do
+  tid <- asString team
+  body <- make status
+  req <-
+    baseRequest domain Galley Unversioned $
+      joinHttpPath ["i", "teams", tid, "features", featureName]
+  res <- submit "PUT" $ addJSON body req
+  res.status `shouldMatchRange` (400, 499)
 
 data FeatureStatus = Disabled | Enabled
   deriving (Eq)

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -133,6 +133,10 @@ instance Show FeatureStatus where
 instance ToJSON FeatureStatus where
   toJSON = Aeson.String . T.pack . show
 
+oppositeStatus :: FeatureStatus -> FeatureStatus
+oppositeStatus Disabled = Enabled
+oppositeStatus Enabled = Disabled
+
 data WithStatusNoLock = WithStatusNoLock
   { status :: FeatureStatus,
     ttl :: Word

--- a/integration/test/Notifications.hs
+++ b/integration/test/Notifications.hs
@@ -181,6 +181,9 @@ isConnectionNotif status n =
     <$> nPayload n %. "type" `isEqual` "user.connection"
     <*> nPayload n %. "connection.status" `isEqual` status
 
+isFeatureConfigUpdateNotif :: MakesValue a => a -> App Bool
+isFeatureConfigUpdateNotif n = fieldEquals n "payload.0.type" "feature-config.update"
+
 assertLeaveNotification ::
   ( HasCallStack,
     MakesValue fromUser,

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -681,7 +681,7 @@ testDeleteTeamMemberLimitedEventFanout = do
 
   -- Only the team admins will get the team-level event about Alex being removed
   -- from the team
-  setTeamFeatureStatus OwnDomain team "limitedEventFanout" "enabled"
+  setTeamFeatureStatus OwnDomain team "limitedEventFanout" Enabled
 
   withWebSockets [alice, amy, bob, alison, ana] $
     \[wsAlice, wsAmy, wsBob, wsAlison, wsAna] -> do

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -22,6 +22,7 @@ module Test.Conversation where
 import API.Brig
 import qualified API.BrigInternal as BrigI
 import API.Galley
+import API.GalleyCommon
 import API.GalleyInternal
 import Control.Applicative
 import Control.Concurrent (threadDelay)

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1010,3 +1010,7 @@ genericSimpleFlagWithLockStatus featureName defaultStatus defaultLockStatus = do
 testGuestLinksLockStatus :: HasCallStack => App ()
 testGuestLinksLockStatus =
   genericSimpleFlagWithLockStatus "conversationGuestLinks" Enabled LockStatusUnlocked
+
+testSndFactorPasswordChallenge :: HasCallStack => App ()
+testSndFactorPasswordChallenge =
+  genericSimpleFlagWithLockStatus "sndFactorPasswordChallenge" Disabled LockStatusLocked

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -889,3 +889,13 @@ testGuestLinksInternal =
   where
     domain = OwnDomain
     featureName = "conversationGuestLinks"
+
+testGuestLinksPublic :: HasCallStack => App ()
+testGuestLinksPublic =
+  genericGuestLinks
+    domain
+    (getTeamFeature featureName)
+    (setTeamFeature featureName)
+  where
+    domain = OwnDomain
+    featureName = "conversationGuestLinks"

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -334,3 +334,7 @@ checkSimpleFlag path name defStatus = do
 testDigitalSignatures :: HasCallStack => App ()
 testDigitalSignatures = do
   checkSimpleFlag "digitalSignatures" "digitalSignatures" Disabled
+
+testValidateSAMLEmails :: HasCallStack => App ()
+testValidateSAMLEmails = do
+  checkSimpleFlag "validateSAMLemails" "validateSAMLemails" Enabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -94,7 +94,7 @@ assertFeatureFromAllLock ::
   user ->
   App ()
 assertFeatureFromAllLock mLock meConfig eStatus featureName user = do
-  actual <- extractTeamFeatureFromAll featureName user
+  actual <- extractTeamFeatureFromAllPersonal featureName user
   actual %. "status" `shouldMatch` show eStatus
   for_ meConfig (actual %. "config" `shouldMatch`)
   for_ mLock (actual %. "lockStatus" `shouldMatch`)

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1110,3 +1110,7 @@ testFeatureNoConfigMultiSearchVisibilityInbound = do
   where
     domain = OwnDomain
     featureName = "searchVisibilityInbound"
+
+testConferenceCallingUnlimitedTTL :: HasCallStack => App ()
+testConferenceCallingUnlimitedTTL =
+  checkSimpleFlagTTL FeatureTTLUnlimited "conferenceCalling" "conferenceCalling" Enabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1114,3 +1114,7 @@ testFeatureNoConfigMultiSearchVisibilityInbound = do
 testConferenceCallingUnlimitedTTL :: HasCallStack => App ()
 testConferenceCallingUnlimitedTTL =
   checkSimpleFlagTTL FeatureTTLUnlimited "conferenceCalling" "conferenceCalling" Enabled
+
+testConferenceCalling2secTTL :: HasCallStack => App ()
+testConferenceCalling2secTTL =
+  checkSimpleFlagTTL (FeatureTTLSeconds 2) "conferenceCalling" "conferenceCalling" Enabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -17,19 +17,99 @@
 
 module Test.FeatureFlags where
 
-import API.GalleyInternal
+import API.Galley
+import qualified API.GalleyInternal as I
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
 import SetupHelpers
+import Testlib.HTTP
 import Testlib.Prelude
+
+--------------------------------------------------------------------------------
+-- Helpers
+
+data FeatureStatus = Disabled | Enabled
+  deriving (Eq, Enum)
+
+instance Show FeatureStatus where
+  show = \case
+    Disabled -> "disabled"
+    Enabled -> "enabled"
+
+disabled, enabled :: String
+disabled = "disabled"
+enabled = "enabled"
+
+expectedStatus :: HasCallStack => FeatureStatus -> Aeson.Value
+expectedStatus fs =
+  Aeson.object ["lockStatus" .= "unlocked", "status" .= show fs, "ttl" .= "unlimited"]
+
+assertFeature ::
+  (HasCallStack, MakesValue user, MakesValue team) =>
+  String ->
+  user ->
+  team ->
+  FeatureStatus ->
+  App ()
+assertFeature featureName user team expected = do
+  tf <- getTeamFeature featureName user team
+  assertSuccessMatchBody (expectedStatus expected) tf
+
+assertFeatureFromAll ::
+  (HasCallStack, MakesValue user) =>
+  String ->
+  user ->
+  FeatureStatus ->
+  App ()
+assertFeatureFromAll featureName user expected = do
+  actual <- extractTeamFeatureFromAll featureName user
+  actual %. "status" `shouldMatch` show expected
+
+assertFeatureInternal ::
+  (HasCallStack, MakesValue domain) =>
+  String ->
+  domain ->
+  String ->
+  FeatureStatus ->
+  App ()
+assertFeatureInternal featureName dom team expected = do
+  tf <- I.getTeamFeature dom featureName team
+  assertSuccessMatchBody (expectedStatus expected) tf
+
+--------------------------------------------------------------------------------
 
 testLimitedEventFanout :: HasCallStack => App ()
 testLimitedEventFanout = do
   let featureName = "limitedEventFanout"
   (_alice, team, _) <- createTeam OwnDomain 1
-  -- getTeamFeatureStatus OwnDomain team "limitedEventFanout" "enabled"
-  bindResponse (getTeamFeature OwnDomain featureName team) $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json %. "status" `shouldMatch` "disabled"
-  setTeamFeatureStatus OwnDomain team featureName "enabled"
-  bindResponse (getTeamFeature OwnDomain featureName team) $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json %. "status" `shouldMatch` "enabled"
+  assertFeatureInternal featureName OwnDomain team Disabled
+  I.setTeamFeatureStatus OwnDomain team featureName "enabled"
+  assertFeatureInternal featureName OwnDomain team Enabled
+
+testSSOPut :: HasCallStack => App ()
+testSSOPut = do
+  let dom = OwnDomain
+      featureName = "sso"
+      setting = "settings.featureFlags." <> featureName
+  (_alice, team, alex : _) <- createTeam dom 2
+  nonMember <- randomUser dom def
+
+  getTeamFeature featureName nonMember team `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 403
+    resp.json %. "label" `shouldMatch` "no-team-member"
+
+  configuredSSO <- readServiceConfig Galley & (%. setting) & asText
+  if T.unpack configuredSSO == "disabled-by-default"
+    then do
+      assertFeature featureName alex team Disabled
+      assertFeatureInternal featureName dom team Disabled
+      assertFeatureFromAll featureName alex Disabled
+
+      I.setTeamFeatureStatus OwnDomain team featureName "enabled"
+      assertFeature featureName alex team Enabled
+      assertFeatureInternal featureName dom team Enabled
+      assertFeatureFromAll featureName alex Enabled
+    else do
+      assertFeature featureName alex team Enabled
+      assertFeatureInternal featureName dom team Enabled
+      assertFeatureFromAll featureName alex Enabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1014,3 +1014,7 @@ testGuestLinksLockStatus =
 testSndFactorPasswordChallenge :: HasCallStack => App ()
 testSndFactorPasswordChallenge =
   genericSimpleFlagWithLockStatus "sndFactorPasswordChallenge" Disabled LockStatusLocked
+
+testOutlookCalIntegration :: HasCallStack => App ()
+testOutlookCalIntegration =
+  genericSimpleFlagWithLockStatus "outlookCalIntegration" Disabled LockStatusLocked

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1018,3 +1018,27 @@ testSndFactorPasswordChallenge =
 testOutlookCalIntegration :: HasCallStack => App ()
 testOutlookCalIntegration =
   genericSimpleFlagWithLockStatus "outlookCalIntegration" Disabled LockStatusLocked
+
+testSearchVisibilityInbound :: HasCallStack => App ()
+testSearchVisibilityInbound = do
+  let defaultValue = Disabled
+  (_owner, team, []) <- createTeam domain 1
+  let getFlagInternal :: HasCallStack => FeatureStatus -> App ()
+      getFlagInternal expected =
+        let ws = WithStatusNoLock expected () FeatureTTLUnlimited
+         in assertFeatureInternal ws featureName domain team
+
+      setFlagInternal :: HasCallStack => FeatureStatus -> App ()
+      setFlagInternal status =
+        let ws = WithStatusNoLock status () FeatureTTLUnlimited
+         in I.putTeamFeatureStatus domain team featureName ws
+
+  let opposite = oppositeStatus defaultValue
+
+  -- Initial value should be the default value
+  getFlagInternal defaultValue
+  setFlagInternal opposite
+  getFlagInternal opposite
+  where
+    domain = OwnDomain
+    featureName = "searchVisibility"

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -34,12 +34,12 @@ import Testlib.Prelude
 --------------------------------------------------------------------------------
 -- Helpers
 
-expectedStatus ::
+expectedWithStatus ::
   (ToJSON cfg, HasCallStack) =>
   WithStatusNoLock cfg ->
   LockStatus ->
   Aeson.Value
-expectedStatus WithStatusNoLock {..} lock =
+expectedWithStatus WithStatusNoLock {..} lock =
   let cfg = toJSON config
    in Aeson.object $
         [ "lockStatus" .= lock,
@@ -65,7 +65,7 @@ assertFeatureLock ::
   App ()
 assertFeatureLock lock ws featureName user team = do
   tf <- getTeamFeature featureName user team
-  assertSuccessMatchBody (expectedStatus ws lock) tf
+  assertSuccessMatchBody (expectedWithStatus ws lock) tf
 
 assertFeature ::
   ( HasCallStack,
@@ -112,7 +112,7 @@ assertFeatureInternalLock ::
   App ()
 assertFeatureInternalLock lock ws featureName dom team = do
   tf <- I.getTeamFeature dom featureName team
-  assertSuccessMatchBody (expectedStatus ws lock) tf
+  assertSuccessMatchBody (expectedWithStatus ws lock) tf
 
 assertFeatureInternal ::
   (HasCallStack, MakesValue domain, ToJSON cfg) =>

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -409,7 +409,7 @@ checkSimpleFlag path name defStatus = do
     let expStatus =
           Aeson.object
             [ "status" .= opposite,
-              "lockStatus" .= "unlocked",
+              "lockStatus" .= LockStatusUnlocked,
               "ttl" .= FeatureTTLUnlimited
             ]
     withWebSocket owner $ \ws -> do
@@ -1020,25 +1020,5 @@ testOutlookCalIntegration =
   genericSimpleFlagWithLockStatus "outlookCalIntegration" Disabled LockStatusLocked
 
 testSearchVisibilityInbound :: HasCallStack => App ()
-testSearchVisibilityInbound = do
-  let defaultValue = Disabled
-  (_owner, team, []) <- createTeam domain 1
-  let getFlagInternal :: HasCallStack => FeatureStatus -> App ()
-      getFlagInternal expected =
-        let ws = WithStatusNoLock expected () FeatureTTLUnlimited
-         in assertFeatureInternal ws featureName domain team
-
-      setFlagInternal :: HasCallStack => FeatureStatus -> App ()
-      setFlagInternal status =
-        let ws = WithStatusNoLock status () FeatureTTLUnlimited
-         in I.putTeamFeatureStatus domain team featureName ws
-
-  let opposite = oppositeStatus defaultValue
-
-  -- Initial value should be the default value
-  getFlagInternal defaultValue
-  setFlagInternal opposite
-  getFlagInternal opposite
-  where
-    domain = OwnDomain
-    featureName = "searchVisibility"
+testSearchVisibilityInbound =
+  checkSimpleFlag "searchVisibility" "searchVisibility" Disabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -714,3 +714,7 @@ testFeatureConfigConsistency = do
     parseObjectKeys = \case
       Aeson.Object hm -> pure . Set.fromList . map Aeson.toText . Aeson.keys $ hm
       x -> assertFailure ("JSON was not an object, but " <> show x)
+
+testConferenceCalling :: HasCallStack => App ()
+testConferenceCalling = do
+  checkSimpleFlag "conferenceCalling" "conferenceCalling" Enabled

--- a/integration/test/Test/Search.hs
+++ b/integration/test/Test/Search.hs
@@ -112,7 +112,7 @@ federatedUserSearch d1 d2 test = do
   u2 <- randomUser d2 def {BrigI.team = True}
   uidD2 <- objId u2
   team2 <- u2 %. "team"
-  GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" "enabled"
+  GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" GalleyI.Enabled
 
   addTeamRestriction d1 d2 team2 test.restrictionD1D2
   addTeamRestriction d2 d1 teamU1 test.restrictionD2D1
@@ -167,7 +167,7 @@ testFederatedUserSearchNonTeamSearcher = do
     u1 <- randomUser d1 def
     u2 <- randomUser d2 def {BrigI.team = True}
     team2 <- u2 %. "team"
-    GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" "enabled"
+    GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" GalleyI.Enabled
 
     u2Handle <- API.randomHandle
     bindResponse (BrigP.putHandle u2 u2Handle) $ assertSuccess

--- a/integration/test/Test/Search.hs
+++ b/integration/test/Test/Search.hs
@@ -5,6 +5,7 @@ import qualified API.BrigInternal as BrigI
 import qualified API.Common as API
 import API.Galley
 import qualified API.Galley as Galley
+import API.GalleyCommon
 import qualified API.GalleyInternal as GalleyI
 import GHC.Stack
 import SetupHelpers
@@ -112,7 +113,7 @@ federatedUserSearch d1 d2 test = do
   u2 <- randomUser d2 def {BrigI.team = True}
   uidD2 <- objId u2
   team2 <- u2 %. "team"
-  GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" GalleyI.Enabled
+  GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" Enabled
 
   addTeamRestriction d1 d2 team2 test.restrictionD1D2
   addTeamRestriction d2 d1 teamU1 test.restrictionD2D1
@@ -167,7 +168,7 @@ testFederatedUserSearchNonTeamSearcher = do
     u1 <- randomUser d1 def
     u2 <- randomUser d2 def {BrigI.team = True}
     team2 <- u2 %. "team"
-    GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" GalleyI.Enabled
+    GalleyI.setTeamFeatureStatus d2 team2 "searchVisibilityInbound" Enabled
 
     u2Handle <- API.randomHandle
     bindResponse (BrigP.putHandle u2 u2Handle) $ assertSuccess

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -66,7 +66,7 @@ testUpdateHandle = do
   bindResponse (getTeamFeature owner featureName team) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "disabled"
-  setTeamFeatureStatus owner team featureName "enabled"
+  setTeamFeatureStatus owner team featureName Enabled
   bindResponse (getTeamFeature owner featureName team) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "enabled"
@@ -129,7 +129,7 @@ testUpdateSelf (MkTagged mode) = do
   bindResponse (getTeamFeature owner featureName team) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "disabled"
-  setTeamFeatureStatus owner team featureName "enabled"
+  setTeamFeatureStatus owner team featureName Enabled
   bindResponse (getTeamFeature owner featureName team) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "enabled"

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -4,6 +4,7 @@ module Test.User where
 
 import API.Brig
 import API.BrigInternal
+import API.GalleyCommon
 import API.GalleyInternal
 import API.Spar
 import qualified Data.UUID as UUID

--- a/integration/test/Testlib/HTTP.hs
+++ b/integration/test/Testlib/HTTP.hs
@@ -117,6 +117,10 @@ assertLabel status label resp = do
   j <- getJSON status resp
   j %. "label" `shouldMatch` label
 
+assertSuccessMatchBody :: HasCallStack => Aeson.Value -> Response -> App ()
+assertSuccessMatchBody bdy resp = withResponse resp $ \r ->
+  getJSON 200 r `shouldMatch` bdy
+
 onFailureAddResponse :: HasCallStack => Response -> App a -> App a
 onFailureAddResponse r m = App $ do
   e <- ask

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -44,7 +44,6 @@
 , gitignoreSource
 , gundeck-types
 , HsOpenSSL
-, hspec
 , http-api-data
 , http-client
 , http-client-openssl
@@ -247,7 +246,6 @@ mkDerivation {
     filepath
     galley-types
     HsOpenSSL
-    hspec
     http-api-data
     http-client
     http-client-openssl

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -492,7 +492,6 @@ executable galley-integration
     , galley
     , galley-types
     , HsOpenSSL
-    , hspec
     , http-api-data
     , http-client
     , http-client-openssl

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -99,6 +99,12 @@ settings:
     limitedEventFanout:
       defaults:
         status: disabled
+    selfDeletingMessages:
+      defaults:
+        config:
+          enforcedTimeoutSeconds: 0
+        lockStatus: unlocked
+        status: enabled
 
 logLevel: Warn
 logNetStrings: false

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -64,8 +64,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "FileSharing with lock status" $ testSimpleFlagWithLockStatus @FileSharingConfig FeatureStatusEnabled LockStatusUnlocked,
-      test s "Classified Domains (enabled)" testClassifiedDomainsEnabled,
+    [ test s "Classified Domains (enabled)" testClassifiedDomainsEnabled,
       test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
       test s "All features" testAllFeatures,
       test s "Feature Configs / Team Features Consistency" testFeatureConfigConsistency,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -58,8 +58,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
-      test s "SearchVisibilityInbound - internal multi team API" testFeatureNoConfigMultiSearchVisibilityInbound,
+    [ test s "SearchVisibilityInbound - internal multi team API" testFeatureNoConfigMultiSearchVisibilityInbound,
       testGroup
         "TTL / Conference calling"
         [ test s "ConferenceCalling unlimited TTL" $ testSimpleFlagTTL @ConferenceCallingConfig FeatureStatusEnabled FeatureTTLUnlimited,
@@ -505,28 +504,6 @@ testSimpleFlagTTL defaultValue ttl = do
   -- Clean up
   setFlagInternal defaultValue FeatureTTLUnlimited
   getFlag defaultValue
-
-testSearchVisibilityInbound :: TestM ()
-testSearchVisibilityInbound = do
-  let defaultValue = FeatureStatusDisabled
-  (_owner, tid, _) <- createBindingTeamWithNMembers 1
-
-  let getFlagInternal :: HasCallStack => FeatureStatus -> TestM ()
-      getFlagInternal expected =
-        flip (assertFlagNoConfig @SearchVisibilityInboundConfig) expected $ getTeamFeatureFlagInternal @SearchVisibilityInboundConfig tid
-
-      setFlagInternal :: FeatureStatus -> TestM ()
-      setFlagInternal statusValue =
-        void $ putTeamFeatureFlagInternal @SearchVisibilityInboundConfig expect2xx tid (WithStatusNoLock statusValue SearchVisibilityInboundConfig FeatureTTLUnlimited)
-
-  let otherValue = case defaultValue of
-        FeatureStatusDisabled -> FeatureStatusEnabled
-        FeatureStatusEnabled -> FeatureStatusDisabled
-
-  -- Initial value should be the default value
-  getFlagInternal defaultValue
-  setFlagInternal otherValue
-  getFlagInternal otherValue
 
 testFeatureNoConfigMultiSearchVisibilityInbound :: TestM ()
 testFeatureNoConfigMultiSearchVisibilityInbound = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -31,21 +31,17 @@ import Control.Lens.Operators ()
 import Control.Monad.Catch (MonadCatch)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Key qualified as AesonKey
-import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Char8 (unpack)
 import Data.Id
 import Data.Json.Util (fromUTCTimeMillis, readUTCTimeMillis)
 import Data.List1 qualified as List1
 import Data.Schema (ToSchema)
-import Data.Set qualified as Set
 import Data.Timeout (TimeoutUnit (Second), (#))
 import GHC.TypeLits (KnownSymbol)
 import Galley.Options (exposeInvitationURLsTeamAllowlist, featureFlags, settings)
 import Galley.Types.Teams
 import Imports
 import Network.Wai.Utilities (label)
-import Test.Hspec (expectationFailure)
 import Test.QuickCheck (Gen, generate, suchThat)
 import Test.Tasty
 import Test.Tasty.Cannon qualified as WS
@@ -63,8 +59,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "Feature Configs / Team Features Consistency" testFeatureConfigConsistency,
-      test s "ConferenceCalling" $ testSimpleFlag @ConferenceCallingConfig FeatureStatusEnabled,
+    [ test s "ConferenceCalling" $ testSimpleFlag @ConferenceCallingConfig FeatureStatusEnabled,
       test s "SelfDeletingMessages" testSelfDeletingMessages,
       test s "ConversationGuestLinks - public API" testGuestLinksPublic,
       test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
@@ -768,27 +763,6 @@ testGuestLinks getStatus putStatus setLockStatusInternal = do
   -- when lock status is unlocked again the previously set feature status is restored
   checkSetLockStatusInternal LockStatusUnlocked
   checkGet FeatureStatusDisabled LockStatusUnlocked
-
-testFeatureConfigConsistency :: TestM ()
-testFeatureConfigConsistency = do
-  (_owner, tid, member : _) <- createBindingTeamWithNMembers 1
-
-  allFeaturesRes <- getAllFeatureConfigs member >>= parseObjectKeys
-
-  allTeamFeaturesRes <- getAllTeamFeatures member tid >>= parseObjectKeys
-
-  unless (allTeamFeaturesRes `Set.isSubsetOf` allFeaturesRes) $
-    liftIO $
-      expectationFailure (show allTeamFeaturesRes <> " is not a subset of " <> show allFeaturesRes)
-  where
-    parseObjectKeys :: ResponseLBS -> TestM (Set.Set Text)
-    parseObjectKeys res = do
-      case responseJsonEither res of
-        Left err -> liftIO $ assertFailure ("Did not parse as an object" <> err)
-        Right (val :: Aeson.Value) ->
-          case val of
-            (Aeson.Object hm) -> pure (Set.fromList . map AesonKey.toText . KeyMap.keys $ hm)
-            x -> liftIO $ assertFailure ("JSON was not an object, but " <> show x)
 
 testSearchVisibilityInbound :: TestM ()
 testSearchVisibilityInbound = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -64,8 +64,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "Classified Domains (enabled)" testClassifiedDomainsEnabled,
-      test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
+    [ test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
       test s "All features" testAllFeatures,
       test s "Feature Configs / Team Features Consistency" testFeatureConfigConsistency,
       test s "ConferenceCalling" $ testSimpleFlag @ConferenceCallingConfig FeatureStatusEnabled,
@@ -292,26 +291,6 @@ getClassifiedDomainsInternal ::
 getClassifiedDomainsInternal tid =
   assertFlagWithConfig @ClassifiedDomainsConfig $
     getTeamFeatureFlagInternal @ClassifiedDomainsConfig tid
-
-testClassifiedDomainsEnabled :: TestM ()
-testClassifiedDomainsEnabled = do
-  (_owner, tid, member : _) <- createBindingTeamWithNMembers 1
-  let expected =
-        WithStatusNoLock FeatureStatusEnabled (ClassifiedDomainsConfig [Domain "example.com"]) FeatureTTLUnlimited
-
-  let getClassifiedDomainsFeatureConfig ::
-        (HasCallStack, HasGalley m, MonadIO m, MonadHttp m, MonadCatch m) =>
-        UserId ->
-        WithStatusNoLock ClassifiedDomainsConfig ->
-        m ()
-      getClassifiedDomainsFeatureConfig uid expected' = do
-        result <- Util.getFeatureConfig @ClassifiedDomainsConfig uid
-        liftIO $ wsStatus result @?= wssStatus expected'
-        liftIO $ wsConfig result @?= wssConfig expected'
-
-  getClassifiedDomains member tid expected
-  getClassifiedDomainsInternal tid expected
-  getClassifiedDomainsFeatureConfig member expected
 
 testClassifiedDomainsDisabled :: TestM ()
 testClassifiedDomainsDisabled = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -64,8 +64,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "ValidateSAMLEmails" $ testSimpleFlag @ValidateSAMLEmailsConfig FeatureStatusEnabled,
-      test s "FileSharing with lock status" $ testSimpleFlagWithLockStatus @FileSharingConfig FeatureStatusEnabled LockStatusUnlocked,
+    [ test s "FileSharing with lock status" $ testSimpleFlagWithLockStatus @FileSharingConfig FeatureStatusEnabled LockStatusUnlocked,
       test s "Classified Domains (enabled)" testClassifiedDomainsEnabled,
       test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
       test s "All features" testAllFeatures,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -255,20 +255,6 @@ testPatch' testLockStatusChange rndFeatureConfig defStatus defConfig = do
           wsLockStatus actual @?= fromMaybe (wsLockStatus original) (wspLockStatus rndFeatureConfig)
         wsConfig actual @?= fromMaybe (wsConfig original) (wspConfig rndFeatureConfig)
 
-testSimpleFlag ::
-  forall cfg.
-  ( HasCallStack,
-    Typeable cfg,
-    IsFeatureConfig cfg,
-    KnownSymbol (FeatureSymbol cfg),
-    FeatureTrivialConfig cfg,
-    ToSchema cfg,
-    FromJSON (WithStatusNoLock cfg)
-  ) =>
-  FeatureStatus ->
-  TestM ()
-testSimpleFlag defaultValue = testSimpleFlagTTL @cfg defaultValue FeatureTTLUnlimited
-
 testSimpleFlagTTLOverride ::
   forall cfg.
   ( HasCallStack,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -59,7 +59,6 @@ tests s =
   testGroup
     "Feature Config API and Team Features API"
     [ test s "ConversationGuestLinks - public API" testGuestLinksPublic,
-      test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
       test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @GuestLinksConfig FeatureStatusEnabled LockStatusUnlocked,
       test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @SndFactorPasswordChallengeConfig FeatureStatusDisabled LockStatusLocked,
       test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
@@ -607,14 +606,6 @@ testSimpleFlagWithLockStatus defaultStatus defaultLockStatus = do
   setFlagWithGalley defaultStatus
   setLockStatus defaultLockStatus
   getFlags defaultStatus defaultLockStatus
-
-testGuestLinksInternal :: TestM ()
-testGuestLinksInternal = do
-  galley <- viewGalley
-  testGuestLinks
-    (const $ getTeamFeatureFlagInternal @GuestLinksConfig)
-    (const $ putTeamFeatureFlagInternal @GuestLinksConfig galley)
-    (Util.setLockStatusInternal @GuestLinksConfig galley)
 
 testGuestLinksPublic :: TestM ()
 testGuestLinksPublic = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -73,7 +73,6 @@ tests s =
           test s "Unlimited to unlimited" $ testSimpleFlagTTLOverride @ConferenceCallingConfig FeatureStatusEnabled FeatureTTLUnlimited FeatureTTLUnlimited
         ],
       test s "MLS feature config" testMLS,
-      test s "SearchVisibilityInbound" $ testSimpleFlag @SearchVisibilityInboundConfig FeatureStatusDisabled,
       test s "MlsE2EId feature config" $
         testNonTrivialConfigNoTTL
           ( withStatus

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -59,8 +59,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "ConferenceCalling" $ testSimpleFlag @ConferenceCallingConfig FeatureStatusEnabled,
-      test s "SelfDeletingMessages" testSelfDeletingMessages,
+    [ test s "SelfDeletingMessages" testSelfDeletingMessages,
       test s "ConversationGuestLinks - public API" testGuestLinksPublic,
       test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
       test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @GuestLinksConfig FeatureStatusEnabled LockStatusUnlocked,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -26,7 +26,7 @@ import Bilge
 import Bilge.Assert
 import Brig.Types.Test.Arbitrary (Arbitrary (arbitrary))
 import Cassandra as Cql
-import Control.Lens (over, to, view, (.~), (?~))
+import Control.Lens (to, view, (.~), (?~))
 import Control.Lens.Operators ()
 import Control.Monad.Catch (MonadCatch)
 import Data.Aeson (FromJSON, ToJSON)
@@ -64,8 +64,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
-      test s "All features" testAllFeatures,
+    [ test s "All features" testAllFeatures,
       test s "Feature Configs / Team Features Consistency" testFeatureConfigConsistency,
       test s "ConferenceCalling" $ testSimpleFlag @ConferenceCallingConfig FeatureStatusEnabled,
       test s "SelfDeletingMessages" testSelfDeletingMessages,
@@ -272,51 +271,6 @@ testPatch' testLockStatusChange rndFeatureConfig defStatus defConfig = do
         when (testLockStatusChange == AssertLockStatusChange) $
           wsLockStatus actual @?= fromMaybe (wsLockStatus original) (wspLockStatus rndFeatureConfig)
         wsConfig actual @?= fromMaybe (wsConfig original) (wspConfig rndFeatureConfig)
-
-getClassifiedDomains ::
-  (HasCallStack, HasGalley m, MonadIO m, MonadHttp m, MonadCatch m) =>
-  UserId ->
-  TeamId ->
-  WithStatusNoLock ClassifiedDomainsConfig ->
-  m ()
-getClassifiedDomains member tid =
-  assertFlagWithConfig @ClassifiedDomainsConfig $
-    getTeamFeatureFlag @ClassifiedDomainsConfig member tid
-
-getClassifiedDomainsInternal ::
-  (HasCallStack, HasGalley m, MonadIO m, MonadHttp m, MonadCatch m) =>
-  TeamId ->
-  WithStatusNoLock ClassifiedDomainsConfig ->
-  m ()
-getClassifiedDomainsInternal tid =
-  assertFlagWithConfig @ClassifiedDomainsConfig $
-    getTeamFeatureFlagInternal @ClassifiedDomainsConfig tid
-
-testClassifiedDomainsDisabled :: TestM ()
-testClassifiedDomainsDisabled = do
-  (_owner, tid, member : _) <- createBindingTeamWithNMembers 1
-  let expected =
-        WithStatusNoLock FeatureStatusDisabled (ClassifiedDomainsConfig []) FeatureTTLUnlimited
-
-  let getClassifiedDomainsFeatureConfig ::
-        (HasCallStack, HasGalley m, MonadIO m, MonadHttp m, MonadCatch m) =>
-        UserId ->
-        WithStatusNoLock ClassifiedDomainsConfig ->
-        m ()
-      getClassifiedDomainsFeatureConfig uid expected' = do
-        result <- Util.getFeatureConfig @ClassifiedDomainsConfig uid
-        liftIO $ wsStatus result @?= wssStatus expected'
-        liftIO $ wsConfig result @?= wssConfig expected'
-
-  let classifiedDomainsDisabled opts =
-        opts
-          & over
-            (settings . featureFlags . flagClassifiedDomains)
-            (\(ImplicitLockStatus s) -> ImplicitLockStatus (s & setStatus FeatureStatusDisabled & setConfig (ClassifiedDomainsConfig [])))
-  withSettingsOverrides classifiedDomainsDisabled $ do
-    getClassifiedDomains member tid expected
-    getClassifiedDomainsInternal tid expected
-    getClassifiedDomainsFeatureConfig member expected
 
 testSimpleFlag ::
   forall cfg.

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -58,8 +58,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @SndFactorPasswordChallengeConfig FeatureStatusDisabled LockStatusLocked,
-      test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
+    [ test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
       test s "SearchVisibilityInbound - internal multi team API" testFeatureNoConfigMultiSearchVisibilityInbound,
       test s "OutlookCalIntegration" $ testSimpleFlagWithLockStatus @OutlookCalIntegrationConfig FeatureStatusDisabled LockStatusLocked,
       testGroup

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -58,8 +58,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @GuestLinksConfig FeatureStatusEnabled LockStatusUnlocked,
-      test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @SndFactorPasswordChallengeConfig FeatureStatusDisabled LockStatusLocked,
+    [ test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @SndFactorPasswordChallengeConfig FeatureStatusDisabled LockStatusLocked,
       test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
       test s "SearchVisibilityInbound - internal multi team API" testFeatureNoConfigMultiSearchVisibilityInbound,
       test s "OutlookCalIntegration" $ testSimpleFlagWithLockStatus @OutlookCalIntegrationConfig FeatureStatusDisabled LockStatusLocked,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -26,7 +26,7 @@ import Bilge
 import Bilge.Assert
 import Brig.Types.Test.Arbitrary (Arbitrary (arbitrary))
 import Cassandra as Cql
-import Control.Lens (to, view, (.~), (?~))
+import Control.Lens (view, (.~), (?~))
 import Control.Lens.Operators ()
 import Control.Monad.Catch (MonadCatch)
 import Data.Aeson (FromJSON, ToJSON)
@@ -38,8 +38,7 @@ import Data.List1 qualified as List1
 import Data.Schema (ToSchema)
 import Data.Timeout (TimeoutUnit (Second), (#))
 import GHC.TypeLits (KnownSymbol)
-import Galley.Options (exposeInvitationURLsTeamAllowlist, featureFlags, settings)
-import Galley.Types.Teams
+import Galley.Options (exposeInvitationURLsTeamAllowlist, settings)
 import Imports
 import Network.Wai.Utilities (label)
 import Test.QuickCheck (Gen, generate, suchThat)
@@ -59,8 +58,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "SelfDeletingMessages" testSelfDeletingMessages,
-      test s "ConversationGuestLinks - public API" testGuestLinksPublic,
+    [ test s "ConversationGuestLinks - public API" testGuestLinksPublic,
       test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
       test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @GuestLinksConfig FeatureStatusEnabled LockStatusUnlocked,
       test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @SndFactorPasswordChallengeConfig FeatureStatusDisabled LockStatusLocked,
@@ -609,106 +607,6 @@ testSimpleFlagWithLockStatus defaultStatus defaultLockStatus = do
   setFlagWithGalley defaultStatus
   setLockStatus defaultLockStatus
   getFlags defaultStatus defaultLockStatus
-
-testSelfDeletingMessages :: TestM ()
-testSelfDeletingMessages = do
-  defLockStatus :: LockStatus <-
-    view
-      ( tsGConf
-          . settings
-          . featureFlags
-          . flagSelfDeletingMessages
-          . unDefaults
-          . to wsLockStatus
-      )
-
-  -- personal users
-  let settingWithoutLockStatus :: FeatureStatus -> Int32 -> WithStatusNoLock SelfDeletingMessagesConfig
-      settingWithoutLockStatus stat tout =
-        WithStatusNoLock
-          stat
-          (SelfDeletingMessagesConfig tout)
-          FeatureTTLUnlimited
-      settingWithLockStatus :: FeatureStatus -> Int32 -> LockStatus -> WithStatus SelfDeletingMessagesConfig
-      settingWithLockStatus stat tout lockStatus =
-        withStatus
-          stat
-          lockStatus
-          (SelfDeletingMessagesConfig tout)
-          FeatureTTLUnlimited
-
-  personalUser <- randomUser
-  do
-    result <- Util.getFeatureConfig @SelfDeletingMessagesConfig personalUser
-    liftIO $ result @?= settingWithLockStatus FeatureStatusEnabled 0 defLockStatus
-
-  -- team users
-  galley <- viewGalley
-  (owner, tid, []) <- createBindingTeamWithNMembers 0
-
-  let checkSet :: FeatureStatus -> Int32 -> Int -> TestM ()
-      checkSet stat tout expectedStatusCode =
-        do
-          putTeamFeatureFlagInternal @SelfDeletingMessagesConfig
-            galley
-            tid
-            (settingWithoutLockStatus stat tout)
-          !!! statusCode
-            === const expectedStatusCode
-
-      -- internal, public (/team/:tid/features), and team-agnostic (/feature-configs).
-      checkGet :: HasCallStack => FeatureStatus -> Int32 -> LockStatus -> TestM ()
-      checkGet stat tout lockStatus = do
-        let expected = settingWithLockStatus stat tout lockStatus
-        forM_
-          [ getTeamFeatureFlagInternal @SelfDeletingMessagesConfig tid,
-            getTeamFeatureFlagWithGalley @SelfDeletingMessagesConfig galley owner tid
-          ]
-          (!!! responseJsonEither === const (Right expected))
-        result <- Util.getFeatureConfig @SelfDeletingMessagesConfig owner
-        liftIO $ result @?= expected
-
-      checkSetLockStatus :: HasCallStack => LockStatus -> TestM ()
-      checkSetLockStatus status =
-        do
-          Util.setLockStatusInternal @SelfDeletingMessagesConfig galley tid status
-          !!! statusCode
-            === const 200
-
-  -- test that the default lock status comes from `galley.yaml`.
-  -- use this to change `galley.integration.yaml` locally and manually test that conf file
-  -- parsing works as expected.
-  checkGet FeatureStatusEnabled 0 defLockStatus
-
-  case defLockStatus of
-    LockStatusLocked -> do
-      checkSet FeatureStatusDisabled 0 409
-    LockStatusUnlocked -> do
-      checkSet FeatureStatusDisabled 0 200
-      checkGet FeatureStatusDisabled 0 LockStatusUnlocked
-      checkSet FeatureStatusEnabled 0 200
-      checkGet FeatureStatusEnabled 0 LockStatusUnlocked
-
-  -- now don't worry about what's in the config, write something to cassandra, and test with that.
-  checkSetLockStatus LockStatusLocked
-  checkGet FeatureStatusEnabled 0 LockStatusLocked
-  checkSet FeatureStatusDisabled 0 409
-  checkGet FeatureStatusEnabled 0 LockStatusLocked
-  checkSet FeatureStatusEnabled 30 409
-  checkGet FeatureStatusEnabled 0 LockStatusLocked
-  checkSetLockStatus LockStatusUnlocked
-  checkGet FeatureStatusEnabled 0 LockStatusUnlocked
-  checkSet FeatureStatusDisabled 0 200
-  checkGet FeatureStatusDisabled 0 LockStatusUnlocked
-  checkSet FeatureStatusEnabled 30 200
-  checkGet FeatureStatusEnabled 30 LockStatusUnlocked
-  checkSet FeatureStatusDisabled 30 200
-  checkGet FeatureStatusDisabled 30 LockStatusUnlocked
-  checkSetLockStatus LockStatusLocked
-  checkGet FeatureStatusEnabled 0 LockStatusLocked
-  checkSet FeatureStatusEnabled 50 409
-  checkSetLockStatus LockStatusUnlocked
-  checkGet FeatureStatusDisabled 30 LockStatusUnlocked
 
 testGuestLinksInternal :: TestM ()
 testGuestLinksInternal = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -60,7 +60,6 @@ tests s =
     "Feature Config API and Team Features API"
     [ test s "SearchVisibilityInbound - internal API" testSearchVisibilityInbound,
       test s "SearchVisibilityInbound - internal multi team API" testFeatureNoConfigMultiSearchVisibilityInbound,
-      test s "OutlookCalIntegration" $ testSimpleFlagWithLockStatus @OutlookCalIntegrationConfig FeatureStatusDisabled LockStatusLocked,
       testGroup
         "TTL / Conference calling"
         [ test s "ConferenceCalling unlimited TTL" $ testSimpleFlagTTL @ConferenceCallingConfig FeatureStatusEnabled FeatureTTLUnlimited,
@@ -507,103 +506,6 @@ testSimpleFlagTTL defaultValue ttl = do
   setFlagInternal defaultValue FeatureTTLUnlimited
   getFlag defaultValue
 
-testSimpleFlagWithLockStatus ::
-  forall cfg.
-  ( HasCallStack,
-    Typeable cfg,
-    Eq cfg,
-    Show cfg,
-    FeatureTrivialConfig cfg,
-    IsFeatureConfig cfg,
-    KnownSymbol (FeatureSymbol cfg),
-    ToSchema cfg,
-    ToJSON (WithStatusNoLock cfg)
-  ) =>
-  FeatureStatus ->
-  LockStatus ->
-  TestM ()
-testSimpleFlagWithLockStatus defaultStatus defaultLockStatus = do
-  galley <- viewGalley
-  (owner, tid, member : _) <- createBindingTeamWithNMembers 1
-  nonMember <- randomUser
-
-  let getFlag :: HasCallStack => FeatureStatus -> LockStatus -> TestM ()
-      getFlag expectedStatus expectedLockStatus = do
-        let flag = getTeamFeatureFlag @cfg member tid
-        assertFlagNoConfigWithLockStatus @cfg flag expectedStatus expectedLockStatus
-
-      getFeatureConfig :: HasCallStack => FeatureStatus -> LockStatus -> TestM ()
-      getFeatureConfig expectedStatus expectedLockStatus = do
-        actual <- Util.getFeatureConfig @cfg member
-        liftIO $ wsStatus actual @?= expectedStatus
-        liftIO $ wsLockStatus actual @?= expectedLockStatus
-
-      getFlagInternal :: HasCallStack => FeatureStatus -> LockStatus -> TestM ()
-      getFlagInternal expectedStatus expectedLockStatus = do
-        let flag = getTeamFeatureFlagInternal @cfg tid
-        assertFlagNoConfigWithLockStatus @cfg flag expectedStatus expectedLockStatus
-
-      getFlags expectedStatus expectedLockStatus = do
-        getFlag expectedStatus expectedLockStatus
-        getFeatureConfig expectedStatus expectedLockStatus
-        getFlagInternal expectedStatus expectedLockStatus
-
-      setFlagWithGalley :: FeatureStatus -> TestM ()
-      setFlagWithGalley statusValue =
-        putTeamFeatureFlagWithGalley @cfg galley owner tid (WithStatusNoLock statusValue (trivialConfig @cfg) FeatureTTLUnlimited)
-          !!! statusCode
-            === const 200
-
-      assertSetStatusForbidden :: FeatureStatus -> TestM ()
-      assertSetStatusForbidden statusValue =
-        putTeamFeatureFlagWithGalley @cfg galley owner tid (WithStatusNoLock statusValue (trivialConfig @cfg) FeatureTTLUnlimited)
-          !!! statusCode
-            === const 409
-
-      setLockStatus :: LockStatus -> TestM ()
-      setLockStatus lockStatus =
-        Util.setLockStatusInternal @cfg galley tid lockStatus
-          !!! statusCode
-            === const 200
-
-  assertFlagForbidden $ getTeamFeatureFlag @cfg nonMember tid
-
-  let otherStatus = case defaultStatus of
-        FeatureStatusDisabled -> FeatureStatusEnabled
-        FeatureStatusEnabled -> FeatureStatusDisabled
-
-  -- Initial status and lock status should be the defaults
-  getFlags defaultStatus defaultLockStatus
-
-  -- unlock feature if it is locked
-  when (defaultLockStatus == LockStatusLocked) $ setLockStatus LockStatusUnlocked
-
-  -- setting should work
-  cannon <- view tsCannon
-  -- should receive an event
-  WS.bracketR cannon member $ \ws -> do
-    setFlagWithGalley otherStatus
-    void . liftIO $
-      WS.assertMatch (5 # Second) ws $
-        wsAssertFeatureConfigWithLockStatusUpdate @cfg otherStatus LockStatusUnlocked
-
-  getFlags otherStatus LockStatusUnlocked
-
-  -- lock feature
-  setLockStatus LockStatusLocked
-  -- feature status should now be the default again
-  getFlags defaultStatus LockStatusLocked
-  assertSetStatusForbidden defaultStatus
-  -- unlock feature
-  setLockStatus LockStatusUnlocked
-  -- feature status should be the previously set value
-  getFlags otherStatus LockStatusUnlocked
-
-  -- clean up
-  setFlagWithGalley defaultStatus
-  setLockStatus defaultLockStatus
-  getFlags defaultStatus defaultLockStatus
-
 testSearchVisibilityInbound :: TestM ()
 testSearchVisibilityInbound = do
   let defaultValue = FeatureStatusDisabled
@@ -955,25 +857,6 @@ assertFlagNoConfig res expected = do
       )
       === const (Right expected)
 
-assertFlagNoConfigWithLockStatus ::
-  forall cfg.
-  ( HasCallStack,
-    Typeable cfg,
-    FeatureTrivialConfig cfg,
-    FromJSON (WithStatus cfg),
-    Eq cfg,
-    Show cfg
-  ) =>
-  TestM ResponseLBS ->
-  FeatureStatus ->
-  LockStatus ->
-  TestM ()
-assertFlagNoConfigWithLockStatus res expectedStatus expectedLockStatus = do
-  res !!! do
-    statusCode === const 200
-    responseJsonEither @(WithStatus cfg)
-      === const (Right (withStatus expectedStatus expectedLockStatus (trivialConfig @cfg) FeatureTTLUnlimited))
-
 assertFlagWithConfig ::
   forall cfg m.
   ( HasCallStack,
@@ -1014,23 +897,6 @@ wsAssertFeatureTrivialConfigUpdate status ttl notification = do
   FeatureConfig._eventData e
     @?= Aeson.toJSON
       (withStatus status (wsLockStatus (defFeatureStatus @cfg)) (trivialConfig @cfg) ttl)
-
-wsAssertFeatureConfigWithLockStatusUpdate ::
-  forall cfg.
-  ( IsFeatureConfig cfg,
-    ToSchema cfg,
-    KnownSymbol (FeatureSymbol cfg),
-    FeatureTrivialConfig cfg
-  ) =>
-  FeatureStatus ->
-  LockStatus ->
-  Notification ->
-  IO ()
-wsAssertFeatureConfigWithLockStatusUpdate status lockStatus notification = do
-  let e :: FeatureConfig.Event = List1.head (WS.unpackPayload notification)
-  FeatureConfig._eventType e @?= FeatureConfig.Update
-  FeatureConfig._eventFeatureName e @?= (featureName @cfg)
-  FeatureConfig._eventData e @?= Aeson.toJSON (withStatus status lockStatus (trivialConfig @cfg) FeatureTTLUnlimited)
 
 wsAssertFeatureConfigUpdate ::
   forall cfg.

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -64,8 +64,7 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup
     "Feature Config API and Team Features API"
-    [ test s "DigitalSignatures" $ testSimpleFlag @DigitalSignaturesConfig FeatureStatusDisabled,
-      test s "ValidateSAMLEmails" $ testSimpleFlag @ValidateSAMLEmailsConfig FeatureStatusEnabled,
+    [ test s "ValidateSAMLEmails" $ testSimpleFlag @ValidateSAMLEmailsConfig FeatureStatusEnabled,
       test s "FileSharing with lock status" $ testSimpleFlagWithLockStatus @FileSharingConfig FeatureStatusEnabled LockStatusUnlocked,
       test s "Classified Domains (enabled)" testClassifiedDomainsEnabled,
       test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,


### PR DESCRIPTION
The PR migrates team feature integration tests from the `galley-integration` package to the `integration` package.

This doesn't migrate all the tests that are to be found in the `API.Teams.Feature` package; the rest is going to happen in a follow-up PR to ease reviewing.

Tracked by https://wearezeta.atlassian.net/browse/WPB-6442.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
