### PR TITLE
[WPB-7222] Drop depencency on `convertible-strings` in production code

### DIFF
--- a/changelog.d/5-internal/WPB-7222
+++ b/changelog.d/5-internal/WPB-7222
@@ -1,0 +1,1 @@
+drop cs in all production code and from Imports

--- a/libs/bilge/src/Bilge/Request.hs
+++ b/libs/bilge/src/Bilge/Request.hs
@@ -82,7 +82,7 @@ import Data.ByteString.Lazy qualified as Lazy
 import Data.ByteString.Lazy.Char8 qualified as LC
 import Data.CaseInsensitive (original)
 import Data.Id (RequestId (..))
-import Imports hiding (cs, intercalate)
+import Imports hiding (intercalate)
 import Network.HTTP.Client (Cookie, GivesPopper, Request, RequestBody (..))
 import Network.HTTP.Client qualified as Rq
 import Network.HTTP.Client.Internal (CookieJar (..), brReadSome, throwHttp)

--- a/libs/extended/default.nix
+++ b/libs/extended/default.nix
@@ -29,6 +29,7 @@
 , servant-client-core
 , servant-openapi3
 , servant-server
+, string-conversions
 , temporary
 , text
 , time
@@ -69,7 +70,14 @@ mkDerivation {
     unliftio
     wai
   ];
-  testHaskellDepends = [ aeson base hspec imports temporary ];
+  testHaskellDepends = [
+    aeson
+    base
+    hspec
+    imports
+    string-conversions
+    temporary
+  ];
   testToolDepends = [ hspec-discover ];
   description = "Extended versions of common modules";
   license = lib.licenses.agpl3Only;

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -172,6 +172,7 @@ test-suite extended-tests
     , extended
     , hspec
     , imports
+    , string-conversions
     , temporary
 
   default-language:   GHC2021

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -19,6 +19,7 @@
 -- errors instead of plaintext.
 module Servant.API.Extended where
 
+import Data.ByteString
 import Data.ByteString.Lazy qualified as BL
 import Data.EitherR (fmapL)
 import Data.Kind
@@ -92,7 +93,7 @@ instance
               fromMaybe "application/octet-stream" $
                 lookup hContentType $
                   requestHeaders request
-        case canHandleCTypeH (Proxy :: Proxy list) (cs contentTypeH) :: Maybe (BL.ByteString -> Either String a) of
+        case canHandleCTypeH (Proxy :: Proxy list) (fromStrict contentTypeH) :: Maybe (BL.ByteString -> Either String a) of
           Nothing -> delayedFail err415
           Just f -> pure f
       -- Body check, we get a body parsing functions as the first argument.

--- a/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
+++ b/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
@@ -19,6 +19,7 @@ module Test.System.Logger.ExtendedSpec where
 
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
+import Data.String.Conversions
 import Imports
 import System.IO.Temp
 import System.Logger.Extended hiding ((.=))

--- a/libs/galley-types/default.nix
+++ b/libs/galley-types/default.nix
@@ -21,6 +21,7 @@
 , tasty-quickcheck
 , text
 , types-common
+, utf8-string
 , uuid
 , wire-api
 }:
@@ -43,6 +44,7 @@ mkDerivation {
     schema-profunctor
     text
     types-common
+    utf8-string
     uuid
     wire-api
   ];

--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -85,6 +85,7 @@ library
     , schema-profunctor
     , text                   >=0.11
     , types-common           >=0.16
+    , utf8-string
     , uuid
     , wire-api
 

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -26,7 +26,7 @@ where
 import Data.Aeson
 import Data.Id (ClientId, UserId)
 import Data.Map.Strict qualified as Map
-import Imports hiding (cs)
+import Imports
 import Wire.API.Message
 
 --------------------------------------------------------------------------------

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -62,6 +62,8 @@ where
 import Control.Lens (makeLenses, view)
 import Data.Aeson
 import Data.Aeson.Types qualified as A
+import Data.ByteString (toStrict)
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.Id (UserId)
 import Data.Schema qualified as Schema
 import Data.Set qualified as Set
@@ -199,7 +201,7 @@ instance ToJSON FeatureFlags where
 instance FromJSON FeatureSSO where
   parseJSON (String "enabled-by-default") = pure FeatureSSOEnabledByDefault
   parseJSON (String "disabled-by-default") = pure FeatureSSODisabledByDefault
-  parseJSON bad = fail $ "FeatureSSO: " <> cs (encode bad)
+  parseJSON bad = fail $ "FeatureSSO: " <> (UTF8.toString . toStrict . encode $ bad)
 
 instance ToJSON FeatureSSO where
   toJSON FeatureSSOEnabledByDefault = String "enabled-by-default"
@@ -209,7 +211,7 @@ instance FromJSON FeatureLegalHold where
   parseJSON (String "disabled-permanently") = pure $ FeatureLegalHoldDisabledPermanently
   parseJSON (String "disabled-by-default") = pure $ FeatureLegalHoldDisabledByDefault
   parseJSON (String "whitelist-teams-and-implicit-consent") = pure FeatureLegalHoldWhitelistTeamsAndImplicitConsent
-  parseJSON bad = fail $ "FeatureLegalHold: " <> cs (encode bad)
+  parseJSON bad = fail $ "FeatureLegalHold: " <> (UTF8.toString . toStrict . encode $ bad)
 
 instance ToJSON FeatureLegalHold where
   toJSON FeatureLegalHoldDisabledPermanently = String "disabled-permanently"
@@ -219,7 +221,7 @@ instance ToJSON FeatureLegalHold where
 instance FromJSON FeatureTeamSearchVisibilityAvailability where
   parseJSON (String "enabled-by-default") = pure FeatureTeamSearchVisibilityAvailableByDefault
   parseJSON (String "disabled-by-default") = pure FeatureTeamSearchVisibilityUnavailableByDefault
-  parseJSON bad = fail $ "FeatureSearchVisibility: " <> cs (encode bad)
+  parseJSON bad = fail $ "FeatureSearchVisibility: " <> (UTF8.toString . toStrict . encode $ bad)
 
 instance ToJSON FeatureTeamSearchVisibilityAvailability where
   toJSON FeatureTeamSearchVisibilityAvailableByDefault = String "enabled-by-default"

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -83,7 +83,7 @@ import Data.List1 qualified as List1
 import Data.Range
 import Data.Range qualified as Range
 import Data.Set qualified as Set
-import Imports hiding (cs)
+import Imports
 import Wire.API.Message (Priority (..))
 import Wire.API.Push.V2.Token
 import Wire.Arbitrary

--- a/libs/imports/default.nix
+++ b/libs/imports/default.nix
@@ -11,7 +11,6 @@
 , gitignoreSource
 , lib
 , mtl
-, string-conversions
 , text
 , transformers
 , unliftio
@@ -29,7 +28,6 @@ mkDerivation {
     deepseq
     extra
     mtl
-    string-conversions
     text
     transformers
     unliftio

--- a/libs/imports/imports.cabal
+++ b/libs/imports/imports.cabal
@@ -75,7 +75,6 @@ library
     , deepseq
     , extra
     , mtl
-    , string-conversions
     , text
     , transformers
     , unliftio

--- a/libs/imports/src/Imports.hs
+++ b/libs/imports/src/Imports.hs
@@ -114,7 +114,6 @@ module Imports
     -- * Extra Helpers
     whenM,
     unlessM,
-    cs,
 
     -- * Functor
     (<$$>),
@@ -165,7 +164,6 @@ import Data.Ord
 import Data.Semigroup hiding (diff)
 import Data.Set (Set)
 import Data.String
-import Data.String.Conversions (cs)
 import Data.Text (Text)
 import Data.Text.Lazy qualified
 import Data.Traversable

--- a/libs/jwt-tools/default.nix
+++ b/libs/jwt-tools/default.nix
@@ -12,7 +12,9 @@
 , imports
 , lib
 , rusty_jwt_tools_ffi
+, string-conversions
 , transformers
+, utf8-string
 }:
 mkDerivation {
   pname = "jwt-tools";
@@ -24,9 +26,16 @@ mkDerivation {
     http-types
     imports
     transformers
+    utf8-string
   ];
   librarySystemDepends = [ rusty_jwt_tools_ffi ];
-  testHaskellDepends = [ bytestring hspec imports transformers ];
+  testHaskellDepends = [
+    bytestring
+    hspec
+    imports
+    string-conversions
+    transformers
+  ];
   description = "FFI to rusty-jwt-tools";
   license = lib.licenses.agpl3Only;
 }

--- a/libs/jwt-tools/jwt-tools.cabal
+++ b/libs/jwt-tools/jwt-tools.cabal
@@ -68,6 +68,7 @@ library
     , http-types
     , imports
     , transformers
+    , utf8-string
 
   default-language:   GHC2021
   other-extensions:   ForeignFunctionInterface
@@ -83,6 +84,7 @@ test-suite jwt-tools-tests
     , hspec
     , imports
     , jwt-tools
+    , string-conversions
     , transformers
 
   hs-source-dirs:     test

--- a/libs/jwt-tools/src/Data/Jwt/Tools.hs
+++ b/libs/jwt-tools/src/Data/Jwt/Tools.hs
@@ -42,6 +42,7 @@ where
 import Control.Exception hiding (handle)
 import Control.Monad.Trans.Except
 import Data.ByteString.Conversion
+import Data.ByteString.UTF8 qualified as UTF8
 import Foreign.C.String (CString, newCString, peekCString)
 import Foreign.Ptr (Ptr, nullPtr)
 import Imports
@@ -163,7 +164,7 @@ generateDpopToken dpopProof uid cid handle displayName tid domain nonce uri meth
   domainCStr <- toCStr domain
   nonceCStr <- toCStr nonce
   uriCStr <- toCStr uri
-  methodCStr <- liftIO $ newCString $ cs $ methodToBS method
+  methodCStr <- liftIO $ newCString $ UTF8.toString $ methodToBS method
   backendPubkeyBundleCStr <- toCStr backendPubkeyBundle
 
   -- log all variable inputs (can comment in if need to generate new test data)
@@ -205,7 +206,7 @@ generateDpopToken dpopProof uid cid handle displayName tid domain nonce uri meth
     toCStr = liftIO . newCString . toStr
       where
         toStr :: a -> String
-        toStr = cs . toByteString'
+        toStr = UTF8.toString . toByteString'
 
     methodToBS :: StdMethod -> ByteString
     methodToBS = \case
@@ -221,8 +222,8 @@ generateDpopToken dpopProof uid cid handle displayName tid domain nonce uri meth
 
 toResult :: Maybe Word8 -> Maybe String -> Either DPoPTokenGenerationError ByteString
 -- the only valid cases are when the error=0 (meaning no error) or nothing and the token is not null
-toResult (Just 0) (Just token) = Right $ cs token
-toResult Nothing (Just token) = Right $ cs token
+toResult (Just 0) (Just token) = Right $ UTF8.fromString token
+toResult Nothing (Just token) = Right $ UTF8.fromString token
 -- errors
 toResult (Just errNo) _ = Left $ fromInt (fromIntegral errNo)
   where

--- a/libs/jwt-tools/test/Spec.hs
+++ b/libs/jwt-tools/test/Spec.hs
@@ -18,6 +18,7 @@
 import Control.Monad.Trans.Except
 import Data.ByteString.Char8 (split)
 import Data.Jwt.Tools
+import Data.String.Conversions
 import Imports
 import Test.Hspec
 

--- a/libs/metrics-wai/default.nix
+++ b/libs/metrics-wai/default.nix
@@ -16,6 +16,7 @@
 , servant
 , servant-multipart
 , text
+, utf8-string
 , wai
 , wai-middleware-prometheus
 , wai-route
@@ -35,6 +36,7 @@ mkDerivation {
     servant
     servant-multipart
     text
+    utf8-string
     wai
     wai-middleware-prometheus
     wai-route

--- a/libs/metrics-wai/metrics-wai.cabal
+++ b/libs/metrics-wai/metrics-wai.cabal
@@ -79,6 +79,7 @@ library
     , servant
     , servant-multipart
     , text                       >=0.11
+    , utf8-string
     , wai                        >=3
     , wai-middleware-prometheus
     , wai-route                  >=0.3

--- a/libs/polysemy-wire-zoo/src/Wire/Sem/Jwk.hs
+++ b/libs/polysemy-wire-zoo/src/Wire/Sem/Jwk.hs
@@ -5,6 +5,7 @@ module Wire.Sem.Jwk where
 import Control.Exception
 import Crypto.JOSE.JWK
 import Data.Aeson
+import Data.ByteString (fromStrict)
 import qualified Data.ByteString as BS
 import Imports
 import Polysemy
@@ -18,4 +19,8 @@ interpretJwk :: Members '[Embed IO] r => Sem (Jwk ': r) a -> Sem r a
 interpretJwk = interpret $ \(Get fp) -> liftIO $ readJwk fp
 
 readJwk :: FilePath -> IO (Maybe JWK)
-readJwk fp = try @IOException (BS.readFile fp) <&> either (const Nothing) (decode . cs)
+readJwk fp =
+  try @IOException (BS.readFile fp)
+    <&> either
+      (const Nothing)
+      (decode . fromStrict)

--- a/libs/types-common/default.nix
+++ b/libs/types-common/default.nix
@@ -41,6 +41,7 @@
 , random
 , schema-profunctor
 , servant-server
+, string-conversions
 , tagged
 , tasty
 , tasty-hunit
@@ -52,6 +53,7 @@
 , unix
 , unordered-containers
 , uri-bytestring
+, utf8-string
 , uuid
 , yaml
 }:
@@ -105,6 +107,7 @@ mkDerivation {
     unix
     unordered-containers
     uri-bytestring
+    utf8-string
     uuid
     yaml
   ];
@@ -116,6 +119,7 @@ mkDerivation {
     cereal
     imports
     protobuf
+    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/libs/types-common/src/Data/Code.hs
+++ b/libs/types-common/src/Data/Code.hs
@@ -35,7 +35,8 @@ import Data.Range
 import Data.Schema
 import Data.Text (pack)
 import Data.Text.Ascii
-import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding
+import Data.Text.Encoding.Error
 import Data.Time.Clock
 import Imports
 import Servant (FromHttpApiData (..), ToHttpApiData (..))
@@ -62,7 +63,7 @@ instance FromHttpApiData Key where
     first pack $ runParser parser (encodeUtf8 s)
 
 instance ToHttpApiData Key where
-  toQueryParam key = cs (toByteString' key)
+  toQueryParam key = decodeUtf8With lenientDecode (toByteString' key)
 
 -- | A secret value bound to a 'Key' and a 'Timeout'.
 newtype Value = Value {asciiValue :: Range 6 20 AsciiBase64Url}
@@ -85,7 +86,7 @@ instance FromHttpApiData Value where
     first pack $ runParser parser (encodeUtf8 s)
 
 instance ToHttpApiData Value where
-  toQueryParam key = cs (toByteString' key)
+  toQueryParam key = decodeUtf8With lenientDecode (toByteString' key)
 
 -- | A 'Timeout' is rendered in/parsed from JSON as an integer representing the
 -- number of seconds remaining.

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -82,7 +82,7 @@ instance FromByteString Domain where
   parser = domainParser
 
 instance ToByteString Domain where
-  builder = Builder.lazyByteString . cs @Text @LByteString . _domainText
+  builder = Builder.lazyByteString . BS.Char8.fromStrict . Text.E.encodeUtf8 . _domainText
 
 instance FromHttpApiData Domain where
   parseUrlPiece = first Text.pack . mkDomain

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -61,6 +61,7 @@ import Data.ByteString.Base64.URL qualified as B64U
 import Data.ByteString.Builder qualified as BB
 import Data.ByteString.Conversion qualified as BS
 import Data.ByteString.Lazy qualified as L
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.Fixed
 import Data.OpenApi qualified as S
 import Data.Schema
@@ -141,7 +142,7 @@ instance Show UTCTimeMillis where
   showsPrec d = showParen (d > 10) . showString . Text.unpack . showUTCTimeMillis
 
 instance BS.ToByteString UTCTimeMillis where
-  builder = BB.byteString . cs . show
+  builder = BB.byteString . UTF8.fromString . show
 
 instance BS.FromByteString UTCTimeMillis where
   parser = maybe (fail "UTCTimeMillis") pure . readUTCTimeMillis =<< BS.parser

--- a/libs/types-common/src/Util/Logging.hs
+++ b/libs/types-common/src/Util/Logging.hs
@@ -29,7 +29,7 @@ import System.Logger.Message (Msg)
 sha256String :: Text -> Text
 sha256String t =
   let digest = hash @ByteString @SHA256 (encodeUtf8 t)
-   in cs . show $ digest
+   in T.pack . show $ digest
 
 logHandle :: Handle -> (Msg -> Msg)
 logHandle handl =
@@ -44,7 +44,7 @@ logFunction fn = Log.field "fn" fn . Log.field "module" (getModule fn)
       x -> T.intercalate "." (init x)
 
 logUser :: UserId -> (Msg -> Msg)
-logUser uid = Log.field "user" (cs @_ @Text . show $ uid)
+logUser uid = Log.field "user" (T.pack . show $ uid)
 
 logTeam :: TeamId -> (Msg -> Msg)
-logTeam tid = Log.field "team" (cs @_ @Text . show $ tid)
+logTeam tid = Log.field "team" (T.pack . show $ tid)

--- a/libs/types-common/test/Test/Data/PEMKeys.hs
+++ b/libs/types-common/test/Test/Data/PEMKeys.hs
@@ -22,6 +22,7 @@ where
 
 import Data.ByteString.Conversion
 import Data.PEMKeys
+import Data.String.Conversions
 import Imports
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -39,6 +39,7 @@ import Data.Json.Util qualified as Util
 import Data.Nonce (Nonce)
 import Data.ProtocolBuffers.Internal
 import Data.Serialize
+import Data.String.Conversions
 import Data.Text.Ascii
 import Data.Text.Ascii qualified as Ascii
 import Data.Time

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -136,6 +136,7 @@ library
     , unix
     , unordered-containers   >=0.2
     , uri-bytestring         >=0.2
+    , utf8-string
     , uuid                   >=1.3.11
     , yaml                   >=0.8.22
 
@@ -209,6 +210,7 @@ test-suite tests
     , cereal
     , imports
     , protobuf
+    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -245,7 +245,9 @@ federationRemoteHTTP2Error target path = \case
     addErrData err =
       err
         { Wai.errorData =
-            ((mkDomain . cs . srvTargetDomain $ target) :: Either String Domain)
+            ( (mkDomain . T.decodeUtf8With T.lenientDecode . srvTargetDomain $ target) ::
+                Either String Domain
+            )
               & either (const Nothing) (\dom -> Just (Wai.FederationErrorData dom path))
         }
 
@@ -271,7 +273,9 @@ federationRemoteResponseError target path status body =
       )
   )
     { Wai.errorData =
-        ((mkDomain . cs . srvTargetDomain $ target) :: Either String Domain)
+        ( (mkDomain . T.decodeUtf8With T.lenientDecode . srvTargetDomain $ target) ::
+            Either String Domain
+        )
           & either (const Nothing) (\dom -> Just (Wai.FederationErrorData dom path)),
       Wai.innerError =
         Just $

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -86,6 +86,7 @@
 , singletons-base
 , singletons-th
 , sop-core
+, string-conversions
 , tagged
 , tasty
 , tasty-hspec
@@ -244,6 +245,7 @@ mkDerivation {
     schema-profunctor
     servant
     servant-server
+    string-conversions
     tasty
     tasty-hspec
     tasty-hunit

--- a/libs/wire-api/src/Wire/API/Call/Config.hs
+++ b/libs/wire-api/src/Wire/API/Call/Config.hs
@@ -93,6 +93,7 @@ import Data.Aeson qualified as A hiding ((<?>))
 import Data.Aeson.Types qualified as A
 import Data.Attoparsec.Text hiding (Parser, parse)
 import Data.Attoparsec.Text qualified as Text
+import Data.ByteString (toStrict)
 import Data.ByteString.Builder
 import Data.ByteString.Conversion (toByteString)
 import Data.ByteString.Conversion qualified as BC
@@ -104,6 +105,7 @@ import Data.Schema
 import Data.Text qualified as Text
 import Data.Text.Ascii
 import Data.Text.Encoding qualified as TE
+import Data.Text.Encoding.Error
 import Data.Text.Strict.Lens (utf8)
 import Data.Time.Clock.POSIX
 import Imports
@@ -264,7 +266,9 @@ data TurnURI = TurnURI
   deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema TurnURI)
 
 instance ToSchema TurnURI where
-  schema = (cs . toByteString) .= parsedText "TurnURI" parseTurnURI
+  schema =
+    (TE.decodeUtf8With lenientDecode . toStrict . toByteString)
+      .= parsedText "TurnURI" parseTurnURI
 
 turnURI :: Scheme -> TurnHost -> Port -> Maybe Transport -> TurnURI
 turnURI = TurnURI
@@ -478,7 +482,7 @@ instance ToSchema SFTUsername where
       fromText = parseOnly (parseSFTUsername <* endOfInput)
 
       toText :: SFTUsername -> Text
-      toText = cs . toByteString
+      toText = TE.decodeUtf8With lenientDecode . toStrict . toByteString
 
 instance BC.ToByteString SFTUsername where
   builder su =
@@ -555,7 +559,7 @@ instance ToSchema TurnUsername where
       fromText = parseOnly (parseTurnUsername <* endOfInput)
 
       toText :: TurnUsername -> Text
-      toText = cs . toByteString
+      toText = TE.decodeUtf8With lenientDecode . toStrict . toByteString
 
 instance BC.ToByteString TurnUsername where
   builder tu =

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -104,6 +104,7 @@ import Data.Range (Range, fromRange, rangedSchema)
 import Data.SOP
 import Data.Schema
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Data.UUID qualified as UUID
 import Data.UUID.V5 qualified as UUIDV5
 import Imports
@@ -724,7 +725,7 @@ newConvSchema sch =
       \to be part of this conversation"
     usersRoleDesc :: Text
     usersRoleDesc =
-      cs $
+      Text.pack $
         "The conversation permissions the users \
         \added in this request should have. \
         \Optional, defaults to '"

--- a/libs/wire-api/src/Wire/API/Internal/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Internal/Notification.hs
@@ -47,7 +47,7 @@ import Data.Id
 import Data.List1
 import Data.OpenApi qualified as Swagger
 import Data.Schema qualified as S
-import Imports hiding (cs)
+import Imports
 import Wire.API.Notification
 
 -------------------------------------------------------------------------------

--- a/libs/wire-api/src/Wire/API/MLS/AuthenticatedContent.hs
+++ b/libs/wire-api/src/Wire/API/MLS/AuthenticatedContent.hs
@@ -25,7 +25,7 @@ module Wire.API.MLS.AuthenticatedContent
 where
 
 import Crypto.PubKey.Ed25519
-import Imports hiding (cs)
+import Imports
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Context
 import Wire.API.MLS.Epoch

--- a/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
@@ -68,7 +68,7 @@ import Data.Text.Lazy qualified as LT
 import Data.Text.Lazy.Builder qualified as LT
 import Data.Text.Lazy.Builder.Int qualified as LT
 import Data.Word
-import Imports hiding (cs)
+import Imports
 import Web.HttpApiData
 import Wire.API.MLS.Serialisation
 import Wire.Arbitrary

--- a/libs/wire-api/src/Wire/API/MLS/Group/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Group/Serialisation.hs
@@ -35,7 +35,7 @@ import Data.Qualified
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.UUID qualified as UUID
-import Imports hiding (cs)
+import Imports
 import Web.HttpApiData (FromHttpApiData (parseHeader))
 import Wire.API.Conversation
 import Wire.API.MLS.Group

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -49,7 +49,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.X509 qualified as X509
 import GHC.Records
-import Imports hiding (cs)
+import Imports
 import Test.QuickCheck
 import Web.HttpApiData
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -45,7 +45,7 @@ import Data.Json.Util
 import Data.OpenApi qualified as S
 import Data.Schema hiding (HasField)
 import GHC.Records
-import Imports hiding (cs)
+import Imports
 import Test.QuickCheck hiding (label)
 import Wire.API.Event.Conversation
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -25,7 +25,7 @@ import Control.Lens (makePrisms)
 import Data.Binary
 import Data.ByteString as B
 import GHC.Records
-import Imports hiding (cs)
+import Imports
 import Test.QuickCheck
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Extension

--- a/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
@@ -35,7 +35,7 @@ import Data.Schema hiding (HasField)
 import Data.Text qualified as T
 import Data.Time.Clock
 import GHC.Records
-import Imports hiding (cs)
+import Imports
 import Servant (FromHttpApiData (..), ToHttpApiData (toQueryParam))
 import Test.QuickCheck
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Validation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Validation.hs
@@ -29,7 +29,7 @@ import Data.Text.Lazy qualified as LT
 import Data.Text.Lazy.Builder qualified as LT
 import Data.Text.Lazy.Builder.Int qualified as LT
 import Data.X509 qualified as X509
-import Imports hiding (cs)
+import Imports
 import Wire.API.MLS.Capabilities
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Credential

--- a/libs/wire-api/src/Wire/API/MLS/Welcome.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Welcome.hs
@@ -18,7 +18,7 @@
 module Wire.API.MLS.Welcome where
 
 import Data.OpenApi qualified as S
-import Imports hiding (cs)
+import Imports
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Commit
 import Wire.API.MLS.KeyPackage

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -51,6 +51,7 @@ import Data.OpenApi (ToParamSchema (..))
 import Data.OpenApi qualified as S
 import Data.SOP
 import Data.Schema
+import Data.Text.Encoding
 import Data.Time.Clock (UTCTime)
 import Data.UUID qualified as UUID
 import Imports
@@ -150,7 +151,7 @@ newtype RawNotificationId = RawNotificationId {unRawNotificationId :: ByteString
   deriving stock (Eq, Show, Generic)
 
 instance FromHttpApiData RawNotificationId where
-  parseUrlPiece = pure . RawNotificationId . cs
+  parseUrlPiece = pure . RawNotificationId . encodeUtf8
 
 instance ToParamSchema RawNotificationId where
   toParamSchema _ = toParamSchema (Proxy @Text)

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -64,7 +64,9 @@ instance PagingTable tables => ToHttpApiData (MultiTablePagingState name tables)
   toQueryParam = (Text.decodeUtf8 . Base64Url.encode) . encodePagingState
 
 instance PagingTable tables => FromHttpApiData (MultiTablePagingState name tables) where
-  parseQueryParam = mapLeft cs . (parsePagingState <=< (Base64Url.decode . Text.encodeUtf8))
+  parseQueryParam =
+    mapLeft Text.pack
+      . (parsePagingState <=< (Base64Url.decode . Text.encodeUtf8))
 
 -- | A class for values that can be encoded with a single byte. Used to add a
 -- byte of extra information to the paging state in order to recover the table

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -72,7 +72,7 @@ import Data.Text.Encoding qualified as Text
 import Data.Typeable
 import GHC.TypeLits
 import Generics.SOP as GSOP
-import Imports hiding (cs)
+import Imports
 import Network.HTTP.Media qualified as M
 import Network.HTTP.Types (hContentType)
 import Network.HTTP.Types qualified as HTTP

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -25,6 +25,7 @@ import Data.Metrics.Servant
 import Data.OpenApi.Lens hiding (HasServer)
 import Data.OpenApi.Operation
 import Data.Proxy
+import Data.Text qualified as T
 import GHC.TypeLits
 import Imports
 import Servant
@@ -42,7 +43,7 @@ class RenderableSymbol a where
   renderSymbol :: Text
 
 instance {-# OVERLAPPABLE #-} KnownSymbol a => RenderableSymbol a where
-  renderSymbol = cs . show $ symbolVal (Proxy @a)
+  renderSymbol = T.pack . show $ symbolVal (Proxy @a)
 
 instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol '(a, b) where
   renderSymbol = "(" <> (renderSymbol @a) <> ", " <> (renderSymbol @b) <> ")"
@@ -55,7 +56,7 @@ instance (HasOpenApi api, RenderableSymbol name) => HasOpenApi (Named name api) 
       dscr :: Text
       dscr =
         " [<a href=\"https://docs.wire.com/developer/developer/servant.html#named-and-internal-route-ids\">internal route ID:</a> "
-          <> cs (renderSymbol @name)
+          <> renderSymbol @name
           <> "]"
 
 instance HasServer api ctx => HasServer (Named name api) ctx where

--- a/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
@@ -21,6 +21,7 @@ import Control.Monad.Except (throwError)
 import Data.ByteString.Conversion
 import Data.EitherR (fmapL)
 import Data.Text qualified as T
+import Data.Text.Lazy (fromStrict)
 import Imports
 import Network.HTTP.Types qualified as HTTP
 import Network.Wai
@@ -44,7 +45,7 @@ versionMiddleware disabledAPIVersions app req k = case parseVersion (removeVersi
     err :: Text -> IO ResponseReceived
     err v =
       k . errorRs' . mkError HTTP.status404 "unsupported-version" $
-        "Version " <> cs v <> " is not supported"
+        "Version " <> fromStrict v <> " is not supported"
 
     errint :: IO ResponseReceived
     errint =

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -61,12 +61,15 @@ import Data.Aeson.Types qualified as A
 import Data.Attoparsec.Text
 import Data.Bifunctor (first)
 import Data.ByteString.Conversion
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.CaseInsensitive qualified as CI
 import Data.OpenApi (ToParamSchema (..))
 import Data.OpenApi qualified as S
 import Data.Schema
 import Data.Text qualified as Text
-import Data.Text.Encoding (decodeUtf8', encodeUtf8)
+import Data.Text.Encoding
+import Data.Text.Encoding.Error
+import Data.Text.Lazy qualified as LT
 import Data.Time.Clock
 import Data.Tuple.Extra (fst3, snd3, thd3)
 import Imports
@@ -189,10 +192,10 @@ instance FromByteString Email where
   parser = parser >>= maybe (fail "Invalid email") pure . parseEmail
 
 instance S.FromHttpApiData Email where
-  parseUrlPiece = maybe (Left "Invalid email") Right . fromByteString . cs
+  parseUrlPiece = maybe (Left "Invalid email") Right . fromByteString . encodeUtf8
 
 instance S.ToHttpApiData Email where
-  toUrlPiece = cs . toByteString'
+  toUrlPiece = decodeUtf8With lenientDecode . toByteString'
 
 instance Arbitrary Email where
   arbitrary = do
@@ -281,10 +284,10 @@ instance FromByteString Phone where
   parser = parser >>= maybe (fail "Invalid phone") pure . parsePhone
 
 instance S.FromHttpApiData Phone where
-  parseUrlPiece = maybe (Left "Invalid phone") Right . fromByteString . cs
+  parseUrlPiece = maybe (Left "Invalid phone") Right . fromByteString . encodeUtf8
 
 instance S.ToHttpApiData Phone where
-  toUrlPiece = cs . toByteString'
+  toUrlPiece = decodeUtf8With lenientDecode . toByteString'
 
 instance Arbitrary Phone where
   arbitrary =
@@ -394,7 +397,7 @@ lenientlyParseSAMLIssuer mbtxt = forM mbtxt $ \txt -> do
       asurl :: Either String SAML.Issuer
       asurl =
         bimap show SAML.Issuer $
-          URI.parseURI URI.laxURIParserOptions (cs txt)
+          URI.parseURI URI.laxURIParserOptions (encodeUtf8 . LT.toStrict $ txt)
 
       err :: String
       err = "lenientlyParseSAMLIssuer: " <> show (asxml, asurl, mbtxt)
@@ -412,11 +415,11 @@ lenientlyParseSAMLNameID (Just txt) = do
         maybe
           (Left "not an email")
           (fmap emailToSAMLNameID . validateEmail)
-          (parseEmail (cs txt))
+          (parseEmail . LT.toStrict $ txt)
 
       astxt :: Either String SAML.NameID
       astxt = do
-        nm <- mkName (cs txt)
+        nm <- mkName . LT.toStrict $ txt
         SAML.mkNameID (SAML.mkUNameIDUnspecified (fromName nm)) Nothing Nothing Nothing
 
       err :: String
@@ -449,7 +452,12 @@ mkSampleUref :: Text -> Text -> SAML.UserRef
 mkSampleUref iseed nseed = SAML.UserRef issuer nameid
   where
     issuer :: SAML.Issuer
-    issuer = SAML.Issuer ([uri|http://example.com/|] & URI.pathL .~ cs ("/" </> cs iseed))
+    issuer =
+      SAML.Issuer
+        ( [uri|http://example.com/|]
+            & URI.pathL
+              .~ UTF8.fromString ("/" </> Text.unpack iseed)
+        )
 
     nameid :: SAML.NameID
     nameid = fromRight (error "impossible") $ do

--- a/libs/wire-api/src/Wire/API/User/RichInfo.hs
+++ b/libs/wire-api/src/Wire/API/User/RichInfo.hs
@@ -133,7 +133,7 @@ ciObject name sch = mkSchema s r w
         desc = S.description ?~ ("json object with case-insensitive fields." :: Text)
 
     r :: A.Value -> A.Parser b
-    r = A.withObject (cs name) f
+    r = A.withObject (Text.unpack name) f
       where
         f :: A.Object -> A.Parser b
         f = schemaIn sch . g
@@ -350,8 +350,8 @@ instance ToSchema RichField where
 instance Arbitrary RichField where
   arbitrary =
     RichField
-      <$> (CI.mk . cs . QC.getPrintableString <$> arbitrary)
-      <*> (cs . QC.getPrintableString <$> arbitrary)
+      <$> (CI.mk . Text.pack . QC.getPrintableString <$> arbitrary)
+      <*> (Text.pack . QC.getPrintableString <$> arbitrary)
   shrink (RichField k v) = RichField <$> QC.shrink k <*> QC.shrink v
 
 --------------------------------------------------------------------------------

--- a/libs/wire-api/src/Wire/API/User/Scim.hs
+++ b/libs/wire-api/src/Wire/API/User/Scim.hs
@@ -61,6 +61,7 @@ import Data.Map qualified as Map
 import Data.Misc (PlainTextPassword6)
 import Data.OpenApi hiding (Operation)
 import Data.Proxy
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time.Clock (UTCTime)
 import Imports
@@ -252,8 +253,8 @@ instance QC.Arbitrary (Scim.User SparTag) where
     where
       addFields :: Scim.User.User tag -> QC.Gen (Scim.User.User tag)
       addFields usr = do
-        gexternalId <- cs . QC.getPrintableString <$$> QC.arbitrary
-        gdisplayName <- cs . QC.getPrintableString <$$> QC.arbitrary
+        gexternalId <- T.pack . QC.getPrintableString <$$> QC.arbitrary
+        gdisplayName <- T.pack . QC.getPrintableString <$$> QC.arbitrary
         gactive <- Just . Scim.ScimBool <$> QC.arbitrary -- (`Nothing` maps on `Just True` and was in the way of a unit test.)
         gemails <- catMaybes <$> (A.decode <$$> QC.listOf (QC.elements ["a@b.c", "x@y,z", "roland@st.uv"]))
         pure
@@ -268,7 +269,7 @@ instance QC.Arbitrary (Scim.User SparTag) where
       genSchemas = QC.listOf1 $ QC.elements Scim.fakeEnumSchema
 
       genUserName :: QC.Gen Text
-      genUserName = cs . QC.getPrintableString <$> QC.arbitrary
+      genUserName = T.pack . QC.getPrintableString <$> QC.arbitrary
 
       genExtra :: QC.Gen ScimUserExtra
       genExtra = QC.arbitrary

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -73,7 +73,7 @@ instance ToParamSchema PagingState where
   toParamSchema _ = toParamSchema (Proxy @Text)
 
 instance FromHttpApiData PagingState where
-  parseQueryParam s = mapLeft cs $ PagingState <$> validateBase64Url s
+  parseQueryParam s = mapLeft T.pack $ PagingState <$> validateBase64Url s
 
 instance ToHttpApiData PagingState where
   toQueryParam = toText . unPagingState

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
@@ -33,6 +33,7 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.ProtoLens.Encoding (decodeMessage, encodeMessage)
 import Data.ProtoLens.Message (Message)
 import Data.ProtoLens.TextFormat (readMessage, showMessage)
+import Data.String.Conversions
 import Data.Text.Lazy.IO qualified as LText
 import Imports
 import Test.Tasty (TestTree)

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
@@ -4,6 +4,7 @@ import Data.Aeson as Aeson
 import Data.Binary.Builder
 import Data.ByteString.Conversion
 import Data.Set as Set
+import Data.String.Conversions
 import Imports
 import Servant.API
 import Test.Tasty

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/Version/Wai.hs
@@ -2,6 +2,7 @@ module Test.Wire.API.Routes.Version.Wai where
 
 import Data.Proxy
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Data.Text as T
 import Imports
 import Network.HTTP.Types.Status (status200, status400)

--- a/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
@@ -20,6 +20,7 @@ module Test.Wire.API.User.Search where
 import Data.Aeson (encode, toJSON)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
+import Data.String.Conversions
 import Imports
 import Test.Tasty qualified as T
 import Test.Tasty.QuickCheck (counterexample, testProperty)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -614,6 +614,7 @@ test-suite wire-api-golden-tests
     , lens
     , pem
     , proto-lens
+    , string-conversions
     , tasty
     , tasty-hunit
     , text
@@ -689,6 +690,7 @@ test-suite wire-api-tests
     , schema-profunctor
     , servant
     , servant-server
+    , string-conversions
     , tasty
     , tasty-hspec
     , tasty-hunit

--- a/libs/wire-subsystems/default.nix
+++ b/libs/wire-subsystems/default.nix
@@ -26,6 +26,7 @@
 , QuickCheck
 , quickcheck-instances
 , retry
+, string-conversions
 , text
 , tinylog
 , types-common
@@ -73,6 +74,7 @@ mkDerivation {
     polysemy-wire-zoo
     QuickCheck
     quickcheck-instances
+    string-conversions
     types-common
     wire-api
   ];

--- a/libs/wire-subsystems/test/unit/Wire/NotificationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/NotificationSubsystem/InterpreterSpec.hs
@@ -8,6 +8,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)), fromList)
 import Data.List1 qualified as List1
 import Data.Range (fromRange, toRange)
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Data.Time.Clock.DiffTime
 import Gundeck.Types.Push.V2 qualified as V2
 import Imports

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -127,6 +127,7 @@ test-suite wire-subsystems-tests
     , polysemy-wire-zoo
     , QuickCheck
     , quickcheck-instances
+    , string-conversions
     , types-common
     , wire-api
     , wire-subsystems

--- a/services/background-worker/background-worker.cabal
+++ b/services/background-worker/background-worker.cabal
@@ -49,6 +49,7 @@ library
     , transformers-base
     , types-common
     , unliftio
+    , utf8-string
     , wai-utilities
     , wire-api
     , wire-api-federation

--- a/services/background-worker/default.nix
+++ b/services/background-worker/default.nix
@@ -37,6 +37,7 @@
 , transformers-base
 , types-common
 , unliftio
+, utf8-string
 , wai
 , wai-utilities
 , wire-api
@@ -71,6 +72,7 @@ mkDerivation {
     transformers-base
     types-common
     unliftio
+    utf8-string
     wai-utilities
     wire-api
     wire-api-federation

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -5,6 +5,7 @@ module Wire.BackgroundWorker where
 import Data.Domain
 import Data.Map.Strict qualified as Map
 import Data.Metrics.Servant qualified as Metrics
+import Data.Text qualified as T
 import Imports
 import Network.AMQP qualified as Q
 import Network.Wai.Utilities.Server
@@ -47,7 +48,7 @@ run opts = do
           -- Close the channel. `extended` will then close the connection, flushing messages to the server.
           Log.info l $ Log.msg $ Log.val "Closing RabbitMQ channel"
           Q.closeChannel chan
-  let server = defaultServer (cs $ opts.backgroundWorker._host) opts.backgroundWorker._port env.logger env.metrics
+  let server = defaultServer (T.unpack $ opts.backgroundWorker._host) opts.backgroundWorker._port env.logger env.metrics
   settings <- newSettings server
   -- Additional cleanup when shutting down via signals.
   runSettingsWithCleanup cleanup settings (servantApp env) Nothing

--- a/services/background-worker/src/Wire/BackgroundWorker/Health.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Health.hs
@@ -1,5 +1,6 @@
 module Wire.BackgroundWorker.Health where
 
+import Data.ByteString.Lazy.UTF8 qualified as UTF8
 import Data.Map.Strict qualified as Map
 import Imports
 import Servant
@@ -17,7 +18,7 @@ statusWorkersImpl = do
   notWorkingWorkers <- Map.keys . Map.filter not <$> (readIORef =<< asks statuses)
   if null notWorkingWorkers
     then pure NoContent
-    else lift $ throwError err500 {errBody = "These workers are not working: " <> cs (show notWorkingWorkers)}
+    else lift $ throwError err500 {errBody = "These workers are not working: " <> UTF8.fromString (show notWorkingWorkers)}
 
 api :: Env -> HealthAPI AsServer
 api env = fromServant $ hoistServer (Proxy @(ToServant HealthAPI AsApi)) (runAppT env) (toServant apiInAppT)

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -351,6 +351,7 @@ library
     , unliftio                   >=0.2
     , unordered-containers       >=0.2
     , uri-bytestring             >=0.2
+    , utf8-string
     , uuid                       >=1.3.5
     , vector                     >=0.11
     , wai                        >=3.0
@@ -496,6 +497,7 @@ executable brig-integration
     , servant-client-core
     , spar
     , streaming-commons
+    , string-conversions
     , tasty                  >=1.0
     , tasty-ant-xml
     , tasty-cannon           >=0.3.4

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -122,6 +122,7 @@
 , statistics
 , stomp-queue
 , streaming-commons
+, string-conversions
 , tasty
 , tasty-ant-xml
 , tasty-cannon
@@ -144,6 +145,7 @@
 , unliftio
 , unordered-containers
 , uri-bytestring
+, utf8-string
 , uuid
 , vector
 , wai
@@ -277,6 +279,7 @@ mkDerivation {
     unliftio
     unordered-containers
     uri-bytestring
+    utf8-string
     uuid
     vector
     wai
@@ -352,6 +355,7 @@ mkDerivation {
     servant-client-core
     spar
     streaming-commons
+    string-conversions
     tasty
     tasty-ant-xml
     tasty-cannon

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -25,6 +25,7 @@ import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Conversion
 import Data.Domain (Domain)
 import Data.Jwt.Tools (DPoPTokenGenerationError (..))
+import Data.Text.Lazy as LT
 import Data.ZAuth.Validation qualified as ZAuth
 import Imports
 import Network.HTTP.Types.Header
@@ -447,7 +448,7 @@ customerExtensionBlockedDomain domain = Wai.mkError (mkStatus 451 "Unavailable F
   where
     msg =
       "[Customer extension] the email domain "
-        <> cs (show domain)
+        <> LT.pack (show domain)
         <> " that you are attempting to register a user with has been \
            \blocked for creating wire users.  Please contact your IT department."
 

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -69,6 +69,8 @@ import Data.Id as Id
 import Data.Map.Strict qualified as Map
 import Data.Qualified
 import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as LT
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.System
 import Imports hiding (head)
@@ -296,24 +298,24 @@ addFederationRemote fedDomConf = do
         "keeping track of remote domains in the brig config file is deprecated, but as long as we \
         \do that, adding a domain with different settings than in the config file is not allowed.  want "
           <> ( "Just "
-                 <> cs (show fedDomConf)
+                 <> T.pack (show fedDomConf)
                  <> "or Nothing, "
              )
           <> ( "got "
-                 <> cs (show (Map.lookup (domain fedDomConf) cfg))
+                 <> T.pack (show (Map.lookup (domain fedDomConf) cfg))
              )
 
 updateFederationRemote :: (Member FederationConfigStore r) => Domain -> FederationDomainConfig -> (Handler r) ()
 updateFederationRemote dom fedcfg = do
   if (dom /= fedcfg.domain)
     then
-      throwError . fedError . FederationUnexpectedError . cs $
+      throwError . fedError . FederationUnexpectedError . T.pack $
         "federation domain of a given peer cannot be changed from " <> show (domain fedcfg) <> " to " <> show dom <> "."
     else
       lift (liftSem (E.updateFederationConfig fedcfg)) >>= \case
         UpdateFederationSuccess -> pure ()
         UpdateFederationRemoteNotFound ->
-          throwError . fedError . FederationUnexpectedError . cs $
+          throwError . fedError . FederationUnexpectedError . T.pack $
             "federation domain does not exist and cannot be updated: " <> show (dom, fedcfg)
         UpdateFederationRemoteDivergingConfig ->
           throwError . fedError . FederationUnexpectedError $
@@ -571,7 +573,13 @@ listActivatedAccounts elh includePendingInvitations = do
 getActivationCodeH :: Maybe Email -> Maybe Phone -> (Handler r) GetActivationCodeResp
 getActivationCodeH (Just email) Nothing = getActivationCode (Left email)
 getActivationCodeH Nothing (Just phone) = getActivationCode (Right phone)
-getActivationCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+getActivationCodeH bade badp =
+  throwStd
+    ( badRequest
+        ( "need exactly one of email, phone: "
+            <> LT.pack (show (bade, badp))
+        )
+    )
 
 getActivationCode :: Either Email Phone -> (Handler r) GetActivationCodeResp
 getActivationCode emailOrPhone = do
@@ -587,7 +595,11 @@ getPasswordResetCodeH ::
   (Handler r) GetPasswordResetCodeResp
 getPasswordResetCodeH (Just email) Nothing = getPasswordResetCode (Left email)
 getPasswordResetCodeH Nothing (Just phone) = getPasswordResetCode (Right phone)
-getPasswordResetCodeH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+getPasswordResetCodeH bade badp =
+  throwStd
+    ( badRequest
+        ("need exactly one of email, phone: " <> LT.pack (show (bade, badp)))
+    )
 
 getPasswordResetCode ::
   ( Member CodeStore r,
@@ -659,7 +671,11 @@ revokeIdentityH ::
   (Handler r) NoContent
 revokeIdentityH (Just email) Nothing = lift $ NoContent <$ API.revokeIdentity (Left email)
 revokeIdentityH Nothing (Just phone) = lift $ NoContent <$ API.revokeIdentity (Right phone)
-revokeIdentityH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+revokeIdentityH bade badp =
+  throwStd
+    ( badRequest
+        ("need exactly one of email, phone: " <> LT.pack (show (bade, badp)))
+    )
 
 updateConnectionInternalH ::
   ( Member GalleyProvider r,
@@ -676,7 +692,11 @@ updateConnectionInternalH updateConn = do
 checkBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) CheckBlacklistResponse
 checkBlacklistH (Just email) Nothing = checkBlacklist (Left email)
 checkBlacklistH Nothing (Just phone) = checkBlacklist (Right phone)
-checkBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+checkBlacklistH bade badp =
+  throwStd
+    ( badRequest
+        ("need exactly one of email, phone: " <> LT.pack (show (bade, badp)))
+    )
 
 checkBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) CheckBlacklistResponse
 checkBlacklist emailOrPhone = lift $ bool NotBlacklisted YesBlacklisted <$> API.isBlacklisted emailOrPhone
@@ -684,7 +704,11 @@ checkBlacklist emailOrPhone = lift $ bool NotBlacklisted YesBlacklisted <$> API.
 deleteFromBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) NoContent
 deleteFromBlacklistH (Just email) Nothing = deleteFromBlacklist (Left email)
 deleteFromBlacklistH Nothing (Just phone) = deleteFromBlacklist (Right phone)
-deleteFromBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+deleteFromBlacklistH bade badp =
+  throwStd
+    ( badRequest
+        ("need exactly one of email, phone: " <> LT.pack (show (bade, badp)))
+    )
 
 deleteFromBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) NoContent
 deleteFromBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistDelete emailOrPhone
@@ -692,7 +716,11 @@ deleteFromBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistDelete email
 addBlacklistH :: Member BlacklistStore r => Maybe Email -> Maybe Phone -> (Handler r) NoContent
 addBlacklistH (Just email) Nothing = addBlacklist (Left email)
 addBlacklistH Nothing (Just phone) = addBlacklist (Right phone)
-addBlacklistH bade badp = throwStd (badRequest ("need exactly one of email, phone: " <> Imports.cs (show (bade, badp))))
+addBlacklistH bade badp =
+  throwStd
+    ( badRequest
+        ("need exactly one of email, phone: " <> LT.pack (show (bade, badp)))
+    )
 
 addBlacklist :: Member BlacklistStore r => Either Email Phone -> (Handler r) NoContent
 addBlacklist emailOrPhone = lift $ NoContent <$ API.blacklistInsert emailOrPhone

--- a/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
@@ -34,7 +34,7 @@ import Data.ByteString qualified as LBS
 import Data.Qualified
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Imports hiding (cs)
+import Imports
 import Wire.API.Error
 import Wire.API.Error.Brig
 import Wire.API.MLS.CipherSuite

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -39,6 +39,7 @@ import Data.Id
 import Data.Misc
 import Data.Set qualified as Set
 import Data.Text.Ascii
+import Data.Text.Encoding qualified as T
 import Data.Time
 import Imports hiding (exp)
 import OpenSSL.Random (randBytes)
@@ -125,13 +126,40 @@ createNewOAuthAuthorizationCode :: UserId -> CreateOAuthAuthorizationCodeRequest
 createNewOAuthAuthorizationCode uid code = do
   runExceptT (validateAndCreateAuthorizationCode uid code) >>= \case
     Right oauthCode ->
-      pure $ CreateOAuthCodeSuccess $ code.redirectUri & addParams [("code", toByteString' oauthCode), ("state", cs code.state)]
+      pure $
+        CreateOAuthCodeSuccess $
+          code.redirectUri
+            & addParams
+              [ ("code", toByteString' oauthCode),
+                ("state", T.encodeUtf8 code.state)
+              ]
     Left CreateNewOAuthCodeErrorFeatureDisabled ->
-      pure $ CreateOAuthCodeFeatureDisabled $ code.redirectUri & addParams [("error", "access_denied"), ("error_description", "OAuth is not enabled"), ("state", cs code.state)]
+      pure $
+        CreateOAuthCodeFeatureDisabled $
+          code.redirectUri
+            & addParams
+              [ ("error", "access_denied"),
+                ("error_description", "OAuth is not enabled"),
+                ("state", T.encodeUtf8 code.state)
+              ]
     Left CreateNewOAuthCodeErrorClientNotFound ->
-      pure $ CreateOAuthCodeClientNotFound $ code.redirectUri & addParams [("error", "access_denied"), ("error_description", "The client ID was not found"), ("state", cs code.state)]
+      pure $
+        CreateOAuthCodeClientNotFound $
+          code.redirectUri
+            & addParams
+              [ ("error", "access_denied"),
+                ("error_description", "The client ID was not found"),
+                ("state", T.encodeUtf8 code.state)
+              ]
     Left CreateNewOAuthCodeErrorUnsupportedResponseType ->
-      pure $ CreateOAuthCodeUnsupportedResponseType $ code.redirectUri & addParams [("error", "access_denied"), ("error_description", "The client ID was not found"), ("state", cs code.state)]
+      pure $
+        CreateOAuthCodeUnsupportedResponseType $
+          code.redirectUri
+            & addParams
+              [ ("error", "access_denied"),
+                ("error_description", "The client ID was not found"),
+                ("state", T.encodeUtf8 code.state)
+              ]
     Left CreateNewOAuthCodeErrorRedirectUrlMissMatch ->
       pure CreateOAuthCodeRedirectUrlMissMatch
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -157,7 +157,7 @@ import Data.Misc
 import Data.Qualified
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
 import Data.UUID.V4 (nextRandom)
-import Imports hiding (cs)
+import Imports
 import Network.Wai.Utilities
 import Polysemy
 import Polysemy.Input (Input)

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -48,6 +48,7 @@ import Data.Handle (Handle, parseHandle)
 import Data.Id
 import Data.Maybe
 import Data.Qualified
+import Data.Text qualified as T
 import Data.Text.Ascii (AsciiText (toText))
 import Imports
 import Polysemy
@@ -88,7 +89,7 @@ validateHandle = maybe (throwStd (errorToWai @'InvalidHandle)) pure . parseHandl
 
 logEmail :: Email -> (Msg -> Msg)
 logEmail email =
-  Log.field "email_sha256" (sha256String . cs . show $ email)
+  Log.field "email_sha256" (sha256String . T.pack . show $ email)
 
 logInvitationCode :: InvitationCode -> (Msg -> Msg)
 logInvitationCode code = Log.field "invitation_code" (toText $ fromInvitationCode code)

--- a/services/brig/src/Brig/Effects/JwtTools.hs
+++ b/services/brig/src/Brig/Effects/JwtTools.hs
@@ -12,6 +12,8 @@ import Data.Jwt.Tools qualified as Jwt
 import Data.Misc (HttpsUrl)
 import Data.Nonce (Nonce)
 import Data.PEMKeys
+import Data.Text.Encoding
+import Data.Text.Encoding.Error
 import Imports
 import Network.HTTP.Types (StdMethod (..))
 import Network.HTTP.Types qualified as HTTP
@@ -77,4 +79,4 @@ interpretJwtTools = interpret $ \case
         )
   where
     urlEncode :: Text -> Text
-    urlEncode = cs . HTTP.urlEncode False . cs
+    urlEncode = decodeUtf8With lenientDecode . HTTP.urlEncode False . encodeUtf8

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -32,6 +32,7 @@ import Control.Monad.Catch
 import Control.Retry
 import Data.Aeson (FromJSON)
 import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy.UTF8 qualified as UTF8
 import Data.Credentials (Credentials (..))
 import Data.Metrics qualified as Metrics
 import Database.Bloodhound qualified as ES
@@ -130,7 +131,7 @@ waitForTaskToComplete timeoutSeconds taskNodeId = do
     throwM $
       ReindexFromAnotherIndexError $
         "Task failed with error: "
-          <> cs (Aeson.encode $ ES.taskResponseError task)
+          <> UTF8.toString (Aeson.encode $ ES.taskResponseError task)
   where
     isTaskComplete :: Either ES.EsError (ES.TaskResponse a) -> m Bool
     isTaskComplete (Left e) = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -56,6 +56,7 @@ import Data.Id
 import Data.List1 qualified as List1
 import Data.Qualified (Local)
 import Data.Range
+import Data.Text.Lazy qualified as LT
 import Data.Time.Clock (UTCTime)
 import Imports hiding (head)
 import Network.Wai.Utilities hiding (code, message)
@@ -201,7 +202,12 @@ logInvitationRequest context action =
     eith <- action'
     case eith of
       Left err' -> do
-        Log.warn $ context . Log.msg @Text ("Failed to create invitation, label: " <> (cs . errorLabel) err')
+        Log.warn $
+          context
+            . Log.msg @Text
+              ( "Failed to create invitation, label: "
+                  <> (LT.toStrict . errorLabel) err'
+              )
         pure (Left err')
       Right result@(_, code) -> do
         Log.info $ (context . logInvitationCode code) . Log.msg @Text "Successfully created invitation"

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -56,7 +56,7 @@ import Data.Metrics qualified as Metrics
 import Data.Proxy
 import Data.RetryAfter
 import Data.Time.Clock
-import Imports hiding (cs)
+import Imports
 import Network.Wai (Response)
 import Network.Wai.Utilities.Response (addHeader)
 import System.Logger.Class (field, msg, val, (~~))

--- a/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
@@ -22,7 +22,7 @@ import Data.RetryAfter
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Vector qualified as Vector
-import Imports hiding (cs)
+import Imports
 import Statistics.Sample qualified as Stats
 import Wire.API.User.Auth
 

--- a/services/brig/src/Brig/User/Auth/DB/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/DB/Cookie.hs
@@ -23,7 +23,7 @@ import Brig.User.Auth.DB.Instances ()
 import Cassandra
 import Data.Id
 import Data.Time.Clock
-import Imports hiding (cs)
+import Imports
 import Wire.API.User.Auth
 
 newtype TTL = TTL {ttlSeconds :: Int32}

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -36,6 +36,7 @@ import Data.ByteString.Conversion
 import Data.Handle (Handle)
 import Data.Id (UserId)
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import Imports hiding (head)
 import Network.HTTP.Types.Method
 import Polysemy (Member)
@@ -118,7 +119,7 @@ ejpdRequest (fromMaybe False -> includeContacts) (EJPDRequestBody handles) = do
             case (statusCode resp, responseJsonEither resp) of
               (200, Right (A.String loc)) -> loc
               _ ->
-                cs $
+                T.pack $
                   "could not fetch asset: "
                     <> show key
                     <> ", error: "

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -33,6 +33,7 @@ import Brig.User.Search.Index
 import Control.Error (lastMay)
 import Control.Monad.Catch (MonadThrow (throwM))
 import Data.Aeson (decode', encode)
+import Data.ByteString (fromStrict, toStrict)
 import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
 import Data.Text.Ascii (decodeBase64Url, encodeBase64Url)
@@ -66,10 +67,10 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> siz
   either (throwM . IndexLookupError) (pure . mkResult) r
   where
     toSearchAfterKey :: PagingState -> Maybe ES.SearchAfterKey
-    toSearchAfterKey ps = decode' . cs =<< (decodeBase64Url . unPagingState $ ps)
+    toSearchAfterKey ps = decode' . fromStrict =<< (decodeBase64Url . unPagingState $ ps)
 
     fromSearchAfterKey :: ES.SearchAfterKey -> PagingState
-    fromSearchAfterKey = PagingState . encodeBase64Url . cs . encode
+    fromSearchAfterKey = PagingState . encodeBase64Url . toStrict . encode
 
     mkResult es =
       let hitsPlusOne = ES.hits . ES.searchHits $ es

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -33,6 +33,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Misc (Port (..), mkHttpsUrl)
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Imports
 import System.FilePath ((</>))
 import Test.Tasty

--- a/services/brig/test/integration/API/Internal/Util.hs
+++ b/services/brig/test/integration/API/Internal/Util.hs
@@ -31,6 +31,7 @@ import Control.Lens ((^.))
 import Control.Monad.Catch (MonadCatch)
 import Data.Id
 import Data.Proxy (Proxy (Proxy))
+import Data.String.Conversions
 import Imports
 import Servant.API ((:>))
 import Servant.API.ContentTypes (NoContent)

--- a/services/brig/test/integration/API/OAuth.hs
+++ b/services/brig/test/integration/API/OAuth.hs
@@ -37,6 +37,7 @@ import Data.Id
 import Data.Qualified (Qualified (qUnqualified))
 import Data.Range
 import Data.Set as Set hiding (delete, null, (\\))
+import Data.String.Conversions
 import Data.Text.Ascii (encodeBase16)
 import Data.Text.Encoding qualified as T
 import Data.Time

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -43,6 +43,7 @@ import Data.Handle (fromHandle)
 import Data.Id
 import Data.Map.Strict qualified as Map
 import Data.Qualified (Qualified (qDomain, qUnqualified))
+import Data.String.Conversions
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Database.Bloodhound qualified as ES

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -26,6 +26,7 @@ import Data.Domain (Domain)
 import Data.Id
 import Data.Qualified (Qualified (..))
 import Data.Range (Range)
+import Data.String.Conversions
 import Data.Text.Encoding (encodeUtf8)
 import Database.Bloodhound qualified as ES
 import Imports

--- a/services/brig/test/integration/API/SystemSettings.hs
+++ b/services/brig/test/integration/API/SystemSettings.hs
@@ -24,6 +24,7 @@ import Control.Lens
 import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Conversion (toByteString')
 import Data.Id
+import Data.String.Conversions
 import Imports
 import Network.Wai.Test as WaiTest
 import Test.Tasty

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -28,6 +28,7 @@ import Data.ByteString.Conversion (toByteString)
 import Data.Handle (fromHandle)
 import Data.Id (TeamId, UserId)
 import Data.Range (unsafeRange)
+import Data.String.Conversions
 import Imports
 import System.Random.Shuffle (shuffleM)
 import Test.Tasty (TestTree, testGroup)

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -57,6 +57,7 @@ import Data.Proxy
 import Data.Qualified
 import Data.Range
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Data.Text qualified as T
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as T

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -53,7 +53,7 @@ import Data.Text.Lazy qualified as Lazy
 import Data.Time.Clock
 import Data.UUID.V4 qualified as UUID
 import Data.ZAuth.Token qualified as ZAuth
-import Imports hiding (cs)
+import Imports
 import Network.HTTP.Client (equivCookie)
 import Network.Wai.Utilities.Error qualified as Error
 import Test.Tasty

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -52,6 +52,7 @@ import Data.Nonce (isValidBase64UrlEncodedUUID)
 import Data.Qualified (Qualified (..))
 import Data.Range (unsafeRange)
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Data.Text.Ascii (AsciiChars (validate), encodeBase64UrlUnpadded, toText)
 import Data.Text.Encoding qualified as T
 import Data.Time (addUTCTime)

--- a/services/brig/test/integration/API/User/PasswordReset.hs
+++ b/services/brig/test/integration/API/User/PasswordReset.hs
@@ -30,7 +30,7 @@ import Cassandra qualified as DB
 import Data.Aeson as A
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Misc
-import Imports hiding (cs)
+import Imports
 import Test.Tasty hiding (Timeout)
 import Util
 import Wire.API.User

--- a/services/brig/test/integration/API/User/Property.hs
+++ b/services/brig/test/integration/API/User/Property.hs
@@ -27,6 +27,7 @@ import Brig.Options
 import Brig.Options qualified as Opt
 import Data.Aeson
 import Data.ByteString.Char8 qualified as C
+import Data.String.Conversions
 import Data.Text qualified as T
 import Imports
 import Network.Wai.Utilities.Error qualified as Error

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -47,6 +47,7 @@ import Data.List1 qualified as List1
 import Data.Misc
 import Data.Qualified
 import Data.Range (unsafeRange)
+import Data.String.Conversions
 import Data.Text.Ascii qualified as Ascii
 import Data.Vector qualified as Vec
 import Data.ZAuth.Token qualified as ZAuth

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -36,6 +36,7 @@ import Data.Aeson.Lens (key, _String)
 import Data.ByteString.Conversion (fromByteString, toByteString')
 import Data.Id (InvitationId, TeamId, UserId)
 import Data.Range (unsafeRange)
+import Data.String.Conversions
 import Data.Text.Encoding (encodeUtf8)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -38,7 +38,7 @@ import Data.Qualified
 import Data.Range (checked)
 import Data.Set qualified as Set
 import Federation.Util
-import Imports hiding (cs)
+import Imports
 import System.IO.Temp
 import System.Logger qualified as Log
 import Test.Tasty

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -61,6 +61,7 @@ import Data.Proxy
 import Data.Qualified hiding (isLocal)
 import Data.Range
 import Data.Sequence qualified as Seq
+import Data.String.Conversions
 import Data.Text qualified as T
 import Data.Text qualified as Text
 import Data.Text.Ascii qualified as Ascii

--- a/services/cannon/src/Cannon/Types.hs
+++ b/services/cannon/src/Cannon/Types.hs
@@ -126,7 +126,7 @@ lookupReqId :: Logger -> Request -> IO RequestId
 lookupReqId l r = case lookup requestIdName (requestHeaders r) of
   Just rid -> pure $ RequestId rid
   Nothing -> do
-    localRid <- RequestId . cs . UUID.toText <$> UUID.nextRandom
+    localRid <- RequestId . UUID.toASCIIBytes <$> UUID.nextRandom
     Log.info l $
       "request-id" .= localRid
         ~~ "method" .= requestMethod r

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -67,7 +67,7 @@ import Data.List.Extra (chunksOf)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Timeout (TimeoutUnit (..), (#))
 import Gundeck.Types
-import Imports hiding (cs, threadDelay)
+import Imports hiding (threadDelay)
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -33,6 +33,8 @@ import Data.Domain
 import Data.Id
 import Data.Kind
 import Data.Qualified
+import Data.Text.Encoding
+import Data.Text.Encoding.Error
 import Imports hiding (head)
 import qualified Network.HTTP.Types as HTTP
 import Servant.API
@@ -88,7 +90,11 @@ iDownloadAssetV3 key = do
   where
     -- (NB: don't use HttpsUrl here, as in some test environments we legitimately use "http"!)
     render :: URI.URI -> Text
-    render = cs . Builder.toLazyByteString . URI.serializeURIRef
+    render =
+      decodeUtf8With lenientDecode
+        . LBS.toStrict
+        . Builder.toLazyByteString
+        . URI.serializeURIRef
 
 class HasLocation (tag :: PrincipalTag) where
   assetLocation :: Local AssetKey -> [Text]

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -104,7 +104,7 @@ mkApp o = Codensity $ \k ->
     lookupReqId l r = case lookup requestIdName $ Wai.requestHeaders r of
       Just rid -> pure $ RequestId rid
       Nothing -> do
-        localRid <- RequestId . cs . UUID.toText <$> UUID.nextRandom
+        localRid <- RequestId . UUID.toASCIIBytes <$> UUID.nextRandom
         Log.info l $
           "request-id" .= localRid
             ~~ "method" .= Wai.requestMethod r

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -52,6 +52,7 @@
 , servant-client
 , servant-client-core
 , servant-server
+, string-conversions
 , tasty
 , tasty-hunit
 , tasty-quickcheck
@@ -61,6 +62,7 @@
 , transformers
 , types-common
 , unix
+, utf8-string
 , uuid
 , wai
 , wai-extra
@@ -120,6 +122,7 @@ mkDerivation {
     transformers
     types-common
     unix
+    utf8-string
     uuid
     wai
     wai-utilities
@@ -154,6 +157,7 @@ mkDerivation {
     QuickCheck
     random
     servant-client-core
+    string-conversions
     tasty-hunit
     text
     types-common
@@ -188,6 +192,7 @@ mkDerivation {
     servant-client
     servant-client-core
     servant-server
+    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -147,6 +147,7 @@ library
     , transformers
     , types-common
     , unix
+    , utf8-string
     , uuid
     , wai
     , wai-utilities
@@ -303,6 +304,7 @@ executable federator-integration
     , QuickCheck
     , random
     , servant-client-core
+    , string-conversions
     , tasty-hunit
     , text
     , types-common
@@ -404,6 +406,7 @@ test-suite federator-tests
     , servant-client
     , servant-client-core
     , servant-server
+    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/federator/src/Federator/Discovery.hs
+++ b/services/federator/src/Federator/Discovery.hs
@@ -96,7 +96,7 @@ runFederatorDiscovery = interpret $ \case
     -- FUTUREWORK(federation): This string conversion is wrong, we should encode
     -- this using IDNA encoding or expect domain to be bytestring everywhere
     -- (https://wearezeta.atlassian.net/browse/SQCORE-912)
-    domainSrv d = cs $ "_wire-server-federator._tcp." <> domainText d
+    domainSrv d = Text.encodeUtf8 $ "_wire-server-federator._tcp." <> domainText d
 
 lookupDomainByDNS ::
   ( Member DNSLookup r,

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -148,7 +148,7 @@ callInward component (RPC rpc) mReqId originDomain (CertHeader cert) wreq = do
   rid <- case mReqId of
     Just r -> pure r
     Nothing -> do
-      localRid <- liftIO $ RequestId . cs . UUID.toText <$> UUID.nextRandom
+      localRid <- liftIO $ RequestId . Text.encodeUtf8 . UUID.toText <$> UUID.nextRandom
       info $
         "request-id" .= localRid
           ~~ "method" .= Wai.requestMethod wreq

--- a/services/federator/src/Federator/Health.hs
+++ b/services/federator/src/Federator/Health.hs
@@ -1,5 +1,7 @@
 module Federator.Health where
 
+import Data.ByteString (fromStrict)
+import Data.ByteString.UTF8 qualified as UTF8
 import Imports
 import Network.HTTP.Client
 import Network.HTTP.Types.Status qualified as HTTP
@@ -20,4 +22,11 @@ status mgr otherName otherPort False = do
   res <- liftIO $ httpNoBody req mgr
   if HTTP.statusIsSuccessful $ responseStatus res
     then pure NoContent
-    else throwError Servant.err500 {Servant.errBody = otherName <> " server responded with status code = " <> cs (show (responseStatus res))}
+    else
+      throwError
+        Servant.err500
+          { Servant.errBody =
+              otherName
+                <> " server responded with status code = "
+                <> (fromStrict . UTF8.fromString . show . responseStatus $ res)
+          }

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -27,6 +27,7 @@ import Data.Domain
 import Data.Id
 import Data.Metrics.Servant qualified as Metrics
 import Data.Proxy
+import Data.Text.Encoding qualified as T
 import Data.UUID as UUID
 import Data.UUID.V4 as UUID
 import Federator.Env
@@ -117,7 +118,7 @@ callOutward mReqId targetDomain component (RPC path) req = do
   rid <- case mReqId of
     Just r -> pure r
     Nothing -> do
-      localRid <- liftIO $ RequestId . cs . UUID.toText <$> UUID.nextRandom
+      localRid <- liftIO $ RequestId . T.encodeUtf8 . UUID.toText <$> UUID.nextRandom
       info $
         "request-id" .= localRid
           ~~ "method" .= Wai.requestMethod req

--- a/services/federator/src/Federator/Response.hs
+++ b/services/federator/src/Federator/Response.hs
@@ -29,6 +29,7 @@ import Control.Lens
 import Control.Monad.Codensity
 import Data.ByteString.Builder
 import Data.Kind
+import Data.Text qualified as T
 import Federator.Discovery
 import Federator.Env
 import Federator.Error
@@ -172,7 +173,7 @@ getFederationDomainConfigs :: Env -> IO FedUp.FederationDomainConfigs
 getFederationDomainConfigs env = do
   let mgr = env ^. httpManager
       Endpoint h p = env ^. service $ Brig
-      baseurl = BaseUrl Http (cs h) (fromIntegral p) ""
+      baseurl = BaseUrl Http (T.unpack h) (fromIntegral p) ""
       clientEnv = mkClientEnv mgr baseurl
   FedUp.getFederationDomainConfigs clientEnv >>= \case
     Right v -> pure v

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -94,7 +94,7 @@ interpretServiceHTTP = interpret $ \case
               path = rpcPath,
               requestHeaders =
                 [ ("Content-Type", "application/json"),
-                  (originDomainHeaderName, cs (domainText domain)),
+                  (originDomainHeaderName, Text.encodeUtf8 (domainText domain)),
                   (RPC.requestIdName, unRequestId rid)
                 ]
                   <> headers

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -25,6 +25,7 @@ import Data.Binary.Builder
 import Data.Domain
 import Data.Id
 import Data.LegalHold (UserLegalHoldStatus (UserLegalHoldNoConsent))
+import Data.String.Conversions
 import Data.Text.Encoding qualified as Text
 import Federator.Discovery
 import Federator.Monitor (FederationSetupError)

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -37,6 +37,7 @@ import Data.Aeson.Types qualified as Aeson
 import Data.ByteString.Char8 qualified as C8
 import Data.Id
 import Data.Misc
+import Data.String.Conversions
 import Data.Text qualified as Text
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID

--- a/services/federator/test/unit/Test/Federator/ExternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/ExternalServer.hs
@@ -24,6 +24,7 @@ import Data.ByteString qualified as BS
 import Data.Default
 import Data.Domain
 import Data.Sequence as Seq
+import Data.String.Conversions
 import Data.Text.Encoding qualified as Text
 import Federator.Discovery
 import Federator.Error.ServerError (ServerError (..))

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -89,6 +89,7 @@
 , ssl-util
 , stm
 , streaming-commons
+, string-conversions
 , tagged
 , tasty
 , tasty-ant-xml
@@ -109,6 +110,7 @@
 , unliftio
 , unordered-containers
 , uri-bytestring
+, utf8-string
 , uuid
 , uuid-types
 , vector
@@ -206,6 +208,7 @@ mkDerivation {
     types-common-journal
     unliftio
     uri-bytestring
+    utf8-string
     uuid
     wai
     wai-extra
@@ -281,6 +284,7 @@ mkDerivation {
     sop-core
     ssl-util
     streaming-commons
+    string-conversions
     tagged
     tasty
     tasty-ant-xml

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -357,6 +357,7 @@ library
     , types-common-journal   >=0.1
     , unliftio               >=0.2
     , uri-bytestring         >=0.2
+    , utf8-string
     , uuid                   >=1.3
     , wai                    >=3.0
     , wai-extra              >=3.0
@@ -527,6 +528,7 @@ executable galley-integration
     , sop-core
     , ssl-util
     , streaming-commons
+    , string-conversions
     , tagged
     , tasty                  >=0.8
     , tasty-ant-xml

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -26,6 +26,7 @@ where
 
 import Control.Exception.Safe (catchAny)
 import Control.Lens hiding (Getter, Setter, (.=))
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.Id as Id
 import Data.Json.Util (ToJSONObject (toJSONObject))
 import Data.Map qualified as Map
@@ -453,7 +454,7 @@ safeForever :: String -> App () -> App ()
 safeForever funName action =
   forever $
     action `catchAny` \exc -> do
-      err $ "error" .= show exc ~~ msg (val $ cs funName <> " failed")
+      err $ "error" .= show exc ~~ msg (val $ UTF8.fromString funName <> " failed")
       threadDelay 60000000 -- pause to keep worst-case noise in logs manageable
 
 guardLegalholdPolicyConflictsH ::

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -33,7 +33,7 @@ import Galley.API.MLS.Types
 import Galley.API.MLS.Util
 import Galley.Effects
 import Galley.Effects.MemberStore
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Resource (Resource)

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -30,7 +30,7 @@ import Galley.API.MLS.Types
 import Galley.Data.Conversation.Types qualified as Data
 import Galley.Effects.ConversationStore
 import Galley.Types.UserList
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Protocol

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -48,7 +48,7 @@ import Galley.Effects.BrigAccess
 import Galley.Effects.ProposalStore
 import Galley.Env
 import Galley.Options
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -42,7 +42,7 @@ import Galley.Effects.ProposalStore
 import Galley.Effects.SubConversationStore
 import Galley.Env
 import Galley.Types.Conversations.Members
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -50,7 +50,7 @@ import Galley.Effects
 import Galley.Effects.FederatorAccess
 import Galley.Effects.MemberStore qualified as Eff
 import Galley.Effects.SubConversationStore qualified as Eff
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -27,7 +27,7 @@ import Data.Qualified
 import GHC.Records (HasField (..))
 import Galley.Data.Conversation.Types
 import Galley.Types.Conversations.Members
-import Imports hiding (cs)
+import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.MLS.CipherSuite

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -34,7 +34,7 @@ import Galley.API.Push
 import Galley.Effects.ExternalAccess
 import Galley.Effects.FederatorAccess
 import Gundeck.Types.Push.V2 (RecipientClients (..))
-import Imports hiding (cs)
+import Imports
 import Network.Wai.Utilities.JSONResponse
 import Polysemy
 import Polysemy.Input

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -79,7 +79,7 @@ import Galley.Env
 import Galley.Options
 import Galley.Types.Conversations.Members
 import Galley.Types.Teams
-import Imports hiding (cs)
+import Imports
 import Network.Wai
 import Network.Wai.Predicate hiding (Error, result, setStatus)
 import Network.Wai.Utilities hiding (Error)

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -38,6 +38,7 @@ where
 
 import Control.Lens
 import Data.ByteString.Conversion (toByteString')
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.Id
 import Data.Json.Util
 import Data.Kind
@@ -204,7 +205,7 @@ pushFeatureConfigEvent tid event = do
       P.warn $
         Log.field "action" (Log.val "Features.pushFeatureConfigEvent")
           . Log.field "feature" (Log.val (toByteString' . Event._eventFeatureName $ event))
-          . Log.field "team" (Log.val (cs . show $ tid))
+          . Log.field "team" (Log.val (UTF8.fromString . show $ tid))
           . Log.msg @Text "Fanout limit exceeded. Events will not be sent."
     else do
       let recipients = membersToRecipients Nothing (memList ^. teamMembers)

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -48,7 +48,7 @@ import Galley.Effects.ConversationStore (ConversationStore (..))
 import Galley.Types.Conversations.Members
 import Galley.Types.ToUserRole
 import Galley.Types.UserList
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Input
 import Polysemy.TinyLog

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -44,7 +44,7 @@ import Galley.Effects.MemberStore (MemberStore (..))
 import Galley.Types.Conversations.Members
 import Galley.Types.ToUserRole
 import Galley.Types.UserList
-import Imports hiding (Set, cs)
+import Imports hiding (Set)
 import Polysemy
 import Polysemy.Input
 import Polysemy.TinyLog

--- a/services/galley/src/Galley/Cassandra/Store.hs
+++ b/services/galley/src/Galley/Cassandra/Store.hs
@@ -21,7 +21,7 @@ module Galley.Cassandra.Store
 where
 
 import Cassandra
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Input
 

--- a/services/galley/src/Galley/Cassandra/SubConversation.hs
+++ b/services/galley/src/Galley/Cassandra/SubConversation.hs
@@ -33,7 +33,7 @@ import Galley.Cassandra.Queries qualified as Cql
 import Galley.Cassandra.Store (embedClient)
 import Galley.Cassandra.Util
 import Galley.Effects.SubConversationStore (SubConversationStore (..))
-import Imports hiding (cs)
+import Imports
 import Polysemy
 import Polysemy.Input
 import Polysemy.TinyLog

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -46,6 +46,7 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Qualified
+import Data.Text qualified as Text
 import Data.Text.Lazy qualified as Lazy
 import Galley.API.Error
 import Galley.Env
@@ -253,11 +254,11 @@ runHereClientM action = do
   mgr <- view manager
   brigep <- view brig
   let env = Client.mkClientEnv mgr baseurl
-      baseurl = Client.BaseUrl Client.Http (cs $ brigep ^. host) (fromIntegral $ brigep ^. port) ""
+      baseurl = Client.BaseUrl Client.Http (Text.unpack $ brigep ^. host) (fromIntegral $ brigep ^. port) ""
   liftIO $ Client.runClientM action env
 
 handleServantResp ::
   Either Client.ClientError a ->
   App a
 handleServantResp (Right cfg) = pure cfg
-handleServantResp (Left errmsg) = throwM . internalErrorWithDescription . cs . show $ errmsg
+handleServantResp (Left errmsg) = throwM . internalErrorWithDescription . Lazy.pack . show $ errmsg

--- a/services/galley/src/Galley/Monad.hs
+++ b/services/galley/src/Galley/Monad.hs
@@ -26,7 +26,7 @@ import Control.Lens
 import Control.Monad.Catch
 import Control.Monad.Except
 import Galley.Env
-import Imports hiding (cs, log)
+import Imports hiding (log)
 import Polysemy
 import Polysemy.Input
 import System.Logger

--- a/services/galley/test/integration/API/Federation/Util.hs
+++ b/services/galley/test/integration/API/Federation/Util.hs
@@ -29,6 +29,7 @@ where
 import Data.Kind
 import Data.Qualified
 import Data.SOP
+import Data.String.Conversions
 import GHC.TypeLits
 import Imports
 import Servant

--- a/services/galley/test/integration/API/Teams/LegalHold/Util.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/Util.hs
@@ -30,6 +30,7 @@ import Data.List1 qualified as List1
 import Data.Misc (PlainTextPassword6)
 import Data.PEM
 import Data.Streaming.Network (bindRandomPortTCP)
+import Data.String.Conversions
 import Data.Tagged
 import Data.Text.Encoding (encodeUtf8)
 import Galley.Options

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -65,6 +65,7 @@ import Data.Range
 import Data.Serialize (runPut)
 import Data.Set qualified as Set
 import Data.Singletons
+import Data.String.Conversions
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as T
 import Data.Text.Encoding qualified as Text

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -57,6 +57,7 @@
 , safe-exceptions
 , scientific
 , servant-server
+, string-conversions
 , tagged
 , tasty
 , tasty-ant-xml
@@ -205,6 +206,7 @@ mkDerivation {
     quickcheck-instances
     quickcheck-state-machine
     scientific
+    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -474,6 +474,7 @@ test-suite gundeck-tests
     , quickcheck-instances
     , quickcheck-state-machine
     , scientific
+    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -187,7 +187,7 @@ lookupReqId :: Logger -> Request -> IO RequestId
 lookupReqId l r = case lookup requestIdName (requestHeaders r) of
   Just rid -> pure $ RequestId rid
   Nothing -> do
-    localRid <- RequestId . cs . UUID.toText <$> UUID.nextRandom
+    localRid <- RequestId . UUID.toASCIIBytes <$> UUID.nextRandom
     Log.info l $
       "request-id" .= localRid
         ~~ "method" .= requestMethod r

--- a/services/gundeck/src/Gundeck/Notification/Data.hs
+++ b/services/gundeck/src/Gundeck/Notification/Data.hs
@@ -39,7 +39,7 @@ import Data.Sequence qualified as Seq
 import Gundeck.Env
 import Gundeck.Options (NotificationTTL (..), internalPageSize, maxPayloadLoadSize, settings)
 import Gundeck.Push.Native.Serialise ()
-import Imports hiding (cs)
+import Imports
 import UnliftIO (pooledForConcurrentlyN_)
 import UnliftIO.Async (pooledMapConcurrentlyN)
 import Wire.API.Internal.Notification

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -62,7 +62,7 @@ import Gundeck.ThreadBudget
 import Gundeck.Types
 import Gundeck.Types.Presence qualified as Presence
 import Gundeck.Util
-import Imports hiding (cs)
+import Imports
 import Network.HTTP.Types
 import Network.Wai.Utilities
 import System.Logger.Class (msg, val, (+++), (.=), (~~))

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -44,7 +44,7 @@ import Gundeck.Monad
 import Gundeck.Presence.Data qualified as Presence
 import Gundeck.Types.Presence
 import Gundeck.Util
-import Imports hiding (cs)
+import Imports
 import Network.HTTP.Client (HttpExceptionContent (..))
 import Network.HTTP.Client.Internal qualified as Http
 import Network.HTTP.Types (StdMethod (POST), status200, status410)

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -102,7 +102,7 @@ run o = do
         Just rid -> do
           mkapp (RequestId rid) req cont
         Nothing -> do
-          localRid <- RequestId . cs . UUID.toText <$> UUID.nextRandom
+          localRid <- RequestId . UUID.toASCIIBytes <$> UUID.nextRandom
           Log.info logger $
             "request-id" .= localRid
               ~~ "method" .= Wai.requestMethod req

--- a/services/gundeck/test/unit/MockGundeck.hs
+++ b/services/gundeck/test/unit/MockGundeck.hs
@@ -61,6 +61,7 @@ import Data.Misc (Milliseconds (Ms))
 import Data.Range
 import Data.Scientific qualified as Scientific
 import Data.Set qualified as Set
+import Data.String.Conversions
 import Gundeck.Aws.Arn as Aws
 import Gundeck.Options
 import Gundeck.Push

--- a/services/gundeck/test/unit/ThreadBudget.hs
+++ b/services/gundeck/test/unit/ThreadBudget.hs
@@ -30,6 +30,7 @@ import Control.Concurrent.Async
 import Control.Lens
 import Control.Monad.Catch (MonadCatch, catch)
 import Data.Metrics.Middleware (metrics)
+import Data.String.Conversions
 import Data.Time
 import GHC.Generics
 import Gundeck.Options

--- a/services/proxy/src/Proxy/Proxy.hs
+++ b/services/proxy/src/Proxy/Proxy.hs
@@ -17,11 +17,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Proxy.Proxy
-  ( Proxy,
-    runProxy,
-  )
-where
+module Proxy.Proxy (Proxy, runProxy) where
 
 import Bilge.Request (requestIdName)
 import Control.Lens hiding ((.=))
@@ -40,7 +36,7 @@ import System.Logger.Class hiding (Error, info)
 newtype Proxy a = Proxy
   { unProxy :: ReaderT Env IO a
   }
-  deriving
+  deriving newtype
     ( Functor,
       Applicative,
       Monad,
@@ -68,7 +64,7 @@ lookupReqId :: Logger -> Request -> IO RequestId
 lookupReqId l r = case lookup requestIdName (requestHeaders r) of
   Just rid -> pure $ RequestId rid
   Nothing -> do
-    localRid <- RequestId . cs . UUID.toText <$> UUID.nextRandom
+    localRid <- RequestId . UUID.toASCIIBytes <$> UUID.nextRandom
     Log.info l $
       "request-id" .= localRid
         ~~ "method" .= requestMethod r

--- a/services/spar/default.nix
+++ b/services/spar/default.nix
@@ -59,6 +59,7 @@
 , servant-openapi3
 , servant-server
 , silently
+, string-conversions
 , tasty-hunit
 , text
 , text-latin1
@@ -67,6 +68,7 @@
 , transformers
 , types-common
 , uri-bytestring
+, utf8-string
 , uuid
 , vector
 , wai
@@ -125,6 +127,7 @@ mkDerivation {
     transformers
     types-common
     uri-bytestring
+    utf8-string
     uuid
     wai
     wai-utilities
@@ -179,6 +182,7 @@ mkDerivation {
     servant
     servant-server
     silently
+    string-conversions
     tasty-hunit
     text
     time
@@ -186,6 +190,7 @@ mkDerivation {
     transformers
     types-common
     uri-bytestring
+    utf8-string
     uuid
     vector
     wai-extra
@@ -220,6 +225,7 @@ mkDerivation {
     saml2-web-sso
     servant
     servant-openapi3
+    string-conversions
     time
     tinylog
     types-common

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -189,6 +189,7 @@ library
     , transformers
     , types-common
     , uri-bytestring
+    , utf8-string
     , uuid
     , wai
     , wai-utilities
@@ -377,6 +378,7 @@ executable spar-integration
     , servant-server
     , silently
     , spar
+    , string-conversions
     , tasty-hunit
     , text
     , time
@@ -472,6 +474,7 @@ executable spar-migrate-data
     , tinylog
     , types-common
     , uri-bytestring
+    , utf8-string
 
   default-language:   Haskell2010
 
@@ -626,6 +629,7 @@ test-suite spec
     , servant
     , servant-openapi3
     , spar
+    , string-conversions
     , time
     , tinylog
     , types-common

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -46,6 +46,10 @@ import Bilge (ResponseLBS, responseBody, responseJsonMaybe)
 import qualified Bilge
 import Control.Monad.Except
 import Data.Aeson
+import qualified Data.ByteString.UTF8 as UTF8
+import Data.Text.Encoding.Error
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy.Encoding as LText
 import Data.Typeable (typeRep)
 import GHC.Stack (callStack, prettyCallStack)
 import Imports
@@ -134,7 +138,10 @@ sparToServerErrorWithLogging logger err = do
 
 servantToWaiError :: ServerError -> Wai.Error
 servantToWaiError (ServerError code phrase body _headers) =
-  Wai.mkError (Status code (cs phrase)) (cs phrase) (cs body)
+  Wai.mkError
+    (Status code (UTF8.fromString phrase))
+    (LText.pack phrase)
+    (LText.decodeUtf8With lenientDecode body)
 
 sparToServerError :: SparError -> ServerError
 sparToServerError = either id waiToServant . renderSparError
@@ -143,7 +150,7 @@ waiToServant :: Wai.Error -> ServerError
 waiToServant waierr =
   ServerError
     { errHTTPCode = statusCode (Wai.code waierr),
-      errReasonPhrase = cs (Wai.label waierr),
+      errReasonPhrase = LText.unpack (Wai.label waierr),
       errBody = encode waierr,
       errHeaders = []
     }
@@ -164,23 +171,41 @@ renderSparError (SAML.CustomError SparReAuthCodeAuthFailed) = Right $ Wai.mkErro
 renderSparError (SAML.CustomError SparReAuthCodeAuthRequired) = Right $ Wai.mkError status403 "code-authentication-required" "Reauthentication failed. Verification code required."
 renderSparError (SAML.CustomError SparCouldNotRetrieveCookie) = Right $ Wai.mkError status502 "bad-upstream" "Unable to get a cookie from an upstream server."
 renderSparError (SAML.CustomError (SparCassandraError msg)) = Right $ Wai.mkError status500 "server-error" msg -- TODO: should we be more specific here and make it 'db-error'?
-renderSparError (SAML.CustomError (SparCassandraTTLError ttlerr)) = Right $ Wai.mkError status400 "ttl-error" (cs $ show ttlerr)
+renderSparError (SAML.CustomError (SparCassandraTTLError ttlerr)) =
+  Right $
+    Wai.mkError
+      status400
+      "ttl-error"
+      (LText.pack $ show ttlerr)
 renderSparError (SAML.UnknownIdP msg) = Right $ Wai.mkError status404 "not-found" ("IdP not found: " <> msg)
 renderSparError (SAML.Forbidden msg) = Right $ Wai.mkError status403 "forbidden" ("Forbidden: " <> msg)
-renderSparError (SAML.BadSamlResponseBase64Error msg) = Right $ Wai.mkError status400 "bad-response-encoding" ("Bad response: base64 error: " <> cs msg)
-renderSparError (SAML.BadSamlResponseXmlError msg) = Right $ Wai.mkError status400 "bad-response-xml" ("Bad response: XML parse error: " <> cs msg)
-renderSparError (SAML.BadSamlResponseSamlError msg) = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: SAML parse error: " <> cs msg)
+renderSparError (SAML.BadSamlResponseBase64Error msg) =
+  Right $
+    Wai.mkError status400 "bad-response-encoding" ("Bad response: base64 error: " <> msg)
+renderSparError (SAML.BadSamlResponseXmlError msg) =
+  Right $
+    Wai.mkError status400 "bad-response-xml" ("Bad response: XML parse error: " <> msg)
+renderSparError (SAML.BadSamlResponseSamlError msg) =
+  Right $
+    Wai.mkError status400 "bad-response-saml" ("Bad response: SAML parse error: " <> msg)
 renderSparError SAML.BadSamlResponseFormFieldMissing = Right $ Wai.mkError status400 "bad-response-saml" "Bad response: SAMLResponse form field missing from HTTP body"
 renderSparError SAML.BadSamlResponseIssuerMissing = Right $ Wai.mkError status400 "bad-response-saml" "Bad response: no Issuer in AuthnResponse"
 renderSparError SAML.BadSamlResponseNoAssertions = Right $ Wai.mkError status400 "bad-response-saml" "Bad response: no assertions in AuthnResponse"
 renderSparError SAML.BadSamlResponseAssertionWithoutID = Right $ Wai.mkError status400 "bad-response-saml" "Bad response: assertion without ID"
-renderSparError (SAML.BadSamlResponseInvalidSignature msg) = Right $ Wai.mkError status400 "bad-response-signature" (cs msg)
+renderSparError (SAML.BadSamlResponseInvalidSignature msg) =
+  Right $
+    Wai.mkError status400 "bad-response-signature" msg
 renderSparError (SAML.CustomError (SparIdPNotFound "")) = Right $ Wai.mkError status404 "not-found" "Could not find IdP."
 renderSparError (SAML.CustomError (SparIdPNotFound msg)) = Right $ Wai.mkError status404 "not-found" ("Could not find IdP: " <> msg)
 renderSparError (SAML.CustomError SparSamlCredentialsNotFound) = Right $ Wai.mkError status404 "not-found" "Could not find SAML credentials, and auto-provisioning is disabled."
 renderSparError (SAML.CustomError SparMissingZUsr) = Right $ Wai.mkError status400 "client-error" "[header] 'Z-User' required"
 renderSparError (SAML.CustomError SparNotInTeam) = Right $ Wai.mkError status403 "no-team-member" "Requesting user is not a team member or not a member of this team."
-renderSparError (SAML.CustomError (SparNoPermission perm)) = Right $ Wai.mkError status403 "insufficient-permissions" ("You need permission " <> cs perm <> ".")
+renderSparError (SAML.CustomError (SparNoPermission perm)) =
+  Right $
+    Wai.mkError
+      status403
+      "insufficient-permissions"
+      ("You need permission " <> perm <> ".")
 renderSparError (SAML.CustomError SparSSODisabled) = Right $ Wai.mkError status403 "sso-disabled" "Please ask customer support to enable this feature for your team."
 renderSparError SAML.UnknownError = Right $ Wai.mkError status500 "server-error" "Unknown server error."
 renderSparError (SAML.BadServerConfig msg) = Right $ Wai.mkError status500 "server-error" ("Error in server config: " <> msg)
@@ -233,7 +258,7 @@ rethrow serviceName resp = do
           ( SAML.CustomError
               . SparCouldNotParseRfcResponse serviceName
               . ("internal error: " <>)
-              . cs
+              . LText.pack
               . show
               . (Bilge.statusCode resp,)
               . fromMaybe "<empty body>"
@@ -245,10 +270,10 @@ rethrow serviceName resp = do
 parseResponse :: forall a m. (FromJSON a, MonadError SparError m, Typeable a) => LText -> ResponseLBS -> m a
 parseResponse serviceName resp = do
   let typeinfo :: LText
-      typeinfo = cs $ show (typeRep ([] @a)) <> ": "
+      typeinfo = LText.pack $ show (typeRep ([] @a)) <> ": "
 
       err :: forall a'. LText -> m a'
       err = throwSpar . SparCouldNotParseRfcResponse serviceName . (typeinfo <>)
 
   bdy <- maybe (err "no body") pure $ responseBody resp
-  either (err . cs) pure $ eitherDecode' bdy
+  either (err . LText.pack) pure $ eitherDecode' bdy

--- a/services/spar/src/Spar/Intra/BrigApp.hs
+++ b/services/spar/src/Spar/Intra/BrigApp.hs
@@ -52,6 +52,8 @@ import Data.ByteString.Conversion
 import qualified Data.CaseInsensitive as CI
 import Data.Handle (Handle (Handle))
 import Data.Id (TeamId, UserId)
+import Data.Text.Encoding
+import Data.Text.Encoding.Error
 import Imports
 import Polysemy
 import Polysemy.Error
@@ -178,7 +180,7 @@ giveDefaultHandle :: (HasCallStack, Member BrigAccess r) => User -> Sem r Handle
 giveDefaultHandle usr = case userHandle usr of
   Just handle -> pure handle
   Nothing -> do
-    let handle = Handle . cs . toByteString' $ uid
+    let handle = Handle . decodeUtf8With lenientDecode . toByteString' $ uid
         uid = userId usr
     BrigAccess.setHandle uid handle
     pure handle

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -26,6 +26,7 @@ import Control.Lens
 import Control.Monad.Except
 import Data.ByteString.Conversion
 import Data.Id (TeamId, UserId)
+import qualified Data.Text.Lazy as LText
 import Imports
 import Network.HTTP.Types.Method
 import Spar.Error
@@ -85,7 +86,7 @@ assertHasPermission tid perm uid = do
         . paths ["i", "teams", toByteString' tid, "members", toByteString' uid]
   case (statusCode resp, parseResponse @TeamMember "galley" resp) of
     (200, Right member) | hasPermission member perm -> pure ()
-    _ -> throwSpar (SparNoPermission (cs $ show perm))
+    _ -> throwSpar (SparNoPermission (LText.pack $ show perm))
 
 assertSSOEnabled ::
   (HasCallStack, MonadError SparError m, MonadSparToGalley m) =>

--- a/services/spar/src/Spar/Orphans.hs
+++ b/services/spar/src/Spar/Orphans.hs
@@ -24,6 +24,7 @@ module Spar.Orphans
   )
 where
 
+import qualified Data.Text.Lazy as LText
 import Imports
 import qualified SAML2.WebSSO as SAML
 import Servant (MimeRender (..), PlainText)
@@ -35,4 +36,4 @@ instance MimeRender PlainText Void where
   mimeRender _ = error "instance MimeRender HTML Void: impossible"
 
 instance MakeCustomError "wai-error" IdPMetadataInfo where
-  makeCustomError = sparToServerError . SAML.CustomError . SparNewIdPBadMetadata . cs
+  makeCustomError = sparToServerError . SAML.CustomError . SparNewIdPBadMetadata . LText.pack

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -38,10 +38,12 @@ where
 import Control.Lens hiding (Strict, (.=))
 import qualified Data.ByteString.Base64 as ES
 import Data.Id (ScimTokenId, UserId)
-import Imports
 -- FUTUREWORK: these imports are not very handy.  split up Spar.Scim into
 -- Spar.Scim.{Core,User,Group} to avoid at least some of the hscim name clashes?
 
+import qualified Data.Text.Encoding as T
+import Data.Text.Encoding.Error
+import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
@@ -133,7 +135,9 @@ createScimToken zusr Api.CreateScimToken {..} = do
 
   let caseOneOrNoIdP :: Maybe SAML.IdPId -> Sem r CreateScimTokenResponse
       caseOneOrNoIdP midpid = do
-        token <- ScimToken . cs . ES.encode <$> Random.bytes 32
+        token <-
+          ScimToken . T.decodeUtf8With lenientDecode . ES.encode
+            <$> Random.bytes 32
         tokenid <- Random.scimTokenId
         -- FUTUREWORK(fisx): the fact that we're using @Now.get@
         -- here means that the 'Now' effect should not contain

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -38,9 +38,6 @@ where
 import Control.Lens hiding (Strict, (.=))
 import qualified Data.ByteString.Base64 as ES
 import Data.Id (ScimTokenId, UserId)
--- FUTUREWORK: these imports are not very handy.  split up Spar.Scim into
--- Spar.Scim.{Core,User,Group} to avoid at least some of the hscim name clashes?
-
 import qualified Data.Text.Encoding as T
 import Data.Text.Encoding.Error
 import Imports

--- a/services/spar/src/Spar/Sem/SAML2/Library.hs
+++ b/services/spar/src/Spar/Sem/SAML2/Library.hs
@@ -24,6 +24,7 @@ module Spar.Sem.SAML2.Library (saml2ToSaml2WebSso) where
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Except
 import Data.Id (TeamId)
+import qualified Data.Text.Lazy as LText
 import Imports
 import Polysemy
 import Polysemy.Error
@@ -53,7 +54,13 @@ wrapMonadClientSPImpl ::
   SPImpl r a
 wrapMonadClientSPImpl action =
   SPImpl action
-    `Catch.catch` (SPImpl . throw . SAML.CustomError . SparCassandraError . cs . show @SomeException)
+    `Catch.catch` ( SPImpl
+                      . throw
+                      . SAML.CustomError
+                      . SparCassandraError
+                      . LText.pack
+                      . show @SomeException
+                  )
 
 instance Member (Final IO) r => Catch.MonadThrow (SPImpl r) where
   throwM = SPImpl . embedFinal . Catch.throwM @IO

--- a/services/spar/test-integration/Test/LoggingSpec.hs
+++ b/services/spar/test-integration/Test/LoggingSpec.hs
@@ -21,6 +21,7 @@ module Test.LoggingSpec
 where
 
 import Control.Lens
+import Data.String.Conversions
 import Imports
 import Network.HTTP.Types.Status (statusCode)
 import qualified Network.Wai.Test as HW

--- a/services/spar/test-integration/Test/MetricsSpec.hs
+++ b/services/spar/test-integration/Test/MetricsSpec.hs
@@ -25,6 +25,7 @@ where
 
 import Bilge
 import Control.Lens
+import Data.String.Conversions
 import Imports
 import Util
 

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -34,6 +34,7 @@ import Data.Id
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Misc
 import Data.Proxy
+import Data.String.Conversions
 import qualified Data.Text as ST
 import qualified Data.Text as T
 import Data.Text.Ascii (decodeBase64, validateBase64)

--- a/services/spar/test-integration/Test/Spar/AppSpec.hs
+++ b/services/spar/test-integration/Test/Spar/AppSpec.hs
@@ -28,6 +28,7 @@ import Control.Lens
 import qualified Data.ByteString.Builder as Builder
 import Data.Id
 import qualified Data.List as List
+import Data.String.Conversions
 import Imports
 import SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.Test.MockResponse as SAML

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -37,6 +37,7 @@ import qualified Data.Code as Code
 import Data.Id (ScimTokenId, TeamId, UserId, randomId)
 import Data.Misc
 import Data.Range (unsafeRange)
+import Data.String.Conversions
 import Data.Text.Ascii (AsciiChars (validate))
 import Data.Time (UTCTime)
 import Data.Time.Clock (getCurrentTime)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -50,6 +50,7 @@ import Data.Id (TeamId, UserId, randomId)
 import Data.Ix (inRange)
 import Data.LanguageCodes (ISO639_1 (..))
 import Data.Misc (HttpsUrl, mkHttpsUrl)
+import Data.String.Conversions
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import qualified Data.Vector as V
 import qualified Data.ZAuth.Token as ZAuth

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -161,6 +161,7 @@ import Data.Id
 import Data.Misc (PlainTextPassword6, plainTextPassword6Unsafe)
 import Data.Proxy
 import Data.Range
+import Data.String.Conversions
 import Data.Text (pack)
 import qualified Data.Text.Ascii as Ascii
 import Data.Text.Encoding (encodeUtf8)

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -30,6 +30,7 @@ import qualified Data.ByteString.Lazy as Lazy
 import Data.Handle (Handle (Handle))
 import Data.Id
 import Data.LanguageCodes (ISO639_1 (EN))
+import Data.String.Conversions
 import qualified Data.Text.Lazy as Lazy
 import Data.Time
 import Data.UUID as UUID

--- a/services/spar/test/Arbitrary.hs
+++ b/services/spar/test/Arbitrary.hs
@@ -26,6 +26,7 @@ import Data.Aeson
 import Data.Id (TeamId, UserId)
 import Data.OpenApi hiding (Header (..))
 import Data.Proxy
+import Data.String.Conversions
 import Imports
 import SAML2.WebSSO.Test.Arbitrary ()
 import SAML2.WebSSO.Types

--- a/services/spar/test/Test/Spar/Intra/BrigSpec.hs
+++ b/services/spar/test/Test/Spar/Intra/BrigSpec.hs
@@ -20,6 +20,7 @@
 module Test.Spar.Intra.BrigSpec where
 
 import Arbitrary ()
+import Data.String.Conversions
 import Imports
 import SAML2.WebSSO as SAML
 import Spar.Intra.BrigApp

--- a/tools/db/inconsistencies/src/DanglingHandles.hs
+++ b/tools/db/inconsistencies/src/DanglingHandles.hs
@@ -51,7 +51,7 @@ runCommand l brig inconsistenciesFile = do
               pure userHandles
           )
         .| C.mapM (liftIO . pooledMapConcurrentlyN 48 (\(handle, userId, claimTime) -> checkUser l brig handle userId claimTime False))
-        .| C.map ((<> "\n") . BS.intercalate "\n" . map (cs . Aeson.encode) . catMaybes)
+        .| C.map ((<> "\n") . BS.intercalate "\n" . map (BS.toStrict . Aeson.encode) . catMaybes)
         .| sinkFile inconsistenciesFile
 
 examineHandles :: Logger -> ClientState -> FilePath -> FilePath -> Bool -> IO ()
@@ -68,7 +68,7 @@ examineHandles l brig handlesFile errorsFile fixClaim = do
                 Log.info l (Log.field "handlesProcesses" i)
               liftIO $ checkHandle l brig handle fixClaim
           )
-        .| C.map ((<> "\n") . cs . Aeson.encode)
+        .| C.map ((<> "\n") . BS.toStrict . Aeson.encode)
         .| sinkFile errorsFile
 
 pageSize :: Int32

--- a/tools/db/inconsistencies/src/DanglingUserKeys.hs
+++ b/tools/db/inconsistencies/src/DanglingUserKeys.hs
@@ -54,7 +54,7 @@ runCommand l brig inconsistenciesFile = do
               pure userKeys
           )
         .| C.mapM (liftIO . pooledMapConcurrentlyN 48 (\(key, uid, claimTime) -> checkUser l brig key uid claimTime False))
-        .| C.map ((<> "\n") . BS.intercalate "\n" . map (cs . Aeson.encode) . catMaybes)
+        .| C.map ((<> "\n") . BS.intercalate "\n" . map (BS.toStrict . Aeson.encode) . catMaybes)
         .| sinkFile inconsistenciesFile
 
 runRepair :: Logger -> ClientState -> FilePath -> FilePath -> Bool -> IO ()
@@ -71,7 +71,7 @@ runRepair l brig inputFile outputFile repairData = do
                 Log.info l (Log.field "keysProcesses" i)
               liftIO $ checkKey l brig key repairData
           )
-        .| C.map ((<> "\n") . cs . Aeson.encode)
+        .| C.map ((<> "\n") . BS.toStrict . Aeson.encode)
         .| sinkFile outputFile
 
 pageSize :: Int32

--- a/tools/db/inconsistencies/src/EmailLessUsers.hs
+++ b/tools/db/inconsistencies/src/EmailLessUsers.hs
@@ -54,7 +54,7 @@ runCommand l brig inconsistenciesFile = do
               pure $ mapMaybe userWithEmailAndStatus userDetails
           )
         .| C.mapM (liftIO . pooledMapConcurrentlyN 48 (checkUser l brig False))
-        .| C.map ((<> "\n") . BS.intercalate "\n" . map (cs . Aeson.encode) . catMaybes)
+        .| C.map ((<> "\n") . BS.intercalate "\n" . map (BS.toStrict . Aeson.encode) . catMaybes)
         .| sinkFile inconsistenciesFile
 
 runRepair :: Logger -> ClientState -> FilePath -> FilePath -> Bool -> IO ()
@@ -71,7 +71,7 @@ runRepair l brig inputFile outputFile repairData = do
                 Log.info l (Log.field "linesProcessed" i)
               liftIO $ repairUser l brig repairData uid
           )
-        .| C.map ((<> "\n") . cs . Aeson.encode)
+        .| C.map ((<> "\n") . BS.toStrict . Aeson.encode)
         .| sinkFile outputFile
 
 pageSize :: Int32

--- a/tools/db/inconsistencies/src/HandleLessUsers.hs
+++ b/tools/db/inconsistencies/src/HandleLessUsers.hs
@@ -49,7 +49,7 @@ runCommand l brig inconsistenciesFile = do
               pure $ mapMaybe userWithHandleAndStatus userDetails
           )
         .| C.mapM (liftIO . pooledMapConcurrentlyN 48 (checkUser brig))
-        .| C.map ((<> "\n") . BS.intercalate "\n" . map (cs . Aeson.encode) . catMaybes)
+        .| C.map ((<> "\n") . BS.intercalate "\n" . map (BS.toStrict . Aeson.encode) . catMaybes)
         .| sinkFile inconsistenciesFile
 
 pageSize :: Int32

--- a/tools/db/move-team/src/ParseSchema.hs
+++ b/tools/db/move-team/src/ParseSchema.hs
@@ -26,7 +26,7 @@ import Data.Aeson (ToJSON, object, (.=))
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Text.Lazy.IO qualified as TIO
-import Imports hiding (cs)
+import Imports
 import Options.Applicative qualified as OA
 import System.Environment (withArgs)
 import System.Exit (exitFailure)

--- a/tools/db/repair-handles/src/Options.hs
+++ b/tools/db/repair-handles/src/Options.hs
@@ -19,6 +19,7 @@ module Options where
 
 import Cassandra hiding (Set)
 import Data.Id
+import Data.Text qualified as T
 import Data.UUID
 import Imports
 import Options.Applicative hiding (action)
@@ -55,7 +56,7 @@ cassandraSettingsParser ks =
           <> value 9042
           <> showDefault
       )
-    <*> ( Keyspace . cs
+    <*> ( Keyspace . T.pack
             <$> strOption
               ( long ("cassandra-keyspace-" ++ ks)
                   <> metavar "STRING"

--- a/tools/db/repair-handles/src/Work.hs
+++ b/tools/db/repair-handles/src/Work.hs
@@ -51,7 +51,7 @@ readHandleMap Env {..} =
     insertAndLog :: (HandleMap, Int) -> [(Maybe UserId, Maybe Handle)] -> IO (HandleMap, Int)
     insertAndLog (hmap, nTotal) pairs = do
       let n = length pairs
-      Log.info envLogger $ Log.msg @Text $ "handles loaded: " <> (cs . show $ nTotal + n)
+      Log.info envLogger $ Log.msg @Text $ "handles loaded: " <> (T.pack . show $ nTotal + n)
       pure (foldl' insert hmap pairs, nTotal + n)
 
     insert :: HandleMap -> (Maybe UserId, Maybe Handle) -> HandleMap
@@ -167,7 +167,7 @@ runCommand env@Env {..} = do
     handleAction :: Env -> ActionResult -> IO ()
     handleAction _env (Left err) = Log.err envLogger (Log.msg . show $ err)
     handleAction _env (Right action) = do
-      Log.debug envLogger $ Log.msg @Text (cs . show $ action)
+      Log.debug envLogger $ Log.msg (show $ action)
       unless (envSettings ^. setDryRun) $
         executeAction env action
 
@@ -189,7 +189,7 @@ runCommand env@Env {..} = do
       where
         mark :: Text -> Int -> Maybe Text
         mark msg n
-          | n > 0 = Just $ msg <> ": " <> cs (show n)
+          | n > 0 = Just $ msg <> ": " <> T.pack (show n)
           | otherwise = Nothing
 
         tally :: (Int, Int, Int, Int) -> ActionResult -> (Int, Int, Int, Int)

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -36,6 +36,7 @@
 , servant-server
 , servant-swagger-ui
 , split
+, string-conversions
 , tagged
 , tasty
 , tasty-ant-xml
@@ -45,6 +46,7 @@
 , transformers
 , types-common
 , unliftio
+, utf8-string
 , uuid
 , wai
 , wai-routing
@@ -87,6 +89,7 @@ mkDerivation {
     transformers
     types-common
     unliftio
+    utf8-string
     uuid
     wai
     wai-routing
@@ -114,6 +117,7 @@ mkDerivation {
     random
     retry
     schema-profunctor
+    string-conversions
     tagged
     tasty
     tasty-ant-xml

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -101,6 +101,7 @@ library
     , transformers           >=0.3
     , types-common           >=0.4.13
     , unliftio
+    , utf8-string
     , uuid                   >=1.3
     , wai                    >=3.0
     , wai-routing            >=0.10
@@ -266,6 +267,7 @@ executable stern-integration
     , retry
     , schema-profunctor
     , stern
+    , string-conversions
     , tagged
     , tasty                  >=0.8
     , tasty-ant-xml

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -35,6 +35,7 @@ import Data.Id
 import Data.Range (unsafeRange)
 import Data.Schema
 import Data.Set qualified as Set
+import Data.String.Conversions
 import GHC.TypeLits
 import Imports
 import Stern.API.Routes (UserConnectionGroups (..))


### PR DESCRIPTION
The PR removes all usages of the `cs` function (from `ConvertibleStrings`) in the application code.

Tracked by https://wearezeta.atlassian.net/browse/WPB-7222.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
