### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2024-04-18-production.0-v0.31.21-0-5f19577

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2024-01-22-production.1-v0.31.17-0-7f83dbe"
+  tag: "2024-04-18-production.0-v0.31.21-0-5f19577"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2024-04-18-production.0-v0.31.21-0-5f19577`
Release: [`2024-04-18-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2024-04-18-production.0)