### PR TITLE
Generalise catchErrors middleware

### DIFF
--- a/changelog.d/5-internal/federator-request-id
+++ b/changelog.d/5-internal/federator-request-id
@@ -1,0 +1,1 @@
+Log federator request ID on exceptions

--- a/services/federator/src/Federator/Response.hs
+++ b/services/federator/src/Federator/Response.hs
@@ -119,13 +119,16 @@ serveServant ::
   IO ()
 serveServant middleware server env port =
   Warp.run port
-    . Wai.catchErrors (view applog env) []
+    . Wai.catchErrorsWithRequestId getRequestId (view applog env) []
     . middleware
     $ app
   where
     app :: Wai.Application
     app =
       genericServe server
+
+    getRequestId :: Wai.Request -> Maybe ByteString
+    getRequestId = lookup "Wire-Origin-Request-Id" . Wai.requestHeaders
 
 type AllEffects =
   '[ Metrics,


### PR DESCRIPTION
Make it possible for services to specify a different way to extract the ID of a request. For federator requests, the ID is in a different header, so the `catchErrors` middleware needs to be aware of the difference when logging.

Related to: https://wearezeta.atlassian.net/browse/WPB-7161

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
