### PR TITLE
reproduce bug: register saml idp first, then register scim token => scim token won't be linked.

### DIFF
--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -504,6 +504,7 @@ idpCreateXML zusr raw idpmeta mReplaces (fromMaybe defWireIdPAPIVersion -> apive
   IdPConfigStore.insertConfig idp
   forM_ mReplaces $ \replaces ->
     IdPConfigStore.setReplacedBy (Replaced replaces) (Replacing (idp ^. SAML.idpId))
+  -- TODO: update scim token if exists, and link it to idp!!
   pure idp
 
 -- | In teams with a scim access token, only one IdP is allowed.  The reason is that scim user

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -475,7 +475,7 @@ specCreateUser = describe "POST /Users" $ do
       testCreateUserNoIdPNoEmail
     it "doesn't list users that exceed their invitation period, and allows recreating them" $ do
       testCreateUserTimeout
-  context "team has one SAML IdP" $ do
+  focus . context "team has one SAML IdP" $ do
     it "creates a user in an existing team" $ do
       testCreateUserWithSamlIdP
     it "adds a Wire scheme to the user record" $ testSchemaIsAdded

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -78,12 +78,11 @@ registerIdPAndScimToken = do
   let brig = env ^. teBrig
       spar = env ^. teSpar
       galley = env ^. teGalley
-  (owner, teamid) <- createUserWithTeam brig galley
+  (owner, teamid) <- call $ createUserWithTeam brig galley
   tok <- registerScimToken teamid Nothing
   idp <- do
     SAML.SampleIdP idpmeta _ _ _ <- SAML.makeSampleIdPMetadata
-    let metadata = IdPMetadataValue (cs $ SAML.encode idpmeta) idpmeta
-    callIdpCreate WireIdPAPIV2 spar (Just owner) metadata
+    call $ callIdpCreate WireIdPAPIV2 spar (Just owner) idpmeta
   pure (tok, (owner, teamid, idp))
 
 -- | Call 'registerTestIdPWithMeta', then 'registerScimToken'.  The user returned is the owner of the team;


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-7021

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
