### PR TITLE
[WPB-5360] update the nginz nginx module to support nginx 1.26

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -76,10 +76,10 @@ self: super: {
   };
 
   nginz = (super.nginx.overrideAttrs rec {
-    version = "1.22.1";
+    version = "1.26.0";
     src = super.fetchurl {
       url = "https://nginx.org/download/nginx-${version}.tar.gz";
-      hash = "sha256-nrszOp6CuVKs0+K0rrHU/2QG9ySRurbNn+afDepzfzE=";
+      hash = "sha256-0ubIQ51sbbUBXY6qskcKtSrvhae/NjGCh5l34IQ3BJc=";
     };
   }).override {
     modules = [

--- a/services/nginz/third_party/nginx-zauth-module/zauth_module.c
+++ b/services/nginz/third_party/nginx-zauth-module/zauth_module.c
@@ -469,8 +469,8 @@ static ngx_int_t zauth_parse_request (ngx_http_request_t * r) {
         } else {
                 ngx_str_t name   = ngx_string("zprovider");
                 ngx_str_t cookie = ngx_null_string;
-                ngx_int_t index  = ngx_http_parse_multi_header_lines(&r->headers_in.cookies, &name, &cookie);
-                if (index != NGX_DECLINED) {
+                ngx_table_elt_t* cookie_header  = ngx_http_parse_multi_header_lines(r, r->headers_in.cookie, &name, &cookie);
+                if (cookie_header != NULL) {
                         res = zauth_token_parse(cookie.data, cookie.len, &tkn);
                 }
         }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5360
turns out it was not that hard after all, I could trace back our compile issue to a refactoring done in this commit
https://github.com/nginx/nginx/commit/3aef1d693f3cc431563a7e6a6aba6a34e5290f03?diff=split&w=1 and that was quite easy to fix

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
