### PR TITLE
Fix openssl example in docs

### DIFF
--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -39,7 +39,7 @@ openssl genpkey -algorithm ed25519
 ECDSA private keys can be generated with:
 
 ```
-openssl genpkey -algorithm ec -genparam dsa -pkeyopt ec_paramgen_curve:P-256
+openssl genpkey -algorithm ec -pkeyopt ec_paramgen_curve:P-256
 ```
 
 and similar (replace `P-256` with `P-384` or `P-521`).


### PR DESCRIPTION
The example command line for generating an ECDSA private key with `openssl` was incorrect.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
