### PR TITLE
[WPB-6783] Support unblocking an MLS 1-to-1 conversation (the `q1-2024` port)

### DIFF
--- a/changelog.d/2-features/WPB-6783
+++ b/changelog.d/2-features/WPB-6783
@@ -1,0 +1,1 @@
+Support unblocking a user in an MLS 1-to-1 conversation

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -21,6 +21,7 @@ import API.Brig
 import API.Galley
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Set as Set
 import MLS.Util
 import Notifications
 import SetupHelpers
@@ -67,7 +68,7 @@ testMLSOne2OneBlocked otherDomain = do
 testMLSOne2OneBlockedAfterConnected :: HasCallStack => One2OneScenario -> App ()
 testMLSOne2OneBlockedAfterConnected scenario = do
   alice <- randomUser OwnDomain def
-  let otherDomain = one2OneScenarioDomain scenario
+  let otherDomain = one2OneScenarioUserDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
   conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
@@ -101,6 +102,61 @@ testMLSOne2OneBlockedAfterConnected scenario = do
     void $ postMLSMessage mp.sender mp.message >>= getJSON 201
     awaitAnyEvent 2 ws `shouldMatch` (Nothing :: Maybe Value)
 
+-- | Alice and Bob are initially connected, then Alice blocks Bob, and finally
+-- Alice unblocks Bob.
+testMLSOne2OneUnblocked :: HasCallStack => One2OneScenario -> App ()
+testMLSOne2OneUnblocked scenario = do
+  alice <- randomUser OwnDomain def
+  let otherDomain = one2OneScenarioUserDomain scenario
+      convDomain = one2OneScenarioConvDomain scenario
+  bob <- createMLSOne2OnePartner otherDomain alice convDomain
+  conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
+  do
+    convId <- conv %. "qualified_id"
+    bobConv <- getMLSOne2OneConversation bob alice >>= getJSON 200
+    convId `shouldMatch` (bobConv %. "qualified_id")
+
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
+  traverse_ uploadNewKeyPackage [bob1]
+  resetGroup alice1 conv
+  withWebSocket bob1 $ \ws -> do
+    commit <- createAddCommit alice1 [bob]
+    void $ sendAndConsumeCommitBundle commit
+    let isMessage n = nPayload n %. "type" `isEqual` "conversation.mls-welcome"
+    n <- awaitMatch isMessage ws
+    nPayload n %. "data" `shouldMatch` B8.unpack (Base64.encode (fold commit.welcome))
+
+  -- Alice blocks Bob
+  void $ putConnection alice bob "blocked" >>= getBody 200
+  void $ getMLSOne2OneConversation alice bob >>= getJSON 403
+
+  -- Reset the group membership in the test setup as only 'bob1' is left in
+  -- reality, even though the test state believes 'alice1' is still part of the
+  -- conversation.
+  modifyMLSState $ \s -> s {members = Set.singleton bob1}
+
+  -- Bob creates a new client and adds it to the one-to-one conversation just so
+  -- that the epoch advances.
+  bob2 <- createMLSClient def bob
+  traverse_ uploadNewKeyPackage [bob2]
+  void $ createAddCommit bob1 [bob] >>= sendAndConsumeCommitBundle
+
+  -- Alice finally unblocks Bob
+  void $ putConnection alice bob "accepted" >>= getBody 200
+  void $ getMLSOne2OneConversation alice bob >>= getJSON 200
+
+  -- Alice rejoins via an external commit
+  void $ createExternalCommit alice1 Nothing >>= sendAndConsumeCommitBundle
+
+  -- Check that an application message can get to Bob
+  withWebSockets [bob1, bob2] $ \wss -> do
+    mp <- createApplicationMessage alice1 "hello, I've always been here"
+    void $ sendAndConsumeMessage mp
+    let isMessage n = nPayload n %. "type" `isEqual` "conversation.mls-message-add"
+    forM_ wss $ \ws -> do
+      n <- awaitMatch isMessage ws
+      nPayload n %. "data" `shouldMatch` B8.unpack (Base64.encode mp.message)
+
 testGetMLSOne2OneSameTeam :: App ()
 testGetMLSOne2OneSameTeam = do
   (alice, _, _) <- createTeam OwnDomain 1
@@ -121,9 +177,9 @@ instance HasTests x => HasTests (One2OneScenario -> x) where
       <> mkTests m (n <> "[domain=other;conv=own]") s f (x One2OneScenarioLocalConv)
       <> mkTests m (n <> "[domain=other;conv=other]") s f (x One2OneScenarioRemoteConv)
 
-one2OneScenarioDomain :: One2OneScenario -> Domain
-one2OneScenarioDomain One2OneScenarioLocal = OwnDomain
-one2OneScenarioDomain _ = OtherDomain
+one2OneScenarioUserDomain :: One2OneScenario -> Domain
+one2OneScenarioUserDomain One2OneScenarioLocal = OwnDomain
+one2OneScenarioUserDomain _ = OtherDomain
 
 one2OneScenarioConvDomain :: One2OneScenario -> Domain
 one2OneScenarioConvDomain One2OneScenarioLocal = OwnDomain
@@ -133,7 +189,7 @@ one2OneScenarioConvDomain One2OneScenarioRemoteConv = OtherDomain
 testMLSOne2One :: HasCallStack => One2OneScenario -> App ()
 testMLSOne2One scenario = do
   alice <- randomUser OwnDomain def
-  let otherDomain = one2OneScenarioDomain scenario
+  let otherDomain = one2OneScenarioUserDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
   [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -517,7 +517,7 @@ type IConversationAPI =
     -- - MemberJoin event to other, if the conversation existed and only the other was member
     --   before
     :<|> Named
-           "conversation-unblock"
+           "conversation-unblock-unqualified"
            ( CanThrow 'InvalidOperation
                :> CanThrow 'ConvNotFound
                :> ZLocalUser
@@ -526,6 +526,21 @@ type IConversationAPI =
                :> Capture "cnv" ConvId
                :> "unblock"
                :> Put '[Servant.JSON] Conversation
+           )
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberJoin event to you, if the conversation existed and had < 2 members before
+    -- - MemberJoin event to other, if the conversation existed and only the other was member
+    --   before
+    :<|> Named
+           "conversation-unblock"
+           ( CanThrow 'InvalidOperation
+               :> CanThrow 'ConvNotFound
+               :> ZLocalUser
+               :> ZOptConn
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> "unblock"
+               :> Put '[Servant.JSON] ()
            )
     :<|> Named
            "conversation-meta"
@@ -544,6 +559,17 @@ type IConversationAPI =
                :> ZLocalUser
                :> QualifiedCapture "user" UserId
                :> Get '[Servant.JSON] Conversation
+           )
+    :<|> Named
+           "conversation-mls-one-to-one-established"
+           ( CanThrow 'NotConnected
+               :> CanThrow 'MLSNotEnabled
+               :> ZLocalUser
+               :> "conversations"
+               :> "mls-one2one"
+               :> QualifiedCapture "user" UserId
+               :> "established"
+               :> Get '[Servant.JSON] Bool
            )
 
 swaggerDoc :: OpenApi

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -575,6 +575,7 @@ revokeIdentityH bade badp = throwStd (badRequest ("need exactly one of email, ph
 
 updateConnectionInternalH ::
   ( Member (Embed HttpClientIO) r,
+    Member GalleyProvider r,
     Member TinyLog r
   ) =>
   UpdateConnectionsInternal ->

--- a/services/brig/src/Brig/Effects/GalleyProvider.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider.hs
@@ -36,6 +36,12 @@ import Wire.API.Team.Member qualified as Team
 import Wire.API.Team.Role
 import Wire.API.Team.SearchVisibility
 
+data MLSOneToOneEstablished
+  = Established
+  | NotEstablished
+  | NotAMember
+  deriving (Eq, Show)
+
 data GalleyProvider m a where
   CreateSelfConv ::
     UserId ->
@@ -109,6 +115,11 @@ data GalleyProvider m a where
   IsMLSOne2OneEstablished ::
     Local UserId ->
     Qualified UserId ->
-    GalleyProvider m Bool
+    GalleyProvider m MLSOneToOneEstablished
+  UnblockConversation ::
+    Local UserId ->
+    Maybe ConnId ->
+    Qualified ConvId ->
+    GalleyProvider m Conversation
 
 makeSem ''GalleyProvider

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -128,9 +128,11 @@ conversationAPI =
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
     <@> mkNamedAPI @"conversation-block-unqualified" Update.blockConvUnqualified
     <@> mkNamedAPI @"conversation-block" Update.blockConv
+    <@> mkNamedAPI @"conversation-unblock-unqualified" Update.unblockConvUnqualified
     <@> mkNamedAPI @"conversation-unblock" Update.unblockConv
     <@> mkNamedAPI @"conversation-meta" Query.getConversationMeta
     <@> mkNamedAPI @"conversation-mls-one-to-one" Query.getMLSOne2OneConversation
+    <@> mkNamedAPI @"conversation-mls-one-to-one-established" Query.isMLSOne2OneEstablished
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)


### PR DESCRIPTION
This ports PR #3940 that has been merged to develop, to the `q1-2024` branch.

Tracked by https://wearezeta.atlassian.net/browse/WPB-6783.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
