### PR TITLE
Re-arrange internal routing table types in brig to make more sense.

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -21,7 +21,6 @@ module Wire.API.Routes.Internal.Brig
     brigInternalClient,
     runBrigInternalClient,
     IStatusAPI,
-    EJPD_API,
     AccountAPI,
     MLSAPI,
     TeamsAPI,
@@ -156,27 +155,23 @@ type GetAllConnections =
     :> ReqBody '[Servant.JSON] ConnectionsStatusRequestV2
     :> Post '[Servant.JSON] [ConnectionStatusV2]
 
-type EJPD_API =
-  ( EJPDRequest
-      :<|> Named "get-account-conference-calling-config" GetAccountConferenceCallingConfig
-      :<|> PutAccountConferenceCallingConfig
-      :<|> DeleteAccountConferenceCallingConfig
-      :<|> GetAllConnectionsUnqualified
-      :<|> GetAllConnections
-  )
-
 type AccountAPI =
-  -- This endpoint can lead to the following events being sent:
-  -- - UserActivated event to created user, if it is a team invitation or user has an SSO ID
-  -- - UserIdentityUpdated event to created user, if email or phone get activated
-  Named
-    "createUserNoVerify"
-    ( "users"
-        :> MakesFederatedCall 'Brig "on-user-deleted-connections"
-        :> MakesFederatedCall 'Brig "send-connection-action"
-        :> ReqBody '[Servant.JSON] NewUser
-        :> MultiVerb 'POST '[Servant.JSON] RegisterInternalResponses (Either RegisterError SelfProfile)
-    )
+  Named "get-account-conference-calling-config" GetAccountConferenceCallingConfig
+    :<|> PutAccountConferenceCallingConfig
+    :<|> DeleteAccountConferenceCallingConfig
+    :<|> GetAllConnectionsUnqualified
+    :<|> GetAllConnections
+    :<|> Named
+           "createUserNoVerify"
+           -- This endpoint can lead to the following events being sent:
+           -- - UserActivated event to created user, if it is a team invitation or user has an SSO ID
+           -- - UserIdentityUpdated event to created user, if email or phone get activated
+           ( "users"
+               :> MakesFederatedCall 'Brig "on-user-deleted-connections"
+               :> MakesFederatedCall 'Brig "send-connection-action"
+               :> ReqBody '[Servant.JSON] NewUser
+               :> MultiVerb 'POST '[Servant.JSON] RegisterInternalResponses (Either RegisterError SelfProfile)
+           )
     :<|> Named
            "createUserNoVerifySpar"
            ( "users"
@@ -532,7 +527,7 @@ type GetVerificationCode =
 type API =
   "i"
     :> ( IStatusAPI
-           :<|> EJPD_API
+           :<|> EJPDRequest
            :<|> AccountAPI
            :<|> MLSAPI
            :<|> GetVerificationCode

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -148,14 +148,9 @@ ejpdAPI ::
     Member NotificationSubsystem r,
     Member Rpc r
   ) =>
-  ServerT BrigIRoutes.EJPD_API (Handler r)
+  ServerT BrigIRoutes.EJPDRequest (Handler r)
 ejpdAPI =
   Brig.User.EJPD.ejpdRequest
-    :<|> Named @"get-account-conference-calling-config" getAccountConferenceCallingConfig
-    :<|> putAccountConferenceCallingConfig
-    :<|> deleteAccountConferenceCallingConfig
-    :<|> getConnectionsStatusUnqualified
-    :<|> getConnectionsStatus
 
 mlsAPI :: ServerT BrigIRoutes.MLSAPI (Handler r)
 mlsAPI = getMLSClients
@@ -176,7 +171,12 @@ accountAPI ::
   ) =>
   ServerT BrigIRoutes.AccountAPI (Handler r)
 accountAPI =
-  Named @"createUserNoVerify" (callsFed (exposeAnnotations createUserNoVerify))
+  Named @"get-account-conference-calling-config" getAccountConferenceCallingConfig
+    :<|> putAccountConferenceCallingConfig
+    :<|> deleteAccountConferenceCallingConfig
+    :<|> getConnectionsStatusUnqualified
+    :<|> getConnectionsStatus
+    :<|> Named @"createUserNoVerify" (callsFed (exposeAnnotations createUserNoVerify))
     :<|> Named @"createUserNoVerifySpar" (callsFed (exposeAnnotations createUserNoVerifySpar))
     :<|> Named @"putSelfEmail" changeSelfEmailMaybeSendH
     :<|> Named @"iDeleteUser" deleteUserNoAuthH


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-7265

New behavior should be trivially identical to the old one, but the routing table tree makes more sense now.

No changelog entry needed.