### PR TITLE
[chore] don't use treefmt for hlint, readd the remove hlint rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,31 @@ ghcid:
 
 # Used by CI
 .PHONY: lint-all
-lint-all: treefmt-check check-local-nix-derivations
+lint-all: treefmt-check check-local-nix-derivations hlint-check-all
+
+.PHONY: hlint-check-all
+hlint-check-all:
+	./tools/hlint.sh -f all -m check
+
+.PHONY: hlint-inplace-all
+hlint-inplace-all:
+	./tools/hlint.sh -f all -m inplace
+
+.PHONY: hlint-check-pr
+hlint-check-pr:
+	./tools/hlint.sh -f pr -m check
+
+.PHONY: hlint-inplace-pr
+hlint-inplace-pr:
+	./tools/hlint.sh -f pr -m inplace
+
+.PHONY: hlint-check
+hlint-check:
+	./tools/hlint.sh -f changeset -m check
+
+.PHONY: hlint-inplace
+hlint-inplace:
+	./tools/hlint.sh -f changeset -m inplace
 
 .PHONY: hlint-inplace-all
 hlint-inplace-all:

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -18,11 +18,6 @@ options = [
   "--check-idempotence",
 ]
 
-[formatter.hlint]
-command = "hlint"
-includes = ["*.hs"]
-excludes = [ "dist*" ]
-
 [formatter.shellcheck]
 command = "shellcheck"
 includes = ["*.sh"]


### PR DESCRIPTION
This is a follow up for #4000  because caching gets invalidated by running with a subset of formatters (see https://github.com/numtide/treefmt/issues/286) we don't use hlint in treefmt at all. This is a bit unfortunate, I think we can readd it though at some point 

## Checklist

 - n/a~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
