### PR TITLE
elasticsearch-ephemeral: Provide password as value

### DIFF
--- a/changelog.d/5-internal/elasticsearch-ephemeral_configurable_password
+++ b/changelog.d/5-internal/elasticsearch-ephemeral_configurable_password
@@ -1,0 +1,3 @@
+Provide password as value in `elasticsearch-ephemeral`. This way we can use
+different passwords on our test systems. Ensuring that the password is really
+configurable (and not accidentally hardcoded somewhere.)

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -34,9 +34,8 @@ spec:
           value: ".watches,.triggered_watches,.watcher-history-*,pod-*,node-*"
         - name: "xpack.security.enabled"
           value: "true"
-        # setting the password here is ok, as this chart is only used for integration tests on CI
         - name: "ELASTIC_PASSWORD"
-          value: "changeme"
+          value: {{ .Values.secrets.password }}
         ports:
         - containerPort: 9200
           name: http

--- a/charts/elasticsearch-ephemeral/values.yaml
+++ b/charts/elasticsearch-ephemeral/values.yaml
@@ -14,3 +14,6 @@ resources:
   requests:
     cpu: "250m"
     memory: "500Mi"
+
+secrets:
+  password: "changeme"


### PR DESCRIPTION
This way we can use different passwords on our test systems. Ensuring that the password is really configurable (and not accidentally hardcoded somewhere.)

Ticket: https://wearezeta.atlassian.net/browse/WPB-7283

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
