### PR TITLE
[WPB-7415] Fix the list of other members in an MLS 1-to-1 conversation (the `develop` counterpart)

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-7415
+++ b/changelog.d/3-bug-fixes/WPB-7415
@@ -1,0 +1,1 @@
+Return an actual list of other users in a remote MLS 1-to-1 conversation

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -109,7 +109,7 @@ remoteMLSOne2OneConversation lself rother rc =
   let members =
         ConvMembers
           { cmSelf = defMember (tUntagged lself),
-            cmOthers = []
+            cmOthers = rc.members.others
           }
    in Conversation
         { cnvQualifiedId = tUntagged (qualifyAs rother rc.id),


### PR DESCRIPTION
The `GET /conversations/one2one/{usr_domain}/{usr}` endpoint would always return an empty list of other members in case the MLS 1-to-1 conversation was hosted on a remote backend. The PR fixes the bug.

This is the `develop` branch counterpart of the already approved PR #3993.

Tracked by https://wearezeta.atlassian.net/browse/WPB-7415.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
