### PR TITLE
Revert http2 pin.

### DIFF
--- a/libs/http2-manager/default.nix
+++ b/libs/http2-manager/default.nix
@@ -19,7 +19,7 @@
 , stm
 , streaming-commons
 , text
-, utf8-string
+, time-manager
 }:
 mkDerivation {
   pname = "http2-manager";
@@ -36,7 +36,7 @@ mkDerivation {
     stm
     streaming-commons
     text
-    utf8-string
+    time-manager
   ];
   testHaskellDepends = [
     async
@@ -51,6 +51,7 @@ mkDerivation {
     random
     stm
     streaming-commons
+    time-manager
   ];
   testToolDepends = [ hspec-discover ];
   description = "Managed connection pool for HTTP2";

--- a/libs/http2-manager/http2-manager.cabal
+++ b/libs/http2-manager/http2-manager.cabal
@@ -44,7 +44,7 @@ library
     , stm
     , streaming-commons
     , text
-    , utf8-string
+    , time-manager
 
   default-language: Haskell2010
 
@@ -85,3 +85,4 @@ test-suite http2-manager-tests
     , random
     , stm
     , streaming-commons
+    , time-manager

--- a/libs/http2-manager/test/Test/HTTP2/Client/ManagerSpec.hs
+++ b/libs/http2-manager/test/Test/HTTP2/Client/ManagerSpec.hs
@@ -26,6 +26,7 @@ import qualified Data.Map as Map
 import Data.Maybe (isJust)
 import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
 import Data.Unique
+import Foreign.Marshal.Alloc (mallocBytes)
 import GHC.IO.Exception
 import HTTP2.Client.Manager
 import HTTP2.Client.Manager.Internal
@@ -36,6 +37,7 @@ import qualified Network.HTTP2.Server as Server
 import Network.Socket
 import qualified OpenSSL.Session as SSL
 import System.Random (randomRIO)
+import qualified System.TimeManager
 import Test.Hspec
 
 echoTest :: Http2Manager -> TLSEnabled -> Int -> Expectation
@@ -268,30 +270,38 @@ withTestServerOnSocket mCtx action (serverPort, listenSock) = do
   bracket (async $ testServerOnSocket mCtx listenSock acceptedConns liveConns) cleanupServer $ \serverThread ->
     action TestServer {..}
 
-allocServerConfig :: (Socket, Maybe SSL.SSL) -> IO Server.Config
-allocServerConfig (sock, Nothing) =
-  HTTP2.allocSimpleConfig sock 4096
-allocServerConfig (sock, Just ssl) = do
-  config <- HTTP2.allocSimpleConfig sock 4096
-  pure $
-    config
-      { Server.confReadN = readData mempty,
-        Server.confSendAll = SSL.write ssl
+allocServerConfig :: Either Socket SSL.SSL -> IO Server.Config
+allocServerConfig (Left sock) = HTTP2.allocSimpleConfig sock 4096
+allocServerConfig (Right ssl) = do
+  buf <- mallocBytes bufsize
+  timmgr <- System.TimeManager.initialize $ 30 * 1000000
+  -- Sometimes the frame header says that the payload length is 0. Reading 0
+  -- bytes multiple times seems to be causing errors in openssl. I cannot figure
+  -- out why. The previous implementation didn't try to read from the socket
+  -- when trying to read 0 bytes, so special handling for 0 maintains that
+  -- behaviour.
+  let readData prevChunk 0 = pure prevChunk
+      readData prevChunk n = do
+        -- Handling SSL.ConnectionAbruptlyTerminated as a stream end
+        -- (some sites terminate SSL connection right after returning the data).
+        chunk <- SSL.read ssl n `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> pure mempty
+        let chunkLen = BS.length chunk
+        if
+            | chunkLen == 0 || chunkLen == n ->
+                pure (prevChunk <> chunk)
+            | chunkLen > n ->
+                error "openssl: SSL.read returned more bytes than asked for, this is probably a bug"
+            | otherwise ->
+                readData (prevChunk <> chunk) (n - chunkLen)
+  pure
+    Server.Config
+      { Server.confWriteBuffer = buf,
+        Server.confBufferSize = bufsize,
+        Server.confSendAll = SSL.write ssl,
+        Server.confReadN = readData mempty,
+        Server.confPositionReadMaker = Server.defaultPositionReadMaker,
+        Server.confTimeoutManager = timmgr
       }
-  where
-    readData prevChunk 0 = pure prevChunk
-    readData prevChunk n = do
-      -- Handling SSL.ConnectionAbruptlyTerminated as a stream end
-      -- (some sites terminate SSL connection right after returning the data).
-      chunk <- SSL.read ssl n `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> pure mempty
-      let chunkLen = BS.length chunk
-      if
-          | chunkLen == 0 || chunkLen == n ->
-              pure (prevChunk <> chunk)
-          | chunkLen > n ->
-              error "openssl: SSL.read returned more bytes than asked for, this is probably a bug"
-          | otherwise ->
-              readData (prevChunk <> chunk) (n - chunkLen)
 
 testServerOnSocket :: Maybe SSL.SSLContext -> Socket -> IORef Int -> IORef (Map Unique (Async ())) -> IO ()
 testServerOnSocket mCtx listenSock connsCounter conns = do
@@ -299,20 +309,20 @@ testServerOnSocket mCtx listenSock connsCounter conns = do
   forever $ do
     (sock, _) <- accept listenSock
     serverCfgParam <- case mCtx of
-      Nothing -> pure $ (sock, Nothing)
+      Nothing -> pure $ Left sock
       Just ctx -> do
         ssl <- SSL.connection ctx sock
         SSL.accept ssl
-        pure (sock, Just ssl)
+        pure (Right ssl)
     connKey <- newUnique
     modifyIORef connsCounter (+ 1)
     let shutdownSSL = case serverCfgParam of
-          (_sock, Just ssl) -> SSL.shutdown ssl SSL.Bidirectional
-          _ -> pure ()
+          Left _ -> pure ()
+          Right ssl -> SSL.shutdown ssl SSL.Bidirectional
         cleanup cfg = do
           Server.freeSimpleConfig cfg `finally` (shutdownSSL `finally` close sock)
     thread <- async $ bracket (allocServerConfig serverCfgParam) cleanup $ \cfg -> do
-      Server.run Server.defaultServerConfig cfg testServer `finally` modifyIORef conns (Map.delete connKey)
+      Server.run cfg testServer `finally` modifyIORef conns (Map.delete connKey)
     modifyIORef conns $ Map.insert connKey thread
 
 testServer :: Server.Request -> Server.Aux -> (Server.Response -> [Server.PushPromise] -> IO ()) -> IO ()

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -141,7 +141,7 @@ let
     };
 
     # We forked to add a handler for the ConnectionIsClosed signal
-    # since it was threated as a halting exception instead of a 
+    # since it was threated as a halting exception instead of a
     # clean exit.
     http2 = {
       src = fetchgit {
@@ -285,7 +285,7 @@ let
       version = "5.0.18.4";
       sha256 = "sha256-gIc4hpdUfTS33rZPfzwLfVcXkQaglmsljqViyYdihdk=";
     };
-    # dependency of hoogle 
+    # dependency of hoogle
     safe = {
       version = "0.3.20";
       sha256 = "sha256-PGwjhrRnkH8cLhd7fHTZFd6ts9abp0w5sLlV8ke1yXU=";

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -140,17 +140,6 @@ let
       };
     };
 
-    # We forked to add a handler for the ConnectionIsClosed signal
-    # since it was threated as a halting exception instead of a
-    # clean exit.
-    http2 = {
-      src = fetchgit {
-        url = "https://github.com/wireapp/http2";
-        rev = "9cad270779bbcd9e6297b9ff05a4a7eb83bca069";
-        sha256 = "sha256-c+PzfZZUxo/tE8oH1ZmKwbUMAq34kGD1OoBWorNLG38=";
-      };
-    };
-
     # PR: https://gitlab.com/twittner/cql/-/merge_requests/11
     cql = {
       src = fetchgit {
@@ -243,37 +232,24 @@ let
         hash = "sha256-E35PVxi/4iJFfWts3td52KKZKQt4dj9KFP3SvWG77Cc=";
       };
     };
-
     # PR: https://github.com/yesodweb/wai/pull/958
     warp = {
       src = fetchgit {
         url = "https://github.com/wireapp/wai";
-        rev = "a48f8f31ad42f26057d7b96d70f897c1a3f69a3c";
-        sha256 = "sha256-fFkiKLlViiV+F1wdQXak3RI454kgWvyRsoDz6g4c5Ks=";
+        rev = "bedd6a835f6d98128880465c30e8115fa986e3f6";
+        sha256 = "sha256-0r/d9YwcKZIZd10EhL2TP+W14Wjk0/S8Q4pVvZuZLaY=";
       };
       packages = {
         "warp" = "warp";
-        "warp-tls" = "warp-tls";
-        "wai-app-static" = "wai-app-static";
-        "wai" = "wai";
-        "wai-extra" = "wai-extra";
-        "wai-websockets" = "wai-websockets";
       };
     };
   };
-
   hackagePins = {
     # Major re-write upstream, we should get rid of this dependency rather than
     # adapt to upstream, this will go away when completing servantification.
     wai-route = {
       version = "0.4.0";
       sha256 = "sha256-DSMckKIeVE/buSMg8Mq+mUm1bYPYB7veA11Ns7vTBbc=";
-    };
-
-    # http2 now depends on this, might be removable after next nixpkgs bump
-    network-control = {
-      version = "0.0.2";
-      sha256 = "sha256-0EvnVu7cktMmSRVk9Ufm0oE4JLQrKLSRYpFpgcJguY0=";
     };
 
     # these are not yet in nixpkgs

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -54,6 +54,7 @@ hself: hsuper: {
   optparse-generic = hsuper.optparse-generic_1_5_2;
   th-abstraction = hsuper.th-abstraction_0_5_0_0;
   tls = hsuper.tls_1_9_0;
+  warp-tls = hsuper.warp-tls_3_4_3;
 
   # -----------------
   # flags and patches


### PR DESCRIPTION
Removed a pin that was introduced in 8f823f2517f, as it only made things worse.

## Checklist

 - ~~[ ] Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
