### PR TITLE
Add gzip middlewares to spar and proxy

### DIFF
--- a/changelog.d/1-api-changes/gzip
+++ b/changelog.d/1-api-changes/gzip
@@ -1,0 +1,1 @@
+Add gzip request support to spar and proxy

--- a/services/proxy/default.nix
+++ b/services/proxy/default.nix
@@ -27,6 +27,7 @@
 , unliftio-core
 , uuid
 , wai
+, wai-middleware-gunzip
 , wai-predicates
 , wai-routing
 , wai-utilities
@@ -61,6 +62,7 @@ mkDerivation {
     unliftio-core
     uuid
     wai
+    wai-middleware-gunzip
     wai-predicates
     wai-routing
     wai-utilities

--- a/services/proxy/proxy.cabal
+++ b/services/proxy/proxy.cabal
@@ -74,31 +74,32 @@ library
     -funbox-strict-fields -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      aeson               >=2.0.1.0
-    , base                >=4.6     && <5
-    , bilge               >=0.21
-    , bytestring          >=0.10
-    , case-insensitive    >=1.2
-    , configurator        >=0.3
-    , exceptions          >=0.8
+      aeson                  >=2.0.1.0
+    , base                   >=4.6     && <5
+    , bilge                  >=0.21
+    , bytestring             >=0.10
+    , case-insensitive       >=1.2
+    , configurator           >=0.3
+    , exceptions             >=0.8
     , extended
-    , http-client         >=0.7
-    , http-client-tls     >=0.3
-    , http-reverse-proxy  >=0.4
-    , http-types          >=0.9
+    , http-client            >=0.7
+    , http-client-tls        >=0.3
+    , http-reverse-proxy     >=0.4
+    , http-types             >=0.9
     , imports
-    , lens                >=4.11
-    , metrics-wai         >=0.5
-    , retry               >=0.7
-    , text                >=1.2
-    , tinylog             >=0.12
-    , types-common        >=0.8
+    , lens                   >=4.11
+    , metrics-wai            >=0.5
+    , retry                  >=0.7
+    , text                   >=1.2
+    , tinylog                >=0.12
+    , types-common           >=0.8
     , unliftio-core
     , uuid
-    , wai                 >=3.2
-    , wai-predicates      >=0.8
-    , wai-routing         >=0.12
-    , wai-utilities       >=0.14.3
+    , wai                    >=3.2
+    , wai-middleware-gunzip
+    , wai-predicates         >=0.8
+    , wai-routing            >=0.12
+    , wai-utilities          >=0.14.3
     , wire-api
 
   default-language:   GHC2021

--- a/services/proxy/src/Proxy/Run.hs
+++ b/services/proxy/src/Proxy/Run.hs
@@ -25,6 +25,7 @@ import Control.Monad.Catch
 import Data.Metrics.Middleware hiding (path)
 import Data.Metrics.Middleware.Prometheus (waiPrometheusMiddleware)
 import Imports hiding (head)
+import Network.Wai.Middleware.Gunzip qualified as GZip
 import Network.Wai.Utilities.Server hiding (serverPort)
 import Proxy.API (sitemap)
 import Proxy.Env
@@ -43,5 +44,6 @@ run o = do
   let middleware =
         versionMiddleware (foldMap expandVersionExp (o ^. disabledAPIVersions))
           . waiPrometheusMiddleware (sitemap e)
+          . GZip.gunzip
           . catchErrors (e ^. applog) [Right m]
   runSettingsWithShutdown s (middleware app) Nothing `finally` destroyEnv e

--- a/services/spar/default.nix
+++ b/services/spar/default.nix
@@ -73,6 +73,7 @@
 , vector
 , wai
 , wai-extra
+, wai-middleware-gunzip
 , wai-utilities
 , warp
 , wire-api
@@ -130,6 +131,7 @@ mkDerivation {
     utf8-string
     uuid
     wai
+    wai-middleware-gunzip
     wai-utilities
     warp
     wire-api

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -192,11 +192,11 @@ library
     , utf8-string
     , uuid
     , wai
+    , wai-middleware-gunzip
     , wai-utilities
     , warp
     , wire-api
     , yaml
-    , wai-middleware-gunzip
 
   default-language:   Haskell2010
 

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -196,6 +196,7 @@ library
     , warp
     , wire-api
     , yaml
+    , wai-middleware-gunzip
 
   default-language:   Haskell2010
 

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -42,6 +42,7 @@ import Imports
 import Network.Wai (Application)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Middleware.Gunzip as GZip
 import Network.Wai.Utilities.Request (lookupRequestId)
 import qualified Network.Wai.Utilities.Server as WU
 import qualified SAML2.WebSSO as SAML
@@ -104,6 +105,7 @@ mkApp sparCtxOpts = do
         versionMiddleware (foldMap expandVersionExp (disabledAPIVersions sparCtxOpts))
           . WU.heavyDebugLogging heavyLogOnly logLevel sparCtxLogger
           . servantPrometheusMiddleware (Proxy @SparAPI)
+          . GZip.gunzip
           . WU.catchErrors sparCtxLogger []
           -- Error 'Response's are usually not thrown as exceptions, but logged in
           -- 'renderSparErrorWithLogging' before the 'Application' can construct a 'Response'


### PR DESCRIPTION
Add gzip middlewares to spar and proxy. This makes it possible for clients to uniformly use gzipped requests across all endpoints.

https://wearezeta.atlassian.net/browse/WPB-8718

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
