### PR TITLE
Revert "[chore] use `PathInfo` consistently" [skip-ci]

### DIFF
--- a/hack/bin/Sbom.hs
+++ b/hack/bin/Sbom.hs
@@ -267,7 +267,7 @@ discoverSBom :: FilePath -> MetaDB -> IO SBom
 discoverSBom outP metaDb = do
   canonicalOutP <- canonicalizePath =<< getSymbolicLinkTarget outP
   info <- pathInfo canonicalOutP
-  let go :: PathInfo -> IO SBom -> IO SBom
+  let go :: (Text, (Text, [Text])) -> IO SBom -> IO SBom
       go (k, (deriver, deps)) = do
         let proxyToIdentity :: SBomMeta Proxy -> SBomMeta Identity
             proxyToIdentity (MkSBomMeta {..}) = MkSBomMeta {directDeps = Identity deps, outPath = Identity k, ..}


### PR DESCRIPTION
@supersven this was actually no `PathInfo`, it just looked similar :eyes:

This reverts commit 71c8c596d5b8024847730d2aac6a5eec1edb4b9b.

## Checklist

 - ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~ n/a
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
