### PR TITLE
[chore] enforce Imports in brig

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -19,6 +19,13 @@ extra-source-files:
   docs/swagger.md
 
 common common-all
+  -- NOTE(mangoiv): we cannot use the -Wunused-packages here because 
+  -- cabal doesn't recognise that we need `base` to be able  to 
+  -- hide it
+  mixins: 
+    , base hiding (Prelude)
+    , imports (Imports as Prelude)
+    , imports
   default-language:   GHC2021
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
@@ -51,7 +58,6 @@ common common-all
     MultiParamTypeClasses
     MultiWayIf
     NamedFieldPuns
-    NoImplicitPrelude
     NumericUnderscores
     OverloadedLabels
     OverloadedRecordDot
@@ -234,12 +240,10 @@ library
     Brig.Version
     Brig.ZAuth
 
-  other-modules:   Paths_brig
   hs-source-dirs:  src
   ghc-options:
     -funbox-strict-fields -fplugin=Polysemy.Plugin
     -fplugin=TransitiveAnns.Plugin -Wredundant-constraints
-    -Wunused-packages
 
   build-depends:
     , aeson                      >=2.0.1.0
@@ -252,7 +256,6 @@ library
     , async                      >=2.1
     , auto-update                >=0.1
     , base                       >=4       && <5
-    , base-prelude
     , base16-bytestring          >=0.1
     , base64-bytestring          >=1.0
     , bilge                      >=0.21.1
@@ -370,10 +373,9 @@ library
 executable brig
   import:        common-all
   main-is:       exec/Main.hs
-  other-modules: Paths_brig
   ghc-options:
     -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -rtsopts -Wredundant-constraints
 
   build-depends:
     , base
@@ -385,7 +387,6 @@ executable brig
 executable brig-index
   import:        common-all
   main-is:       index/src/Main.hs
-  other-modules: Paths_brig
   ghc-options:   -funbox-strict-fields -threaded -with-rtsopts=-N
   build-depends:
     , base

--- a/services/brig/exec/Main.hs
+++ b/services/brig/exec/Main.hs
@@ -21,7 +21,6 @@ module Main
 where
 
 import Brig.Run (run)
-import Imports
 import OpenSSL (withOpenSSL)
 import Util.Options
 

--- a/services/brig/index/src/Main.hs
+++ b/services/brig/index/src/Main.hs
@@ -22,7 +22,6 @@ where
 
 import Brig.Index.Eval
 import Brig.Index.Options
-import Imports
 import Options.Applicative
 import System.Exit
 import System.Logger.Class qualified as Log

--- a/services/brig/schema/Main.hs
+++ b/services/brig/schema/Main.hs
@@ -1,5 +1,4 @@
 import Brig.Schema.Run qualified as Run
-import Imports
 
 main :: IO ()
 main = Run.main

--- a/services/brig/src/Brig/API/Auth.hs
+++ b/services/brig/src/Brig/API/Auth.hs
@@ -40,7 +40,6 @@ import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Data.Time.Clock (UTCTime)
 import Data.ZAuth.Token qualified as ZAuth
-import Imports
 import Network.HTTP.Types
 import Network.Wai.Utilities ((!>>))
 import Network.Wai.Utilities.Error qualified as Wai

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -87,7 +87,6 @@ import Data.Misc (PlainTextPassword6)
 import Data.Qualified
 import Data.Set qualified as Set
 import Data.Time.Clock (UTCTime)
-import Imports
 import Network.HTTP.Types.Method (StdMethod)
 import Network.Wai.Utilities
 import Polysemy

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -58,7 +58,6 @@ import Data.Qualified
 import Data.Range
 import Data.UUID.V4 qualified as UUID
 import Galley.Types.Conversations.One2One
-import Imports
 import Polysemy
 import Polysemy.TinyLog
 import System.Logger.Class qualified as Log

--- a/services/brig/src/Brig/API/Connection/Remote.hs
+++ b/services/brig/src/Brig/API/Connection/Remote.hs
@@ -40,7 +40,6 @@ import Control.Monad.Trans.Except
 import Data.Id as Id
 import Data.Qualified
 import Galley.Types.Conversations.One2One (one2OneConvId)
-import Imports
 import Network.Wai.Utilities.Error
 import Polysemy
 import Wire.API.Connection

--- a/services/brig/src/Brig/API/Connection/Util.hs
+++ b/services/brig/src/Brig/API/Connection/Util.hs
@@ -33,7 +33,6 @@ import Control.Lens (view)
 import Control.Monad.Trans.Except
 import Data.Id (UserId)
 import Data.Qualified
-import Imports
 import Wire.API.Connection (Relation (..))
 
 type ConnectionM r = ExceptT ConnectionError (AppT r)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -26,7 +26,6 @@ import Data.ByteString.Conversion
 import Data.Domain (Domain)
 import Data.Jwt.Tools (DPoPTokenGenerationError (..))
 import Data.ZAuth.Validation qualified as ZAuth
-import Imports
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error qualified as Wai

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -49,7 +49,6 @@ import Data.Qualified
 import Data.Range
 import Data.Set (fromList, (\\))
 import Gundeck.Types.Push qualified as Push
-import Imports hiding ((\\))
 import Network.Wai.Utilities.Error ((!>>))
 import Polysemy
 import Servant (ServerT)
@@ -72,6 +71,7 @@ import Wire.API.UserEvent
 import Wire.API.UserMap (UserMap)
 import Wire.NotificationSubsystem
 import Wire.Sem.Concurrency
+import Prelude hiding ((\\))
 
 type FederationAPI = "federation" :> BrigApi
 

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -51,7 +51,6 @@ import Data.Aeson qualified as Aeson
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.ZAuth.Validation qualified as ZV
-import Imports
 import Network.HTTP.Types (Status (statusCode, statusMessage))
 import Network.Wai (Request, ResponseReceived)
 import Network.Wai.Predicate (Media)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -73,7 +73,6 @@ import Data.Qualified
 import Data.Set qualified as Set
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.System
-import Imports hiding (head)
 import Network.Wai.Routing hiding (toList)
 import Network.Wai.Utilities as Utilities
 import Polysemy
@@ -103,6 +102,7 @@ import Wire.NotificationSubsystem
 import Wire.Rpc
 import Wire.Sem.Concurrency
 import Wire.Sem.Paging.Cassandra (InternalPaging)
+import Prelude hiding (head)
 
 ---------------------------------------------------------------------------
 -- Sitemap (servant)
@@ -586,7 +586,7 @@ listActivatedAccounts elh includePendingInvitations = do
 getActivationCodeH :: Maybe Email -> Maybe Phone -> (Handler r) GetActivationCodeResp
 getActivationCodeH (Just email) Nothing = getActivationCode (Left email)
 getActivationCodeH Nothing (Just phone) = getActivationCode (Right phone)
-getActivationCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+getActivationCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 getActivationCode :: Either Email Phone -> (Handler r) GetActivationCodeResp
 getActivationCode emailOrPhone = do
@@ -602,7 +602,7 @@ getPasswordResetCodeH ::
   (Handler r) GetPasswordResetCodeResp
 getPasswordResetCodeH (Just email) Nothing = getPasswordResetCode (Left email)
 getPasswordResetCodeH Nothing (Just phone) = getPasswordResetCode (Right phone)
-getPasswordResetCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+getPasswordResetCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 getPasswordResetCode ::
   ( Member CodeStore r,
@@ -674,7 +674,7 @@ revokeIdentityH ::
   (Handler r) NoContent
 revokeIdentityH (Just email) Nothing = lift $ NoContent <$ API.revokeIdentity (Left email)
 revokeIdentityH Nothing (Just phone) = lift $ NoContent <$ API.revokeIdentity (Right phone)
-revokeIdentityH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+revokeIdentityH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 updateConnectionInternalH ::
   ( Member GalleyProvider r,
@@ -691,7 +691,7 @@ updateConnectionInternalH updateConn = do
 checkBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) CheckBlacklistResponse
 checkBlacklistH (Just email) Nothing = checkBlacklist (Left email)
 checkBlacklistH Nothing (Just phone) = checkBlacklist (Right phone)
-checkBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+checkBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 checkBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) CheckBlacklistResponse
 checkBlacklist emailOrPhone = lift $ bool NotBlacklisted YesBlacklisted <$> API.isBlacklisted emailOrPhone
@@ -699,7 +699,7 @@ checkBlacklist emailOrPhone = lift $ bool NotBlacklisted YesBlacklisted <$> API.
 deleteFromBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) NoContent
 deleteFromBlacklistH (Just email) Nothing = deleteFromBlacklist (Left email)
 deleteFromBlacklistH Nothing (Just phone) = deleteFromBlacklist (Right phone)
-deleteFromBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+deleteFromBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 deleteFromBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) NoContent
 deleteFromBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistDelete emailOrPhone
@@ -707,7 +707,7 @@ deleteFromBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistDelete email
 addBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) NoContent
 addBlacklistH (Just email) Nothing = addBlacklist (Left email)
 addBlacklistH Nothing (Just phone) = addBlacklist (Right phone)
-addBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+addBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Prelude.cs (show (bade, badp))))
 
 addBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) NoContent
 addBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistInsert emailOrPhone

--- a/services/brig/src/Brig/API/MLS/CipherSuite.hs
+++ b/services/brig/src/Brig/API/MLS/CipherSuite.hs
@@ -19,7 +19,6 @@ module Brig.API.MLS.CipherSuite (getCipherSuite, getCipherSuites) where
 
 import Brig.API.Handler
 import Brig.API.MLS.KeyPackages.Validation
-import Imports
 import Wire.API.MLS.CipherSuite
 
 getOneCipherSuite :: CipherSuite -> Handler r CipherSuiteTag

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -42,7 +42,6 @@ import Data.CommaSeparatedList
 import Data.Id
 import Data.Qualified
 import Data.Set qualified as Set
-import Imports
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
 import Wire.API.MLS.CipherSuite

--- a/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
@@ -34,7 +34,6 @@ import Data.ByteString qualified as LBS
 import Data.Qualified
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Imports hiding (cs)
 import Wire.API.Error
 import Wire.API.Error.Brig
 import Wire.API.MLS.CipherSuite
@@ -43,6 +42,7 @@ import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Lifetime
 import Wire.API.MLS.Serialisation
 import Wire.API.MLS.Validation
+import Prelude hiding (cs)
 
 validateUploadedKeyPackage ::
   ClientIdentity ->

--- a/services/brig/src/Brig/API/MLS/Util.hs
+++ b/services/brig/src/Brig/API/MLS/Util.hs
@@ -24,7 +24,6 @@ import Brig.Data.Client
 import Brig.Options
 import Control.Error
 import Control.Lens (view)
-import Imports
 
 isMLSEnabled :: Handler r Bool
 isMLSEnabled = fromMaybe False . setEnableMLS <$> view settings

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -40,7 +40,6 @@ import Data.Misc
 import Data.Set qualified as Set
 import Data.Text.Ascii
 import Data.Time
-import Imports hiding (exp)
 import OpenSSL.Random (randBytes)
 import Polysemy (Member)
 import Servant hiding (Handler, Tagged)
@@ -54,6 +53,7 @@ import Wire.Sem.Jwk
 import Wire.Sem.Jwk qualified as Jwk
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
+import Prelude hiding (exp)
 
 --------------------------------------------------------------------------------
 -- API Internal

--- a/services/brig/src/Brig/API/Properties.hs
+++ b/services/brig/src/Brig/API/Properties.hs
@@ -32,7 +32,6 @@ import Brig.Data.Properties qualified as Data
 import Brig.IO.Intra qualified as Intra
 import Control.Error
 import Data.Id
-import Imports
 import Polysemy
 import Wire.API.Properties
 import Wire.API.UserEvent

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -98,7 +98,6 @@ import Data.Text.Lazy (pack)
 import Data.Time.Clock (UTCTime)
 import Data.ZAuth.Token qualified as ZAuth
 import FileEmbedLzma
-import Imports hiding (head)
 import Network.Socket (PortNumber)
 import Network.Wai.Utilities as Utilities
 import Polysemy
@@ -159,6 +158,7 @@ import Wire.Sem.Concurrency
 import Wire.Sem.Jwk (Jwk)
 import Wire.Sem.Now (Now)
 import Wire.Sem.Paging.Cassandra (InternalPaging)
+import Prelude hiding (head)
 
 -- User API -----------------------------------------------------------
 

--- a/services/brig/src/Brig/API/Public/Swagger.hs
+++ b/services/brig/src/Brig/API/Public/Swagger.hs
@@ -26,7 +26,6 @@ import Data.OpenApi.Declare qualified as S
 import Data.Text qualified as T
 import FileEmbedLzma
 import GHC.TypeLits
-import Imports hiding (head)
 import Language.Haskell.TH
 import Network.Socket
 import Servant
@@ -36,6 +35,7 @@ import Wire.API.Event.Conversation qualified
 import Wire.API.Event.FeatureConfig qualified
 import Wire.API.Event.Team qualified
 import Wire.API.Routes.Version
+import Prelude hiding (head)
 
 type SwaggerDocsAPIBase = SwaggerSchemaUI "swagger-ui" "swagger.json"
 
@@ -98,7 +98,7 @@ adjustSwaggerForInternalEndpoint service examplePort swagger =
 
     renderedDescription :: Text
     renderedDescription =
-      T.pack . Imports.unlines $
+      T.pack . Prelude.unlines $
         [ "To have access to this *internal* endpoint, create a port forwarding to `"
             ++ service
             ++ "` into the Kubernetes cluster. E.g.:",

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -43,7 +43,6 @@ import Data.Id
 import Data.Jwt.Tools (DPoPTokenGenerationError (..))
 import Data.Qualified
 import Data.RetryAfter
-import Imports
 import Network.Wai.Utilities.Error qualified as Wai
 import Wire.API.Federation.Error
 import Wire.API.User

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -157,7 +157,6 @@ import Data.Misc
 import Data.Qualified
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
 import Data.UUID.V4 (nextRandom)
-import Imports hiding (cs)
 import Network.Wai.Utilities
 import Polysemy
 import Polysemy.Input (Input)
@@ -188,6 +187,7 @@ import Wire.API.UserEvent
 import Wire.NotificationSubsystem
 import Wire.Sem.Concurrency
 import Wire.Sem.Paging.Cassandra (InternalPaging)
+import Prelude hiding (cs)
 
 data AllowSCIMUpdates
   = AllowSCIMUpdates

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -46,10 +46,8 @@ import Control.Monad.Trans.Except
 import Data.Bifunctor
 import Data.Handle (Handle, parseHandle)
 import Data.Id
-import Data.Maybe
 import Data.Qualified
 import Data.Text.Ascii (AsciiText (toText))
-import Imports
 import Polysemy
 import Polysemy.Error qualified as E
 import System.Logger (Msg)

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -64,7 +64,6 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.UUID hiding (null)
-import Imports hiding (group)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), Manager)
 import Network.HTTP.Types.Status (status400)
 import Network.Mail.Mime
@@ -73,6 +72,7 @@ import System.Logger.Class
 import UnliftIO.Async
 import UnliftIO.Exception
 import Util.Options
+import Prelude hiding (group)
 
 data Env = Env
   { _logger :: !Logger,

--- a/services/brig/src/Brig/AWS/SesNotification.hs
+++ b/services/brig/src/Brig/AWS/SesNotification.hs
@@ -25,7 +25,6 @@ import Brig.App
 import Brig.Data.UserKey (userEmailKey)
 import Brig.Effects.BlacklistStore (BlacklistStore)
 import Brig.Effects.BlacklistStore qualified as BlacklistStore
-import Imports
 import Polysemy (Member)
 import System.Logger.Class (field, msg, (~~))
 import System.Logger.Class qualified as Log

--- a/services/brig/src/Brig/AWS/Types.hs
+++ b/services/brig/src/Brig/AWS/Types.hs
@@ -23,7 +23,6 @@ module Brig.AWS.Types
 where
 
 import Data.Aeson
-import Imports
 import Wire.API.User.Identity
 
 -------------------------------------------------------------------------------

--- a/services/brig/src/Brig/Allowlists.hs
+++ b/services/brig/src/Brig/Allowlists.hs
@@ -27,7 +27,6 @@ where
 
 import Data.Aeson
 import Data.Text qualified as Text
-import Imports
 import Wire.API.User.Identity
 
 -- | A service providing a whitelist of allowed email addresses and phone numbers

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -116,7 +116,6 @@ import Control.AutoUpdate
 import Control.Error
 import Control.Lens hiding (index, (.=))
 import Control.Monad.Catch
-import Control.Monad.Trans.Resource
 import Data.ByteString.Conversion
 import Data.Credentials (Credentials (..))
 import Data.Domain
@@ -131,7 +130,6 @@ import Data.Text.IO qualified as Text
 import Data.Time.Clock
 import Database.Bloodhound qualified as ES
 import HTTP2.Client.Manager (Http2Manager, http2ManagerWithSSLCtx)
-import Imports
 import Network.AMQP qualified as Q
 import Network.AMQP.Extended qualified as Q
 import Network.HTTP.Client (responseTimeoutMicro)

--- a/services/brig/src/Brig/Budget.hs
+++ b/services/brig/src/Brig/Budget.hs
@@ -30,7 +30,6 @@ where
 
 import Cassandra
 import Data.Time.Clock
-import Imports
 
 data Budget = Budget
   { budgetTimeout :: !NominalDiffTime,

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -64,7 +64,6 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
-import Imports
 import Network.DNS qualified as DNS
 import OpenSSL.EVP.Digest (Digest)
 import Polysemy

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -49,7 +49,6 @@ import Data.Range
 import Data.Text.Ascii (AsciiBase64, encodeBase64)
 import Data.Text.Strict.Lens
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Imports hiding (head)
 import OpenSSL.EVP.Digest (Digest, hmacBS)
 import Polysemy
 import Polysemy.Error qualified as Polysemy
@@ -59,6 +58,7 @@ import Wire.API.Call.Config (SFTServer)
 import Wire.API.Call.Config qualified as Public
 import Wire.Network.DNS.SRV (srvTarget)
 import Wire.Sem.Logger.TinyLog (loggerToTinyLog)
+import Prelude hiding (head)
 
 -- | ('UserId', 'ConnId' are required as args here to make sure this is an authenticated end-point.)
 getCallsConfigV2 :: UserId -> ConnId -> Maybe (Range 1 10 Int) -> (Handler r) Public.RTCConfiguration

--- a/services/brig/src/Brig/Calling/Internal.hs
+++ b/services/brig/src/Brig/Calling/Internal.hs
@@ -20,7 +20,6 @@ module Brig.Calling.Internal where
 import Control.Lens ((?~))
 import Data.ByteString.Char8 qualified as BS
 import Data.Misc (ensureHttpsUrl)
-import Imports
 import URI.ByteString qualified as URI
 import URI.ByteString.QQ qualified as URI
 import Wire.API.Call.Config qualified as Public

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -27,7 +27,6 @@ import Control.Lens ((^.))
 import Control.Monad.Catch (throwM)
 import Data.Qualified (Local, toLocalUnsafe)
 import Data.Time.Clock (UTCTime, getCurrentTime)
-import Imports
 import Polysemy (Embed, Final, embed, embedToFinal, runFinal)
 import Polysemy.Async
 import Polysemy.Conc

--- a/services/brig/src/Brig/Code.hs
+++ b/services/brig/src/Brig/Code.hs
@@ -71,13 +71,13 @@ import Data.Text qualified as Text
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Encoding qualified as Text
 import Data.UUID (UUID)
-import Imports hiding (lookup)
 import OpenSSL.BN (randIntegerZeroToNMinusOne)
 import OpenSSL.EVP.Digest (Digest, digestBS, getDigestByName)
 import OpenSSL.Random (randBytes)
 import Text.Printf (printf)
 import Wire.API.User qualified as User
 import Wire.API.User.Identity
+import Prelude hiding (lookup)
 
 --------------------------------------------------------------------------------
 -- Code

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -43,7 +43,6 @@ import Data.Text (pack)
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as LT
-import Imports
 import OpenSSL.BN (randIntegerZeroToNMinusOne)
 import OpenSSL.EVP.Digest (digestBS, getDigestByName)
 import Polysemy

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -81,7 +81,6 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time.Clock
 import Data.UUID qualified as UUID
-import Imports
 import System.CryptoBox (Result (Success))
 import System.CryptoBox qualified as CryptoBox
 import System.Logger.Class (field, msg, val)
@@ -123,7 +122,7 @@ addClient ::
   ClientId ->
   NewClient ->
   Int ->
-  Maybe (Imports.Set ClientCapability) ->
+  Maybe (Prelude.Set ClientCapability) ->
   ExceptT ClientDataError m (Client, [Client], Word)
 addClient = addClientWithReAuthPolicy reAuthForNewClients
 
@@ -134,7 +133,7 @@ addClientWithReAuthPolicy ::
   ClientId ->
   NewClient ->
   Int ->
-  Maybe (Imports.Set ClientCapability) ->
+  Maybe (Prelude.Set ClientCapability) ->
   ExceptT ClientDataError m (Client, [Client], Word)
 addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients cps = do
   clients <- lookupClients u
@@ -191,20 +190,20 @@ lookupClient u c = do
   fmap (toClient keys)
     <$> retry x1 (query1 selectClient (params LocalQuorum (u, c)))
 
-lookupClientsBulk :: (MonadClient m) => [UserId] -> m (Map UserId (Imports.Set Client))
+lookupClientsBulk :: (MonadClient m) => [UserId] -> m (Map UserId (Prelude.Set Client))
 lookupClientsBulk uids = liftClient $ do
   userClientTuples <- pooledMapConcurrentlyN 50 getClientSetWithUser uids
   pure $ Map.fromList userClientTuples
   where
-    getClientSetWithUser :: MonadClient m => UserId -> m (UserId, Imports.Set Client)
+    getClientSetWithUser :: MonadClient m => UserId -> m (UserId, Prelude.Set Client)
     getClientSetWithUser u = fmap ((u,) . Set.fromList) . lookupClients $ u
 
-lookupPubClientsBulk :: (MonadClient m) => [UserId] -> m (UserMap (Imports.Set PubClient))
+lookupPubClientsBulk :: (MonadClient m) => [UserId] -> m (UserMap (Prelude.Set PubClient))
 lookupPubClientsBulk uids = liftClient $ do
   userClientTuples <- pooledMapConcurrentlyN 50 getClientSetWithUser uids
   pure $ UserMap $ Map.fromList userClientTuples
   where
-    getClientSetWithUser :: MonadClient m => UserId -> m (UserId, Imports.Set PubClient)
+    getClientSetWithUser :: MonadClient m => UserId -> m (UserId, Prelude.Set PubClient)
     getClientSetWithUser u = (u,) . Set.fromList . map toPubClient <$> executeQuery u
 
     executeQuery :: MonadClient m => UserId -> m [(ClientId, Maybe ClientClass)]
@@ -259,7 +258,7 @@ rmClient u c = do
 updateClientLabel :: MonadClient m => UserId -> ClientId -> Maybe Text -> m ()
 updateClientLabel u c l = retry x5 $ write updateClientLabelQuery (params LocalQuorum (l, u, c))
 
-updateClientCapabilities :: MonadClient m => UserId -> ClientId -> Maybe (Imports.Set ClientCapability) -> m ()
+updateClientCapabilities :: MonadClient m => UserId -> ClientId -> Maybe (Prelude.Set ClientCapability) -> m ()
 updateClientCapabilities u c fs = retry x5 $ write updateClientCapabilitiesQuery (params LocalQuorum (C.Set . Set.toList <$> fs, u, c))
 
 -- | If the update fails, which can happen if device does not exist, then ignore the error silently.

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -65,10 +65,10 @@ import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Qualified
 import Data.Range
 import Data.Time (getCurrentTime)
-import Imports hiding (local)
 import UnliftIO.Async (pooledForConcurrentlyN_, pooledMapConcurrentlyN, pooledMapConcurrentlyN_)
 import Wire.API.Connection
 import Wire.API.Routes.Internal.Brig.Connection
+import Prelude hiding (local)
 
 insertConnection ::
   (MonadClient m) =>

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -18,10 +18,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Brig.Data.Instances
-  (
-  )
-where
+module Brig.Data.Instances () where
 
 import Brig.Types.Common
 import Brig.Types.Search
@@ -36,7 +33,6 @@ import Data.Id ()
 import Data.Range ()
 import Data.Text.Ascii ()
 import Data.Text.Encoding (encodeUtf8)
-import Imports
 import Wire.API.Asset (AssetKey, assetKeyToText, nilAssetKey)
 import Wire.API.Connection (RelationWithHistory (..))
 import Wire.API.MLS.CipherSuite
@@ -301,7 +297,7 @@ instance Cql FederatedUserSearchPolicy where
   fromCql (CqlInt 2) = pure FullSearch
   fromCql n = Left $ "Unexpected SearchVisibilityInbound: " ++ show n
 
-instance Cql (Imports.Set BaseProtocolTag) where
+instance Cql (Prelude.Set BaseProtocolTag) where
   ctype = Tagged IntColumn
 
   toCql = CqlInt . fromIntegral . protocolSetBits

--- a/services/brig/src/Brig/Data/LoginCode.hs
+++ b/services/brig/src/Brig/Data/LoginCode.hs
@@ -35,7 +35,6 @@ import Data.Code
 import Data.Id
 import Data.Text qualified as T
 import Data.Time.Clock
-import Imports
 import OpenSSL.BN (randIntegerZeroToNMinusOne)
 import Text.Printf (printf)
 import Wire.API.User.Auth

--- a/services/brig/src/Brig/Data/MLS/KeyPackage.hs
+++ b/services/brig/src/Brig/Data/MLS/KeyPackage.hs
@@ -32,12 +32,10 @@ import Control.Arrow
 import Control.Error
 import Control.Lens
 import Control.Monad.Random (randomRIO)
-import Data.Functor
 import Data.Id
 import Data.Qualified
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Imports
 import UnliftIO.Async
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.KeyPackage

--- a/services/brig/src/Brig/Data/Nonce.hs
+++ b/services/brig/src/Brig/Data/Nonce.hs
@@ -23,10 +23,8 @@ where
 
 import Brig.Data.Instances ()
 import Cassandra
-import Control.Lens hiding (from)
 import Data.Id (UserId)
 import Data.Nonce (Nonce, NonceTtlSecs)
-import Imports
 
 insertNonce ::
   MonadClient m =>

--- a/services/brig/src/Brig/Data/Properties.hs
+++ b/services/brig/src/Brig/Data/Properties.hs
@@ -30,7 +30,6 @@ import Brig.Data.Instances ()
 import Cassandra
 import Control.Error
 import Data.Id
-import Imports
 import Wire.API.Properties
 
 maxProperties :: Int64

--- a/services/brig/src/Brig/Data/Types.hs
+++ b/services/brig/src/Brig/Data/Types.hs
@@ -26,7 +26,6 @@ module Brig.Data.Types
 where
 
 import Cassandra qualified
-import Imports
 
 -- | An opaque page of results with an indication of whether
 -- more data than contained in the page is available.

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -93,7 +93,6 @@ import Data.Qualified
 import Data.Range (fromRange)
 import Data.Time (addUTCTime)
 import Data.UUID.V4
-import Imports
 import Wire.API.Password
 import Wire.API.Provider.Service
 import Wire.API.Team.Feature qualified as ApiFt

--- a/services/brig/src/Brig/Data/UserKey.hs
+++ b/services/brig/src/Brig/Data/UserKey.hs
@@ -39,7 +39,6 @@ import Brig.Email
 import Brig.Phone
 import Cassandra
 import Data.Id
-import Imports
 import Wire.API.User (fromEmail)
 
 -- | A natural identifier (i.e. unique key) of a user.

--- a/services/brig/src/Brig/Effects/BlacklistPhonePrefixStore.hs
+++ b/services/brig/src/Brig/Effects/BlacklistPhonePrefixStore.hs
@@ -4,7 +4,6 @@ module Brig.Effects.BlacklistPhonePrefixStore where
 
 import Brig.Phone (Phone)
 import Brig.Types.Common (ExcludedPrefix, PhonePrefix)
-import Imports
 import Polysemy
 
 data BlacklistPhonePrefixStore m a where

--- a/services/brig/src/Brig/Effects/BlacklistPhonePrefixStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/BlacklistPhonePrefixStore/Cassandra.hs
@@ -6,7 +6,6 @@ where
 import Brig.Effects.BlacklistPhonePrefixStore
 import Brig.Types.Common
 import Cassandra
-import Imports
 import Polysemy
 import Wire.API.User.Identity
 

--- a/services/brig/src/Brig/Effects/BlacklistStore.hs
+++ b/services/brig/src/Brig/Effects/BlacklistStore.hs
@@ -3,7 +3,6 @@
 module Brig.Effects.BlacklistStore where
 
 import Brig.Data.UserKey
-import Imports
 import Polysemy
 
 data BlacklistStore m a where

--- a/services/brig/src/Brig/Effects/BlacklistStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/BlacklistStore/Cassandra.hs
@@ -6,7 +6,6 @@ where
 import Brig.Data.UserKey
 import Brig.Effects.BlacklistStore (BlacklistStore (..))
 import Cassandra
-import Imports
 import Polysemy
 
 interpretBlacklistStoreToCassandra ::

--- a/services/brig/src/Brig/Effects/CodeStore.hs
+++ b/services/brig/src/Brig/Effects/CodeStore.hs
@@ -20,7 +20,6 @@ module Brig.Effects.CodeStore where
 
 import Data.Id
 import Data.Time.Clock
-import Imports
 import Polysemy
 import Wire.API.User.Password
 

--- a/services/brig/src/Brig/Effects/CodeStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/CodeStore/Cassandra.hs
@@ -30,7 +30,6 @@ import Data.Id
 import Data.Text (pack)
 import Data.Text.Ascii
 import Data.Time.Clock
-import Imports
 import OpenSSL.BN (randIntegerZeroToNMinusOne)
 import OpenSSL.EVP.Digest (digestBS, getDigestByName)
 import OpenSSL.Random (randBytes)

--- a/services/brig/src/Brig/Effects/ConnectionStore.hs
+++ b/services/brig/src/Brig/Effects/ConnectionStore.hs
@@ -20,7 +20,6 @@ module Brig.Effects.ConnectionStore where
 
 import Data.Id
 import Data.Qualified (Local, Remote)
-import Imports
 import Polysemy
 import Wire.API.Connection (UserConnection)
 import Wire.Sem.Paging (Page, PagingBounds, PagingState)

--- a/services/brig/src/Brig/Effects/ConnectionStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/ConnectionStore/Cassandra.hs
@@ -23,7 +23,6 @@ import Brig.Data.Connection
 import Brig.Effects.ConnectionStore
 import Cassandra
 import Data.Range
-import Imports
 import Polysemy
 import Polysemy.Internal.Tactics
 import Wire.Sem.Paging.Cassandra

--- a/services/brig/src/Brig/Effects/FederationConfigStore.hs
+++ b/services/brig/src/Brig/Effects/FederationConfigStore.hs
@@ -5,7 +5,6 @@ module Brig.Effects.FederationConfigStore where
 import Data.Domain
 import Data.Id
 import Data.Qualified
-import Imports
 import Polysemy
 import Wire.API.Routes.FederationDomainConfig
 

--- a/services/brig/src/Brig/Effects/FederationConfigStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/FederationConfigStore/Cassandra.hs
@@ -26,14 +26,12 @@ import Brig.Data.Instances ()
 import Brig.Effects.FederationConfigStore
 import Cassandra
 import Control.Exception (ErrorCall (ErrorCall))
-import Control.Lens
 import Control.Monad.Catch (throwM)
 import Data.Domain
 import Data.Id
 import Data.Map qualified as Map
 import Data.Qualified
 import Database.CQL.Protocol (SerialConsistency (LocalSerialConsistency), serialConsistency)
-import Imports
 import Polysemy
 import Wire.API.Routes.FederationDomainConfig
 import Wire.API.User.Search

--- a/services/brig/src/Brig/Effects/GalleyProvider.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider.hs
@@ -24,7 +24,6 @@ import Data.Currency qualified as Currency
 import Data.Id
 import Data.Json.Util (UTCTimeMillis)
 import Data.Qualified
-import Imports
 import Network.Wai.Utilities.Error qualified as Wai
 import Polysemy
 import Wire.API.Conversation

--- a/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
+++ b/services/brig/src/Brig/Effects/GalleyProvider/RPC.hs
@@ -33,7 +33,6 @@ import Data.Id
 import Data.Json.Util (UTCTimeMillis)
 import Data.Qualified
 import Data.Range
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP.Types.Method
@@ -465,7 +464,7 @@ decodeBodyOrThrow :: forall a r. (Typeable a, FromJSON a, Member (Error ParseExc
 decodeBodyOrThrow t r =
   case decodeBody @a t r of
     Left a ->
-      case Imports.fromException a of
+      case Prelude.fromException a of
         Just pe -> throw @ParseException pe
         Nothing -> error "impossible: something other than ParseExceptionNothing was thrown by decodeBody"
     Right b -> pure b

--- a/services/brig/src/Brig/Effects/JwtTools.hs
+++ b/services/brig/src/Brig/Effects/JwtTools.hs
@@ -12,7 +12,6 @@ import Data.Jwt.Tools qualified as Jwt
 import Data.Misc (HttpsUrl)
 import Data.Nonce (Nonce)
 import Data.PEMKeys
-import Imports
 import Network.HTTP.Types (StdMethod (..))
 import Network.HTTP.Types qualified as HTTP
 import Polysemy

--- a/services/brig/src/Brig/Effects/PasswordResetStore.hs
+++ b/services/brig/src/Brig/Effects/PasswordResetStore.hs
@@ -20,7 +20,6 @@ module Brig.Effects.PasswordResetStore where
 
 import Brig.Types.User (PasswordResetPair)
 import Data.Id
-import Imports
 import Polysemy
 import Wire.API.User.Identity
 import Wire.API.User.Password

--- a/services/brig/src/Brig/Effects/PasswordResetStore/CodeStore.hs
+++ b/services/brig/src/Brig/Effects/PasswordResetStore/CodeStore.hs
@@ -25,12 +25,12 @@ import Brig.Effects.PasswordResetStore
 import Brig.Types.User (PasswordResetPair)
 import Data.Id
 import Data.Time
-import Imports hiding (lookup)
 import Polysemy
 import Wire.API.User.Identity
 import Wire.API.User.Password
 import Wire.Sem.Now
 import Wire.Sem.Now qualified as Now
+import Prelude hiding (lookup)
 
 passwordResetStoreToCodeStore ::
   forall r a.

--- a/services/brig/src/Brig/Effects/PublicKeyBundle.hs
+++ b/services/brig/src/Brig/Effects/PublicKeyBundle.hs
@@ -6,7 +6,6 @@ import Control.Exception
 import Data.ByteString qualified as BS
 import Data.ByteString.Conversion
 import Data.PEMKeys
-import Imports
 import Polysemy
 
 data PublicKeyBundle m a where

--- a/services/brig/src/Brig/Effects/SFT.hs
+++ b/services/brig/src/Brig/Effects/SFT.hs
@@ -32,7 +32,6 @@ import Data.ByteString.Conversion
 import Data.Map qualified as Map
 import Data.Misc
 import Data.Schema
-import Imports hiding (fromException, intercalate)
 import Network.HTTP.Client
 import Polysemy
 import Polysemy.Error hiding (try)
@@ -40,6 +39,7 @@ import Polysemy.TinyLog
 import System.Logger qualified as Log
 import URI.ByteString (uriPath)
 import Wire.API.Call.Config
+import Prelude hiding (fromException, intercalate)
 
 newtype SFTError = SFTError {unSFTError :: String}
   deriving (Eq, Show)

--- a/services/brig/src/Brig/Effects/UserPendingActivationStore.hs
+++ b/services/brig/src/Brig/Effects/UserPendingActivationStore.hs
@@ -4,7 +4,6 @@ module Brig.Effects.UserPendingActivationStore where
 
 import Data.Id
 import Data.Time.Clock
-import Imports
 import Polysemy
 import Wire.Sem.Paging
 

--- a/services/brig/src/Brig/Effects/UserPendingActivationStore/Cassandra.hs
+++ b/services/brig/src/Brig/Effects/UserPendingActivationStore/Cassandra.hs
@@ -9,7 +9,6 @@ import Brig.Effects.UserPendingActivationStore
 import Cassandra
 import Data.Id (UserId)
 import Data.Time (UTCTime)
-import Imports
 import Polysemy
 import Polysemy.Internal.Tactics
 import Wire.Sem.Paging.Cassandra qualified as PC

--- a/services/brig/src/Brig/Email.hs
+++ b/services/brig/src/Brig/Email.hs
@@ -44,7 +44,6 @@ import Brig.App (Env, applog, awsEnv, smtpEnv)
 import Brig.SMTP qualified as SMTP
 import Control.Lens (view)
 import Data.Text qualified as Text
-import Imports
 import Network.Mail.Mime
 import Wire.API.User
 

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -20,7 +20,6 @@ module Brig.Federation.Client where
 
 import Brig.App as Brig
 import Control.Lens
-import Control.Monad
 import Control.Monad.Catch (MonadMask, throwM)
 import Control.Monad.Trans.Except (ExceptT (..), throwE)
 import Control.Retry
@@ -32,7 +31,6 @@ import Data.Qualified
 import Data.Range (Range)
 import Data.Text qualified as T
 import Data.Time.Units
-import Imports
 import Network.AMQP qualified as Q
 import System.Logger.Class qualified as Log
 import Wire.API.Federation.API

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -78,7 +78,6 @@ import Data.Range
 import Data.Time.Clock (UTCTime)
 import Gundeck.Types.Push.V2 (RecipientClients (RecipientClientsAll))
 import Gundeck.Types.Push.V2 qualified as V2
-import Imports
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Polysemy

--- a/services/brig/src/Brig/IO/Journal.hs
+++ b/services/brig/src/Brig/IO/Journal.hs
@@ -38,7 +38,6 @@ import Data.Proto.Id
 import Data.ProtoLens (defMessage)
 import Data.ProtoLens.Encoding (encodeMessage)
 import Data.UUID.V4 (nextRandom)
-import Imports
 import Proto.UserEvents (UserEvent, UserEvent'EventType (..))
 import Proto.UserEvents_Fields qualified as U
 import Wire.API.User

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -35,7 +35,6 @@ import Data.Aeson qualified as Aeson
 import Data.Credentials (Credentials (..))
 import Data.Metrics qualified as Metrics
 import Database.Bloodhound qualified as ES
-import Imports
 import Network.HTTP.Client as HTTP
 import System.Logger qualified as Log
 import System.Logger.Class (Logger, MonadLogger (..))

--- a/services/brig/src/Brig/Index/Migrations.hs
+++ b/services/brig/src/Brig/Index/Migrations.hs
@@ -31,7 +31,6 @@ import Data.Credentials (Credentials (..))
 import Data.Metrics qualified as Metrics
 import Data.Text qualified as Text
 import Database.Bloodhound qualified as ES
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import System.Logger.Class (Logger)
 import System.Logger.Class qualified as Log

--- a/services/brig/src/Brig/Index/Migrations/Types.hs
+++ b/services/brig/src/Brig/Index/Migrations/Types.hs
@@ -26,7 +26,6 @@ import Control.Monad.Catch (MonadThrow)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import Data.Metrics (Metrics)
 import Database.Bloodhound qualified as ES
-import Imports
 import Network.HTTP.Client (Manager)
 import Numeric.Natural (Natural)
 import System.Logger qualified as Logger

--- a/services/brig/src/Brig/Index/Options.hs
+++ b/services/brig/src/Brig/Index/Options.hs
@@ -57,7 +57,6 @@ import Data.Text qualified as Text
 import Data.Text.Strict.Lens
 import Data.Time.Clock (NominalDiffTime)
 import Database.Bloodhound qualified as ES
-import Imports
 import Options.Applicative
 import URI.ByteString
 import URI.ByteString.QQ

--- a/services/brig/src/Brig/Index/Types.hs
+++ b/services/brig/src/Brig/Index/Types.hs
@@ -18,7 +18,6 @@
 module Brig.Index.Types where
 
 import Database.Bloodhound qualified as ES
-import Imports
 
 data CreateIndexSettings = CreateIndexSettings
   { _cisIndexSettings :: [ES.UpdatableIndexSetting],

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -33,7 +33,6 @@ import Control.Monad.Catch
 import Data.ByteString.Conversion
 import Data.Qualified (Local)
 import Data.Time.Clock (UTCTime)
-import Imports
 import Polysemy
 import Polysemy.Conc
 import Polysemy.Input (Input)

--- a/services/brig/src/Brig/InternalEvent/Types.hs
+++ b/services/brig/src/Brig/InternalEvent/Types.hs
@@ -20,7 +20,6 @@ module Brig.InternalEvent.Types
   )
 where
 
-import BasePrelude
 import Data.Aeson
 import Data.Aeson.Types
 import Data.Id

--- a/services/brig/src/Brig/Locale.hs
+++ b/services/brig/src/Brig/Locale.hs
@@ -27,7 +27,6 @@ import Data.LanguageCodes (ISO639_1 (DE, FR))
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format
 import Data.Time.LocalTime (TimeZone (..), utc)
-import Imports
 import Wire.API.User
 
 timeLocale :: Locale -> TimeLocale

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -28,7 +28,6 @@ import Brig.Queue.Types (Queue (..))
 import Brig.SMTP (SMTPConnType (..))
 import Brig.User.Auth.Cookie.Limit
 import Brig.ZAuth qualified as ZAuth
-import Control.Applicative
 import Control.Lens qualified as Lens
 import Data.Aeson (defaultOptions, fieldLabelModifier, genericParseJSON)
 import Data.Aeson qualified as A
@@ -50,7 +49,6 @@ import Data.Time.Clock (DiffTime, NominalDiffTime, secondsToDiffTime)
 import Data.Yaml (FromJSON (..), ToJSON (..), (.:), (.:?))
 import Data.Yaml qualified as Y
 import Galley.Types.Teams (unImplicitLockStatus)
-import Imports
 import Network.AMQP.Extended
 import Network.DNS qualified as DNS
 import System.Logger.Extended (Level, LogFormat)

--- a/services/brig/src/Brig/Phone.hs
+++ b/services/brig/src/Brig/Phone.hs
@@ -48,7 +48,6 @@ import Data.LanguageCodes
 import Data.Metrics qualified as Metrics
 import Data.Text qualified as Text
 import Data.Time.Clock
-import Imports
 import Network.HTTP.Client (HttpException, Manager)
 import Ropes.Nexmo qualified as Nexmo
 import Ropes.Twilio (LookupDetail (..))

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -78,7 +78,6 @@ import Data.Text.Ascii qualified as Ascii
 import Data.Text.Encoding qualified as Text
 import Data.Text.Lazy qualified as Text
 import GHC.TypeNats
-import Imports
 import Network.HTTP.Types.Status
 import Network.Wai (Response)
 import Network.Wai.Predicate (accept)

--- a/services/brig/src/Brig/Provider/DB.hs
+++ b/services/brig/src/Brig/Provider/DB.hs
@@ -29,7 +29,6 @@ import Data.Misc
 import Data.Range (Range, fromRange, rcast, rnil)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import Imports
 import UnliftIO (mapConcurrently)
 import Wire.API.Password
 import Wire.API.Provider

--- a/services/brig/src/Brig/Provider/Email.hs
+++ b/services/brig/src/Brig/Provider/Email.hs
@@ -37,7 +37,6 @@ import Data.Text (pack)
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Encoding qualified as Text
 import Data.Text.Lazy qualified as LT
-import Imports
 import Wire.API.Provider
 import Wire.API.User
 

--- a/services/brig/src/Brig/Provider/RPC.hs
+++ b/services/brig/src/Brig/Provider/RPC.hs
@@ -45,7 +45,6 @@ import Data.List1 qualified as List1
 import Galley.Types.Bot qualified as Galley
 import Galley.Types.Bot.Service (serviceEnabled)
 import Galley.Types.Bot.Service qualified as Galley
-import Imports
 import Network.HTTP.Client qualified as Http
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status

--- a/services/brig/src/Brig/Provider/Template.hs
+++ b/services/brig/src/Brig/Provider/Template.hs
@@ -36,7 +36,6 @@ import Brig.Template
 import Data.ByteString.Conversion (fromByteString)
 import Data.Misc (HttpsUrl)
 import Data.Text.Encoding (encodeUtf8)
-import Imports
 import Wire.API.User.Identity
 
 data ProviderTemplates = ProviderTemplates

--- a/services/brig/src/Brig/Queue.hs
+++ b/services/brig/src/Brig/Queue.hs
@@ -36,7 +36,6 @@ import Data.Aeson
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy qualified as BL
 import Data.Text.Encoding qualified as T
-import Imports
 import OpenSSL.EVP.Digest (Digest, digestLBS)
 import System.Logger.Class as Log hiding (settings)
 

--- a/services/brig/src/Brig/Queue/Stomp.hs
+++ b/services/brig/src/Brig/Queue/Stomp.hs
@@ -26,7 +26,6 @@ module Brig.Queue.Stomp
   )
 where
 
-import BasePrelude hiding (Handler, throwIO)
 import Brig.Options qualified as Opts
 import Codec.MIME.Type qualified as MIME
 import Control.Monad.Catch (Handler (..), MonadMask)
@@ -38,7 +37,8 @@ import Data.Text
 import Data.Text.Encoding
 import Network.Mom.Stompl.Client.Queue hiding (try)
 import System.Logger.Class as Log
-import UnliftIO (MonadUnliftIO, throwIO, withRunInIO)
+import UnliftIO (throwIO, timeout, try)
+import Prelude hiding (withReader)
 
 data Env = Env
   { -- | STOMP broker that we're using
@@ -95,7 +95,7 @@ enqueue b q m =
     retryPolicy = limitRetries 5 <> exponentialBackoff 50000
     enqueueAction =
       liftIO $
-        try @StomplException $
+        try @_ @StomplException $
           stompTimeout "enqueue" 500000 $
             withConnection' b $
               \conn ->

--- a/services/brig/src/Brig/Queue/Types.hs
+++ b/services/brig/src/Brig/Queue/Types.hs
@@ -21,7 +21,6 @@ module Brig.Queue.Types
 where
 
 import Data.Aeson
-import Imports
 
 -- | A remote queue that you can publish to and listen from.
 data Queue = StompQueue Text | SqsQueue Text

--- a/services/brig/src/Brig/RPC.hs
+++ b/services/brig/src/Brig/RPC.hs
@@ -29,7 +29,6 @@ import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as LT
-import Imports
 import Network.HTTP.Types.Method
 import System.Logger.Class hiding (name, (.=))
 import Wire.Rpc (x3)

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -53,7 +53,6 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Text (unpack)
 import Data.UUID as UUID
 import Data.UUID.V4 as UUID
-import Imports hiding (head)
 import Network.HTTP.Media qualified as HTTPMedia
 import Network.HTTP.Types qualified as HTTP
 import Network.Wai qualified as Wai
@@ -77,6 +76,7 @@ import Wire.API.Routes.Version
 import Wire.API.Routes.Version.Wai
 import Wire.API.User (AccountStatus (PendingInvitation))
 import Wire.Sem.Paging qualified as P
+import Prelude hiding (head)
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -40,7 +40,6 @@ import Data.Aeson.TH
 import Data.Pool
 import Data.Text (unpack)
 import Data.Time.Units
-import Imports
 import Network.HaskellNet.SMTP qualified as SMTP
 import Network.HaskellNet.SMTP.SSL qualified as SMTP
 import Network.Mail.Mime

--- a/services/brig/src/Brig/Schema/Run.hs
+++ b/services/brig/src/Brig/Schema/Run.hs
@@ -59,7 +59,6 @@ import Brig.Schema.V81_AddFederationRemoteTeams qualified as V81_AddFederationRe
 import Cassandra.MigrateSchema (migrateSchema)
 import Cassandra.Schema
 import Control.Exception (finally)
-import Imports
 import System.Logger.Extended qualified as Log
 import Util.Options
 

--- a/services/brig/src/Brig/Schema/V43.hs
+++ b/services/brig/src/Brig/Schema/V43.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V43
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V44.hs
+++ b/services/brig/src/Brig/Schema/V44.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V44
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V45.hs
+++ b/services/brig/src/Brig/Schema/V45.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V45
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V46.hs
+++ b/services/brig/src/Brig/Schema/V46.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V46
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V47.hs
+++ b/services/brig/src/Brig/Schema/V47.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V47
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V48.hs
+++ b/services/brig/src/Brig/Schema/V48.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V48
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V49.hs
+++ b/services/brig/src/Brig/Schema/V49.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V49
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V50.hs
+++ b/services/brig/src/Brig/Schema/V50.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V50
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V51.hs
+++ b/services/brig/src/Brig/Schema/V51.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V51
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V52.hs
+++ b/services/brig/src/Brig/Schema/V52.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V52
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V53.hs
+++ b/services/brig/src/Brig/Schema/V53.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V53
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V54.hs
+++ b/services/brig/src/Brig/Schema/V54.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V54
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V55.hs
+++ b/services/brig/src/Brig/Schema/V55.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V55
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V56.hs
+++ b/services/brig/src/Brig/Schema/V56.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V56
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V57.hs
+++ b/services/brig/src/Brig/Schema/V57.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V57
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V58.hs
+++ b/services/brig/src/Brig/Schema/V58.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V58
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V59.hs
+++ b/services/brig/src/Brig/Schema/V59.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V59
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V60_AddFederationIdMapping.hs
+++ b/services/brig/src/Brig/Schema/V60_AddFederationIdMapping.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V60_AddFederationIdMapping
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- | See <https://github.com/wearezeta/documentation/blob/master/topics/federation/federation-design.md#namespaces-and-user-identity>.

--- a/services/brig/src/Brig/Schema/V61_team_invitation_email.hs
+++ b/services/brig/src/Brig/Schema/V61_team_invitation_email.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V61_team_invitation_email
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V62_RemoveFederationIdMapping.hs
+++ b/services/brig/src/Brig/Schema/V62_RemoveFederationIdMapping.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V62_RemoveFederationIdMapping
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- | We decided avoid storing this mapping, handling the transition on the API level instead.

--- a/services/brig/src/Brig/Schema/V63_AddUsersPendingActivation.hs
+++ b/services/brig/src/Brig/Schema/V63_AddUsersPendingActivation.hs
@@ -18,7 +18,6 @@
 module Brig.Schema.V63_AddUsersPendingActivation (migration) where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V64_ClientCapabilities.hs
+++ b/services/brig/src/Brig/Schema/V64_ClientCapabilities.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V64_ClientCapabilities
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V65_FederatedConnections.hs
+++ b/services/brig/src/Brig/Schema/V65_FederatedConnections.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V65_FederatedConnections
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V66_PersonalFeatureConfCallInit.hs
+++ b/services/brig/src/Brig/Schema/V66_PersonalFeatureConfCallInit.hs
@@ -24,7 +24,6 @@ module Brig.Schema.V66_PersonalFeatureConfCallInit
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V67_MLSKeyPackages.hs
+++ b/services/brig/src/Brig/Schema/V67_MLSKeyPackages.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V67_MLSKeyPackages
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V68_AddMLSPublicKeys.hs
+++ b/services/brig/src/Brig/Schema/V68_AddMLSPublicKeys.hs
@@ -21,7 +21,6 @@ module Brig.Schema.V68_AddMLSPublicKeys
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V69_MLSKeyPackageRefMapping.hs
+++ b/services/brig/src/Brig/Schema/V69_MLSKeyPackageRefMapping.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V69_MLSKeyPackageRefMapping
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- FUTUREWORK: remove this table

--- a/services/brig/src/Brig/Schema/V70_UserEmailUnvalidated.hs
+++ b/services/brig/src/Brig/Schema/V70_UserEmailUnvalidated.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V70_UserEmailUnvalidated
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V71_AddTableVCodesThrottle.hs
+++ b/services/brig/src/Brig/Schema/V71_AddTableVCodesThrottle.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V71_AddTableVCodesThrottle
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- | We need the initial_delay column because we can only retrieve the TTL value from a column that is not part of the PK.

--- a/services/brig/src/Brig/Schema/V72_AddNonceTable.hs
+++ b/services/brig/src/Brig/Schema/V72_AddNonceTable.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V72_AddNonceTable
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V73_ReplaceNonceTable.hs
+++ b/services/brig/src/Brig/Schema/V73_ReplaceNonceTable.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V73_ReplaceNonceTable
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V74_AddOAuthTables.hs
+++ b/services/brig/src/Brig/Schema/V74_AddOAuthTables.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V74_AddOAuthTables
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V75_AddOAuthCodeChallenge.hs
+++ b/services/brig/src/Brig/Schema/V75_AddOAuthCodeChallenge.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V75_AddOAuthCodeChallenge
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V76_AddSupportedProtocols.hs
+++ b/services/brig/src/Brig/Schema/V76_AddSupportedProtocols.hs
@@ -20,7 +20,6 @@
 module Brig.Schema.V76_AddSupportedProtocols (migration) where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V77_FederationRemotes.hs
+++ b/services/brig/src/Brig/Schema/V77_FederationRemotes.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V77_FederationRemotes
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V78_ClientLastActive.hs
+++ b/services/brig/src/Brig/Schema/V78_ClientLastActive.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V78_ClientLastActive
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V79_ConnectionRemoteIndex.hs
+++ b/services/brig/src/Brig/Schema/V79_ConnectionRemoteIndex.hs
@@ -7,7 +7,6 @@ module Brig.Schema.V79_ConnectionRemoteIndex
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V80_KeyPackageCiphersuite.hs
+++ b/services/brig/src/Brig/Schema/V80_KeyPackageCiphersuite.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V80_KeyPackageCiphersuite
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- Index key packages by ciphersuite as well as user and client.

--- a/services/brig/src/Brig/Schema/V81_AddFederationRemoteTeams.hs
+++ b/services/brig/src/Brig/Schema/V81_AddFederationRemoteTeams.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V81_AddFederationRemoteTeams
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 migration :: Migration

--- a/services/brig/src/Brig/Schema/V_FUTUREWORK.hs
+++ b/services/brig/src/Brig/Schema/V_FUTUREWORK.hs
@@ -23,7 +23,6 @@ module Brig.Schema.V_FUTUREWORK
 where
 
 import Cassandra.Schema
-import Imports
 import Text.RawString.QQ
 
 -- user_keys_hash usage was removed in https://github.com/wireapp/wire-server/pull/2902

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -57,7 +57,6 @@ import Data.List1 qualified as List1
 import Data.Qualified (Local)
 import Data.Range
 import Data.Time.Clock (UTCTime)
-import Imports hiding (head)
 import Network.Wai.Utilities hiding (code, message)
 import Polysemy
 import Polysemy.Input (Input)
@@ -85,6 +84,7 @@ import Wire.API.User qualified as Public
 import Wire.NotificationSubsystem
 import Wire.Sem.Concurrency
 import Wire.Sem.Paging.Cassandra (InternalPaging)
+import Prelude hiding (head)
 
 servantAPI ::
   ( Member BlacklistStore r,

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -56,7 +56,6 @@ import Data.Text.Encoding
 import Data.Text.Lazy (toStrict)
 import Data.Time.Clock
 import Data.UUID.V4
-import Imports
 import OpenSSL.Random (randBytes)
 import System.Logger.Class qualified as Log
 import URI.ByteString

--- a/services/brig/src/Brig/Team/Email.hs
+++ b/services/brig/src/Brig/Team/Email.hs
@@ -36,7 +36,6 @@ import Control.Lens (view)
 import Data.Id (TeamId, idToText)
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Lazy (toStrict)
-import Imports
 import Wire.API.User
 
 -------------------------------------------------------------------------------

--- a/services/brig/src/Brig/Team/Template.hs
+++ b/services/brig/src/Brig/Team/Template.hs
@@ -31,7 +31,6 @@ where
 
 import Brig.Options
 import Brig.Template
-import Imports
 import Wire.API.User.Identity
 
 data InvitationEmailTemplate = InvitationEmailTemplate

--- a/services/brig/src/Brig/Team/Types.hs
+++ b/services/brig/src/Brig/Team/Types.hs
@@ -17,7 +17,5 @@
 
 module Brig.Team.Types where
 
-import Imports
-
 data ShowOrHideInvitationUrl = ShowInvitationUrl | HideInvitationUrl
   deriving (Eq, Show)

--- a/services/brig/src/Brig/Team/Util.hs
+++ b/services/brig/src/Brig/Team/Util.hs
@@ -27,7 +27,6 @@ import Control.Error
 import Control.Lens
 import Data.Id
 import Data.Set qualified as Set
-import Imports
 import Polysemy (Member)
 import Wire.API.Team.Member
 import Wire.API.Team.Permission

--- a/services/brig/src/Brig/Template.hs
+++ b/services/brig/src/Brig/Template.hs
@@ -50,9 +50,9 @@ import Data.Text.Lazy qualified as Lazy
 import Data.Text.Template (Template, template)
 import Data.Text.Template qualified as Template
 import HTMLEntities.Text qualified as HTML
-import Imports hiding (readFile)
 import System.IO.Error (isDoesNotExistError)
 import Wire.API.User
+import Prelude hiding (readFile)
 
 -- | See 'genTemplateBranding'.
 type TemplateBranding = Text -> Text

--- a/services/brig/src/Brig/Unique.hs
+++ b/services/brig/src/Brig/Unique.hs
@@ -34,7 +34,6 @@ import Cassandra as C
 import Control.Concurrent.Timeout
 import Data.Id
 import Data.Timeout
-import Imports
 
 -- | Obtain a (temporary) exclusive claim on a 'Text' value for some
 -- 'Id'entifier. The claim expires after the provided timeout, whether

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -35,7 +35,6 @@ import Control.Lens (view)
 import Data.Handle (Handle, fromHandle)
 import Data.Id (UserId)
 import Data.Qualified
-import Imports
 import Network.Wai.Utilities ((!>>))
 import Polysemy
 import System.Logger.Class qualified as Log

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -45,7 +45,6 @@ import Data.Domain (Domain)
 import Data.Handle (parseHandle)
 import Data.Id
 import Data.Range
-import Imports
 import Network.Wai.Utilities ((!>>))
 import Polysemy
 import System.Logger (field, msg)

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -61,7 +61,6 @@ import Brig.ZAuth qualified as ZAuth
 import Cassandra
 import Control.Error hiding (bool)
 import Control.Lens (to, view)
-import Control.Monad.Except
 import Data.ByteString.Conversion (toByteString)
 import Data.Handle (Handle)
 import Data.Id
@@ -72,7 +71,6 @@ import Data.Misc (PlainTextPassword6)
 import Data.Qualified (Local)
 import Data.Time.Clock (UTCTime)
 import Data.ZAuth.Token qualified as ZAuth
-import Imports
 import Network.Wai.Utilities.Error ((!>>))
 import Polysemy
 import Polysemy.Input (Input)

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -56,13 +56,13 @@ import Data.Metrics qualified as Metrics
 import Data.Proxy
 import Data.RetryAfter
 import Data.Time.Clock
-import Imports hiding (cs)
 import Network.Wai (Response)
 import Network.Wai.Utilities.Response (addHeader)
 import System.Logger.Class (field, msg, val, (~~))
 import System.Logger.Class qualified as Log
 import Web.Cookie qualified as WebCookie
 import Wire.API.User.Auth
+import Prelude hiding (cs)
 
 --------------------------------------------------------------------------------
 -- Basic Cookie Management

--- a/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
@@ -22,9 +22,9 @@ import Data.RetryAfter
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Vector qualified as Vector
-import Imports hiding (cs)
 import Statistics.Sample qualified as Stats
 import Wire.API.User.Auth
+import Prelude hiding (cs)
 
 --------------------------------------------------------------------------------
 -- Quantitive Limiting

--- a/services/brig/src/Brig/User/Auth/DB/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/DB/Cookie.hs
@@ -23,8 +23,8 @@ import Brig.User.Auth.DB.Instances ()
 import Cassandra
 import Data.Id
 import Data.Time.Clock
-import Imports hiding (cs)
 import Wire.API.User.Auth
+import Prelude hiding (cs)
 
 newtype TTL = TTL {ttlSeconds :: Int32}
   deriving (Cql)

--- a/services/brig/src/Brig/User/Auth/DB/Instances.hs
+++ b/services/brig/src/Brig/User/Auth/DB/Instances.hs
@@ -28,7 +28,6 @@ import Data.Id ()
 import Data.Misc ()
 import Data.Range ()
 import Data.Text.Ascii ()
-import Imports
 import Wire.API.User.Auth
 
 deriving instance Cql CookieLabel

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -36,7 +36,6 @@ import Data.ByteString.Conversion
 import Data.Handle (Handle)
 import Data.Id (UserId)
 import Data.Set qualified as Set
-import Imports hiding (head)
 import Network.HTTP.Types.Method
 import Polysemy (Member)
 import Servant.OpenApi.Internal.Orphans ()
@@ -47,6 +46,7 @@ import Wire.API.Team.Member qualified as Team
 import Wire.API.User
 import Wire.NotificationSubsystem
 import Wire.Rpc
+import Prelude hiding (head)
 
 ejpdRequest ::
   forall r.

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -46,7 +46,6 @@ import Data.Json.Util (fromUTCTimeMillis)
 import Data.Range
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Lazy (toStrict)
-import Imports
 import Wire.API.User
 import Wire.API.User.Activation
 import Wire.API.User.Client

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -32,7 +32,6 @@ import Brig.Unique
 import Cassandra
 import Data.Handle (Handle, fromHandle)
 import Data.Id
-import Imports
 
 -- | Claim a new handle for an existing 'User'.
 claimHandle :: (MonadClient m, MonadReader Env m) => UserId -> Maybe Handle -> Handle -> m Bool

--- a/services/brig/src/Brig/User/Handle/Blacklist.hs
+++ b/services/brig/src/Brig/User/Handle/Blacklist.hs
@@ -22,7 +22,6 @@ where
 
 import Data.Handle (Handle (Handle))
 import Data.HashSet qualified as HashSet
-import Imports
 
 -- | A blacklisted handle cannot be chosen by a (regular) user.
 isBlacklistedHandle :: Handle -> Bool

--- a/services/brig/src/Brig/User/Phone.hs
+++ b/services/brig/src/Brig/User/Phone.hs
@@ -50,7 +50,6 @@ import Data.Range
 import Data.Text qualified as Text
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Lazy (toStrict)
-import Imports
 import Ropes.Nexmo qualified as Nexmo
 import System.Logger.Class qualified as Log
 import Wire.API.User

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -86,7 +86,6 @@ import Data.Text.Lazy.Builder.Int (decimal)
 import Data.Text.Lens hiding (text)
 import Data.UUID qualified as UUID
 import Database.Bloodhound qualified as ES
-import Imports hiding (log, searchable)
 import Network.HTTP.Client hiding (host, path, port)
 import Network.HTTP.Types (StdMethod (POST), hContentType, statusCode)
 import SAML2.WebSSO.Types qualified as SAML
@@ -99,6 +98,7 @@ import Wire.API.Team.Feature (SearchVisibilityInboundConfig, featureNameBS)
 import Wire.API.User
 import Wire.API.User qualified as User
 import Wire.API.User.Search (Sso (..))
+import Prelude hiding (log, searchable)
 
 --------------------------------------------------------------------------------
 -- IndexIO Monad

--- a/services/brig/src/Brig/User/Search/Index/Types.hs
+++ b/services/brig/src/Brig/User/Search/Index/Types.hs
@@ -32,7 +32,6 @@ import Data.Text.ICU.Translit (trans, transliterate)
 import Data.Time (UTCTime)
 import Database.Bloodhound hiding (key)
 import Database.Bloodhound.Internal.Client (DocVersion (DocVersion))
-import Imports
 import Wire.API.Team.Role (Role)
 import Wire.API.User
 import Wire.API.User.Search (Sso (..))

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -36,9 +36,9 @@ import Data.Handle (Handle (fromHandle))
 import Data.Id
 import Data.Qualified (Qualified (Qualified))
 import Database.Bloodhound qualified as ES
-import Imports hiding (log, searchable)
 import Wire.API.User (ColourId (..), Name (fromName))
 import Wire.API.User.Search
+import Prelude hiding (log, searchable)
 
 -- | User that is performing the search
 -- Team of user that is performing the search

--- a/services/brig/src/Brig/User/Search/TeamSize.hs
+++ b/services/brig/src/Brig/User/Search/TeamSize.hs
@@ -28,7 +28,7 @@ import Brig.User.Search.Index
 import Control.Monad.Catch (throwM)
 import Data.Id
 import Database.Bloodhound qualified as ES
-import Imports hiding (log, searchable)
+import Prelude hiding (log, searchable)
 
 teamSize :: MonadIndexIO m => TeamId -> m TeamSize
 teamSize t = liftIndexIO $ do

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -38,8 +38,8 @@ import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
 import Data.Text.Ascii (decodeBase64Url, encodeBase64Url)
 import Database.Bloodhound qualified as ES
-import Imports hiding (log, searchable)
 import Wire.API.User.Search
+import Prelude hiding (log, searchable)
 
 teamUserSearch ::
   (HasCallStack, MonadIndexIO m) =>

--- a/services/brig/src/Brig/User/Template.hs
+++ b/services/brig/src/Brig/User/Template.hs
@@ -41,7 +41,6 @@ where
 
 import Brig.Options qualified as Opt
 import Brig.Template
-import Imports
 import Wire.API.User.Identity
 
 data UserTemplates = UserTemplates

--- a/services/brig/src/Brig/Version.hs
+++ b/services/brig/src/Brig/Version.hs
@@ -21,7 +21,6 @@ import Brig.API.Handler
 import Brig.App
 import Control.Lens
 import Data.Set qualified as Set
-import Imports
 import Servant (ServerT)
 import Wire.API.Routes.Named
 import Wire.API.Routes.Version

--- a/services/brig/src/Brig/ZAuth.hs
+++ b/services/brig/src/Brig/ZAuth.hs
@@ -102,7 +102,6 @@ import Data.Time.Clock.POSIX
 import Data.ZAuth.Creation qualified as ZC
 import Data.ZAuth.Token
 import Data.ZAuth.Validation qualified as ZV
-import Imports
 import OpenSSL.Random
 import Sodium.Crypto.Sign
 import Wire.API.User.Auth qualified as Auth

--- a/services/brig/test/integration.hs
+++ b/services/brig/test/integration.hs
@@ -1,4 +1,3 @@
-import Imports
 import qualified Run
 
 main :: IO ()

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -33,7 +33,6 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Misc (Port (..), mkHttpsUrl)
 import Data.Set qualified as Set
-import Imports
 import System.FilePath ((</>))
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -33,7 +33,6 @@ import Data.Qualified
 import Data.Set qualified as Set
 import Data.UUID.V4 qualified as UUIDv4
 import Federation.Util (generateClientPrekeys)
-import Imports
 import Network.Wai.Test qualified as WaiTest
 import Test.QuickCheck hiding ((===))
 import Test.Tasty

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -42,7 +42,6 @@ import Data.Default
 import Data.Id
 import Data.Qualified
 import GHC.TypeLits (KnownSymbol)
-import Imports
 import System.IO.Temp
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/Internal/Util.hs
+++ b/services/brig/test/integration/API/Internal/Util.hs
@@ -31,7 +31,6 @@ import Control.Lens ((^.))
 import Control.Monad.Catch (MonadCatch)
 import Data.Id
 import Data.Proxy (Proxy (Proxy))
-import Imports
 import Servant.API ((:>))
 import Servant.API.ContentTypes (NoContent)
 import Servant.Client qualified as Client

--- a/services/brig/test/integration/API/MLS/Util.hs
+++ b/services/brig/test/integration/API/MLS/Util.hs
@@ -29,7 +29,6 @@ import Data.Map qualified as Map
 import Data.Qualified
 import Data.Text qualified as Text
 import Data.Timeout
-import Imports
 import System.FilePath
 import System.Process
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/Metrics.hs
+++ b/services/brig/test/integration/API/Metrics.hs
@@ -29,7 +29,6 @@ import Bilge.Assert
 import Brig.Options qualified as Opt
 import Data.Attoparsec.Text
 import Data.ByteString.Conversion
-import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util

--- a/services/brig/test/integration/API/OAuth.hs
+++ b/services/brig/test/integration/API/OAuth.hs
@@ -42,7 +42,6 @@ import Data.Text.Encoding qualified as T
 import Data.Time
 import Data.UUID qualified as UUID
 import Data.UUID.V4 (nextRandom)
-import Imports
 import Network.HTTP.Types (HeaderName)
 import Network.Wai.Utilities qualified as Error
 import Servant.API

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -18,11 +18,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module API.Provider
-  ( tests,
-    Config,
-  )
-where
+module API.Provider (tests, Config) where
 
 import API.Team.Util qualified as Team
 import Bilge hiding (accept, head, timeout)
@@ -62,7 +58,6 @@ import Data.Time.Clock
 import Data.Timeout (TimedOut (..), Timeout, TimeoutUnit (..), (#))
 import Data.UUID qualified as UUID
 import Data.ZAuth.Token qualified as ZAuth
-import Imports hiding (threadDelay)
 import Network.HTTP.Types.Status (status200, status201, status400)
 import Network.Socket
 import Network.Socket qualified as Socket
@@ -100,6 +95,7 @@ import Wire.API.User as User hiding (EmailUpdate, PasswordChange, mkName)
 import Wire.API.User.Auth (CookieType (..))
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
+import Prelude hiding (threadDelay)
 
 tests :: Domain -> Config -> Manager -> DB.ClientState -> Brig -> Cannon -> Galley -> Nginz -> IO TestTree
 tests dom conf p db b c g n = do
@@ -580,7 +576,7 @@ testClaimUserPrekeys config db brig galley = withTestService config db brig defS
     pure cid
   addBotResponse :: AddBotResponse <- responseJsonError =<< addBot brig (User.userId u1) pid sid cid <!! const 201 === statusCode
   let bid = addBotResponse.rsAddBotId
-  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Imports.head someLastPrekeys)
+  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Prelude.head someLastPrekeys)
   c :: Client <- responseJsonError =<< addClient brig (User.userId u1) new
 
   let userClients = UserClients $ Map.fromList [((User.userId u1), Set.fromList [c.clientId])]
@@ -589,7 +585,7 @@ testClaimUserPrekeys config db brig galley = withTestService config db brig defS
   let expected =
         UserClientPrekeyMap $
           UserClientMap $
-            Map.fromList [((User.userId u1), Map.fromList [(c.clientId, Just (Imports.head somePrekeys))])]
+            Map.fromList [((User.userId u1), Map.fromList [(c.clientId, Just (Prelude.head somePrekeys))])]
 
   liftIO $ assertEqual "claim prekeys" expected actual
 
@@ -616,7 +612,7 @@ testGetUserClients config db brig galley = withTestService config db brig defSer
     pure cid
   addBotResponse :: AddBotResponse <- responseJsonError =<< addBot brig (User.userId u1) pid sid cid <!! const 201 === statusCode
   let bid = addBotResponse.rsAddBotId
-  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Imports.head someLastPrekeys)
+  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Prelude.head someLastPrekeys)
   expected :: Client <- responseJsonError =<< addClient brig (User.userId u1) new
   [actual] :: [PubClient] <- responseJsonError =<< getUserClients brig bid (User.userId u1) <!! const 200 === statusCode
   liftIO $ actual.pubClientId @?= expected.clientId

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -24,7 +24,6 @@ import Bilge
 import Brig.Types.User (RichInfoUpdate (RichInfoUpdate))
 import Data.ByteString.Conversion
 import Data.Id
-import Imports
 import Util
 import Wire.API.User.RichInfo
 

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -21,10 +21,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module API.Search
-  ( tests,
-  )
-where
+module API.Search (tests) where
 
 import API.Search.Util
 import API.Team.Util
@@ -47,7 +44,6 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Database.Bloodhound qualified as ES
 import Federation.Util
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.ReverseProxy (waiProxyTo)
 import Network.HTTP.ReverseProxy qualified as Wai
@@ -296,7 +292,7 @@ testSearchSize brig exactHandleInTeam = do
     assertEqual
       ("first match should be exact handle: " <> show searchTerm <> ", but got: \n" <> show res)
       (userQualifiedId handleMatch)
-      (contactQualifiedId $ Imports.head res)
+      (contactQualifiedId $ Prelude.head res)
     assertEqual
       ("exact handle: " <> show searchTerm <> " should only be present once, but got \n" <> show res)
       Nothing

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -28,7 +28,6 @@ import Data.Qualified (Qualified (..))
 import Data.Range (Range)
 import Data.Text.Encoding (encodeUtf8)
 import Database.Bloodhound qualified as ES
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import Test.Tasty.HUnit
 import Util

--- a/services/brig/test/integration/API/Settings.hs
+++ b/services/brig/test/integration/API/Settings.hs
@@ -30,7 +30,6 @@ import Data.ByteString.Char8 qualified as C8
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Set qualified as Set
-import Imports
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.HUnit
 import Util

--- a/services/brig/test/integration/API/SystemSettings.hs
+++ b/services/brig/test/integration/API/SystemSettings.hs
@@ -24,7 +24,6 @@ import Control.Lens
 import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Conversion (toByteString')
 import Data.Id
-import Imports
 import Network.Wai.Test as WaiTest
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -45,7 +45,6 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Time (addUTCTime, getCurrentTime)
 import Data.UUID qualified as UUID (fromString)
 import Data.UUID.V4 qualified as UUID
-import Imports
 import Network.HTTP.Types qualified as HTTP
 import Network.Wai qualified as Wai
 import Network.Wai.Test qualified as WaiTest

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -34,7 +34,6 @@ import Data.Misc (Milliseconds)
 import Data.Range
 import Data.Set qualified as Set
 import Data.Text.Encoding qualified as T
-import Imports
 import Network.Wai.Utilities.Error qualified as Error
 import Test.Tasty.HUnit
 import Util

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -28,7 +28,6 @@ import Data.ByteString.Conversion (toByteString)
 import Data.Handle (fromHandle)
 import Data.Id (TeamId, UserId)
 import Data.Range (unsafeRange)
-import Imports
 import System.Random.Shuffle (shuffleM)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, (@?=))

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -36,7 +36,6 @@ import Brig.Options qualified as Opt
 import Brig.ZAuth qualified as ZAuth
 import Cassandra qualified as DB
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import Imports
 import Test.Tasty hiding (Timeout)
 import Util
 import Util.AWS (UserJournalWatcher)

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -17,10 +17,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module API.User.Account
-  ( tests,
-  )
-where
+module API.User.Account (tests) where
 
 import API.Search.Util qualified as Search
 import API.Team.Util
@@ -65,8 +62,6 @@ import Data.Time.Clock (diffUTCTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
 import Federator.MockServer (FederatedRequest (..), MockException (..))
-import Imports hiding (head)
-import Imports qualified
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP.Types qualified as Http
 import Network.Wai qualified as Wai
@@ -95,6 +90,8 @@ import Wire.API.User.Activation
 import Wire.API.User.Auth
 import Wire.API.User.Auth qualified as Auth
 import Wire.API.User.Client
+import Prelude hiding (head)
+import Prelude qualified
 
 tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> AWS.Env -> UserJournalWatcher -> TestTree
 tests _ at opts p b c ch g aws userJournalWatcher =
@@ -1375,7 +1372,7 @@ testDeleteUserByPassword brig cannon userJournalWatcher = do
   con32 <- putConnection brig uid3 uid2 Accepted <!! const 200 === statusCode
   con23 <- getConnection brig uid2 uid3 <!! const 200 === statusCode
   -- Register a client
-  addClient brig uid1 (defNewClient PermanentClientType [Imports.head somePrekeys] (Imports.head someLastPrekeys))
+  addClient brig uid1 (defNewClient PermanentClientType [Prelude.head somePrekeys] (Prelude.head someLastPrekeys))
     !!! const 201 === statusCode
   -- Initial login
   login brig (defEmailLogin email) PersistentCookie
@@ -1416,7 +1413,7 @@ testDeleteUserWithLegalHold brig cannon userJournalWatcher = do
   user <- randomUser brig
   let uid = userId user
   -- Register a legalhold client
-  addClientInternal brig uid (defNewClient LegalHoldClientType [Imports.head somePrekeys] (Imports.head someLastPrekeys))
+  addClientInternal brig uid (defNewClient LegalHoldClientType [Prelude.head somePrekeys] (Prelude.head someLastPrekeys))
     !!! const 201 === statusCode
   Util.assertUserActivateJournaled userJournalWatcher user "user activate testDeleteInternal1: "
   setHandleAndDeleteUser brig cannon user [] userJournalWatcher $

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -19,10 +19,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module API.User.Auth
-  ( tests,
-  )
-where
+module API.User.Auth (tests) where
 
 import API.Team.Util
 import API.User.Util qualified as Util
@@ -57,7 +54,6 @@ import Data.Text.Lazy qualified as Lazy
 import Data.Time.Clock
 import Data.UUID.V4 qualified as UUID
 import Data.ZAuth.Token qualified as ZAuth
-import Imports hiding (cs)
 import Network.HTTP.Client (equivCookie)
 import Network.Wai.Utilities.Error qualified as Error
 import Test.Tasty
@@ -74,6 +70,7 @@ import Wire.API.User.Auth.LegalHold
 import Wire.API.User.Auth.ReAuth
 import Wire.API.User.Auth.Sso
 import Wire.API.User.Client
+import Prelude hiding (cs)
 
 -- | FUTUREWORK: Implement this function. This wrapper should make sure that
 -- wrapped tests run only when the feature flag 'legalhold' is set to
@@ -1047,7 +1044,7 @@ testAccessWithClientId brig = do
       =<< addClient
         brig
         (userId u)
-        (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+        (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
         <!! const 201 === statusCode
   r <-
     post
@@ -1098,7 +1095,7 @@ testAccessWithClientIdAndOldToken brig = do
       =<< addClient
         brig
         (userId u)
-        (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+        (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
         <!! const 201 === statusCode
   r <-
     post
@@ -1137,7 +1134,7 @@ testAccessWithIncorrectClientId brig = do
   addClient
     brig
     (userId u)
-    (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+    (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
     !!! const 201 === statusCode
   post
     ( unversioned
@@ -1167,7 +1164,7 @@ testAccessWithExistingClientId brig = do
       =<< addClient
         brig
         (userId u)
-        (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+        (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
         <!! const 201 === statusCode
   now <- liftIO getCurrentTime
 

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -59,7 +59,6 @@ import Data.Time.Clock.POSIX
 import Data.UUID (toByteString)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as Vec
-import Imports
 import Network.Wai.Utilities.Error qualified as Error
 import System.Logger qualified as Log
 import Test.QuickCheck (arbitrary, generate)

--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -36,7 +36,6 @@ import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Qualified
 import Data.Time.Clock (getCurrentTime)
 import Data.UUID.V4 qualified as UUID
-import Imports
 import Network.Wai.Utilities.Error qualified as Error
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -37,7 +37,6 @@ import Data.Id
 import Data.List1 qualified as List1
 import Data.Qualified (Qualified (..))
 import Data.UUID qualified as UUID
-import Imports
 import Network.Wai.Utilities.Error qualified as Error
 import Network.Wai.Utilities.Error qualified as Wai
 import Test.Tasty hiding (Timeout)

--- a/services/brig/test/integration/API/User/PasswordReset.hs
+++ b/services/brig/test/integration/API/User/PasswordReset.hs
@@ -30,11 +30,11 @@ import Cassandra qualified as DB
 import Data.Aeson as A
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Misc
-import Imports hiding (cs)
 import Test.Tasty hiding (Timeout)
 import Util
 import Wire.API.User
 import Wire.API.User.Auth
+import Prelude hiding (cs)
 
 tests ::
   DB.ClientState ->

--- a/services/brig/test/integration/API/User/Property.hs
+++ b/services/brig/test/integration/API/User/Property.hs
@@ -28,7 +28,6 @@ import Brig.Options qualified as Opt
 import Data.Aeson
 import Data.ByteString.Char8 qualified as C
 import Data.Text qualified as T
-import Imports
 import Network.Wai.Utilities.Error qualified as Error
 import Test.Tasty hiding (Timeout)
 import Util

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -30,7 +30,6 @@ import Brig.Options qualified as Opt
 import Data.CaseInsensitive qualified as CI
 import Data.List1 qualified as List1
 import Data.Text qualified as Text
-import Imports
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.HUnit
 import Util

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -53,7 +53,6 @@ import Data.ZAuth.Token qualified as ZAuth
 import Federation.Util (withTempMockFederator)
 import Federator.MockServer (FederatedRequest (..))
 import GHC.TypeLits (KnownSymbol)
-import Imports
 import Polysemy
 import Test.Tasty.Cannon qualified as WS
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -39,7 +39,6 @@ import Data.Range (unsafeRange)
 import Data.Text.Encoding (encodeUtf8)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
-import Imports
 import SAML2.WebSSO qualified as SAML
 import Spar.Scim (CreateScimTokenResponse (..), SparTag, userSchemas)
 import Test.QuickCheck (generate)

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -38,7 +38,6 @@ import Data.Qualified
 import Data.Range (checked)
 import Data.Set qualified as Set
 import Federation.Util
-import Imports hiding (cs)
 import System.IO.Temp
 import System.Logger qualified as Log
 import Test.Tasty
@@ -60,6 +59,7 @@ import Wire.API.Routes.MultiTablePaging
 import Wire.API.User hiding (assetKey)
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
+import Prelude hiding (cs)
 
 -- NOTE: These federation tests require deploying two sets of (some) services
 -- This might be best left to a kubernetes setup.
@@ -119,7 +119,7 @@ spec _brigOpts mg brig galley cargohold cannon _federator brigTwo galleyTwo carg
 testGetUsersById :: Brig -> Brig -> Http ()
 testGetUsersById brig1 brig2 = do
   users <- traverse randomUser [brig1, brig2]
-  let self = Imports.head users
+  let self = Prelude.head users
       q = ListUsersByIds (map userQualifiedId users)
       expected = sort (map userQualifiedId users)
   post
@@ -142,9 +142,9 @@ testClaimPrekeySuccess :: Brig -> Brig -> Http ()
 testClaimPrekeySuccess brig1 brig2 = do
   self <- randomUser brig1
   user <- randomUser brig2
-  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Imports.head someLastPrekeys)
+  let new = defNewClient TemporaryClientType (take 1 somePrekeys) (Prelude.head someLastPrekeys)
   c <- responseJsonError =<< addClient brig2 (userId user) new
-  let cpk = ClientPrekey (clientId c) (Imports.head somePrekeys)
+  let cpk = ClientPrekey (clientId c) (Prelude.head somePrekeys)
   let quser = userQualifiedId user
   get
     ( brig1
@@ -410,7 +410,7 @@ testSendMessage brig1 brig2 galley2 cannon1 = do
       <$> addClient
         brig1
         (userId alice)
-        (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+        (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
 
   -- create bob user and client on domain 2
   bob <- randomUser brig2
@@ -474,7 +474,7 @@ testSendMessageToRemoteConv brig1 brig2 galley1 galley2 cannon1 = do
   alice <- randomUser brig1
   aliceClient <-
     fmap clientId . responseJsonError
-      =<< addClient brig1 (userId alice) (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+      =<< addClient brig1 (userId alice) (defNewClient PermanentClientType [] (Prelude.head someLastPrekeys))
         <!! const 201 === statusCode
 
   -- create bob user and client on domain 2

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -47,7 +47,6 @@ import Database.Bloodhound qualified as ES
 import Federator.MockServer qualified as Mock
 import Foreign.C.Error (Errno (..), eCONNREFUSED)
 import GHC.IO.Exception (IOException (ioe_errno))
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Media
 import Network.Socket

--- a/services/brig/test/integration/Index/Create.hs
+++ b/services/brig/test/integration/Index/Create.hs
@@ -26,7 +26,6 @@ import Control.Lens ((.~), (^.))
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Database.Bloodhound qualified as ES
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import System.Logger.Class qualified as Log
 import System.Random as Random

--- a/services/brig/test/integration/Run.hs
+++ b/services/brig/test/integration/Run.hs
@@ -48,7 +48,6 @@ import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml (decodeFileEither)
 import Federation.End2end qualified
-import Imports hiding (local)
 import Index.Create qualified
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -71,6 +70,7 @@ import Util.Test.SQS qualified as SQS
 import Web.HttpApiData
 import Wire.API.Federation.API
 import Wire.API.Routes.Version
+import Prelude hiding (local)
 
 data BackendConf = BackendConf
   { remoteBrig :: Endpoint,

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -15,7 +15,6 @@ import Data.Text (unpack)
 import Data.Text.Lazy (fromStrict)
 import Data.Time.Units
 import Debug.Trace (traceIO)
-import Imports
 import Network.Mail.Mime
 import Network.Mail.Postie qualified as Postie
 import Network.Socket

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -72,7 +72,6 @@ import Data.ZAuth.Token qualified as ZAuth
 import Federator.MockServer qualified as Mock
 import GHC.TypeLits
 import Galley.Types.Conversations.One2One (one2OneConvId)
-import Imports
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Media.MediaType
 import Network.HTTP.Media.RenderHeader (renderHeader)

--- a/services/brig/test/integration/Util/AWS.hs
+++ b/services/brig/test/integration/Util/AWS.hs
@@ -25,7 +25,6 @@ import Data.Id
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.UUID qualified as UUID
-import Imports
 import Proto.UserEvents qualified as PU
 import Proto.UserEvents_Fields qualified as PU
 import Test.Tasty.HUnit

--- a/services/brig/test/unit/Run.hs
+++ b/services/brig/test/unit/Run.hs
@@ -20,7 +20,6 @@ module Run
   )
 where
 
-import Imports
 import Test.Brig.Calling qualified
 import Test.Brig.Calling.Internal qualified
 import Test.Brig.InternalNotification qualified

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -36,7 +36,6 @@ import Data.Misc
 import Data.Range
 import Data.Set qualified as Set
 import Data.Timeout
-import Imports
 import Network.DNS
 import OpenSSL
 import OpenSSL.EVP.Digest (getDigestByName)

--- a/services/brig/test/unit/Test/Brig/Calling/Internal.hs
+++ b/services/brig/test/unit/Test/Brig/Calling/Internal.hs
@@ -21,7 +21,6 @@ module Test.Brig.Calling.Internal where
 
 import Brig.Calling.Internal
 import Data.Misc (mkHttpsUrl)
-import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
 import URI.ByteString.QQ as URI

--- a/services/brig/test/unit/Test/Brig/Effects/Delay.hs
+++ b/services/brig/test/unit/Test/Brig/Effects/Delay.hs
@@ -1,6 +1,5 @@
 module Test.Brig.Effects.Delay where
 
-import Imports
 import Polysemy
 import Wire.Sem.Delay
 

--- a/services/brig/test/unit/Test/Brig/InternalNotification.hs
+++ b/services/brig/test/unit/Test/Brig/InternalNotification.hs
@@ -21,7 +21,6 @@ import Brig.InternalEvent.Types (InternalNotification (..))
 import Data.Aeson qualified as A
 import Data.ByteString.Lazy as BSL
 import Data.Id (clientToText)
-import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/services/brig/test/unit/Test/Brig/MLS.hs
+++ b/services/brig/test/unit/Test/Brig/MLS.hs
@@ -21,7 +21,6 @@ import Brig.API.MLS.KeyPackages.Validation
 import Data.Binary
 import Data.Either
 import Data.Time.Clock
-import Imports
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Wire.API.MLS.Lifetime

--- a/services/brig/test/unit/Test/Brig/Roundtrip.hs
+++ b/services/brig/test/unit/Test/Brig/Roundtrip.hs
@@ -20,7 +20,6 @@ module Test.Brig.Roundtrip (tests) where
 import Brig.Options qualified as Options
 import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON)
 import Data.Aeson.Types (parseEither)
-import Imports
 import Test.Tasty qualified as T
 import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
 import Type.Reflection (typeRep)

--- a/services/brig/test/unit/Test/Brig/User/Search/Index/Types.hs
+++ b/services/brig/test/unit/Test/Brig/User/Search/Index/Types.hs
@@ -28,7 +28,6 @@ import Data.Json.Util
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.UUID
-import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
 import Wire.API.Team.Role


### PR DESCRIPTION
- make import Imports implicit using cabal mixins
- replace qualified imports of Import with qualified imports of Prelude
- remove warnings on unnecessary packages
- remove brig Paths_ module

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
