### PR TITLE
gundeck: Delete all APNS_VOIP and APNS_VOIP_SANDBOX push tokens

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -1720,19 +1720,17 @@ CREATE TABLE galley_test.mls_proposal_refs (
     AND speculative_retry = '99PERCENTILE';
 CREATE KEYSPACE gundeck_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
-CREATE TABLE gundeck_test.push (
-    ptoken text,
-    app text,
-    transport int,
-    client text,
-    connection blob,
-    usr uuid,
-    PRIMARY KEY (ptoken, app, transport)
-) WITH CLUSTERING ORDER BY (app ASC, transport ASC)
-    AND bloom_filter_fp_chance = 0.1
+CREATE TABLE gundeck_test.data_migration (
+    id int,
+    version int,
+    date timestamp,
+    descr text,
+    PRIMARY KEY (id, version)
+) WITH CLUSTERING ORDER BY (version ASC)
+    AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
     AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
@@ -1790,10 +1788,16 @@ CREATE TABLE gundeck_test.meta (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE gundeck_test.notification_payload (
-    id uuid PRIMARY KEY,
-    payload blob
-) WITH bloom_filter_fp_chance = 0.1
+CREATE TABLE gundeck_test.push (
+    ptoken text,
+    app text,
+    transport int,
+    client text,
+    connection blob,
+    usr uuid,
+    PRIMARY KEY (ptoken, app, transport)
+) WITH CLUSTERING ORDER BY (app ASC, transport ASC)
+    AND bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
@@ -1819,6 +1823,24 @@ CREATE TABLE gundeck_test.user_push (
     PRIMARY KEY (usr, ptoken, app, transport)
 ) WITH CLUSTERING ORDER BY (ptoken ASC, app ASC, transport ASC)
     AND bloom_filter_fp_chance = 0.1
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
+CREATE TABLE gundeck_test.notification_payload (
+    id uuid PRIMARY KEY,
+    payload blob
+) WITH bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}

--- a/changelog.d/2-features/delete-voip-tokens
+++ b/changelog.d/2-features/delete-voip-tokens
@@ -1,0 +1,1 @@
+gundeck: Delete all APNS_VOIP and APNS_VOIP_SANDBOX push tokens

--- a/charts/cassandra-migrations/templates/gundeck-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/gundeck-migrate-data.yaml
@@ -1,11 +1,11 @@
-# This jobs runs migrations on the galley DB using the galley-migrate-data tool.
-# The source for the tool can be found at services/galley in the wire-server
+# This jobs runs migrations on the gundeck DB using the gundeck-migrate-data tool.
+# The source for the tool can be found at services/gundeck in the wire-server
 # repository.
-{{- if .Values.enableGalleyMigrations }}
+{{- if .Values.enableGundeckMigrations }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: galley-migrate-data
+  name: gundeck-migrate-data
   labels:
     app: "cassandra-migrations"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -20,15 +20,15 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        app: galley-migrate-data
+        app: gundeck-migrate-data
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: galley-migrate-data
-          image: "{{ .Values.images.galleyMigrateData }}:{{ .Values.images.tag }}"
+        - name: gundeck-migrate-data
+          image: "{{ .Values.images.gundeckMigrateData }}:{{ .Values.images.tag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         {{- if eq (include "includeSecurityContext" .) "true" }}
           securityContext:
@@ -36,24 +36,24 @@ spec:
         {{- end }}
           args:
            - --cassandra-host
-           - "{{ template "cassandraGalleyHost" . }}"
+           - "{{ template "cassandraGundeckHost" . }}"
            - --cassandra-port
            - "9042"
            - --cassandra-keyspace
-           - galley
-           {{- if eq (include "useTlsGalley" .) "true" }}
+           - gundeck
+           {{- if eq (include "useTlsGundeck" .) "true" }}
            - --tls-ca-certificate-file
-           - /certs/galley/{{- (include "tlsSecretRefGalley" . | fromYaml).key }}
+           - /certs/gundeck/{{- (include "tlsSecretRefGundeck" . | fromYaml).key }}
            {{- end }}
-          {{- if eq (include "useTlsGalley" .) "true" }}
+          {{- if eq (include "useTlsGundeck" .) "true" }}
           volumeMounts:
-            - name: galley-cassandra-cert
-              mountPath: "/certs/galley"
+            - name: gundeck-cassandra-cert
+              mountPath: "/certs/gundeck"
           {{- end }}
-      {{- if eq (include "useTlsGalley" .) "true" }}
+      {{- if eq (include "useTlsGundeck" .) "true" }}
       volumes:
-        - name: galley-cassandra-cert
+        - name: gundeck-cassandra-cert
           secret:
-            secretName: {{ (include "tlsSecretRefGalley" . | fromYaml).name }}
+            secretName: {{ (include "tlsSecretRefGundeck" . | fromYaml).name }}
       {{- end }}
 {{- end }}

--- a/charts/cassandra-migrations/values.yaml
+++ b/charts/cassandra-migrations/values.yaml
@@ -5,6 +5,7 @@ images:
   galley: quay.io/wire/galley-schema
   spar: quay.io/wire/spar-schema
   galleyMigrateData: quay.io/wire/galley-migrate-data
+  gundeckMigrateData: quay.io/wire/gundeck-migrate-data
   sparMigrateData: quay.io/wire/spar-migrate-data
 
 # Setting cassandra host name and replication is mandatory to specify.

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -76,7 +76,7 @@ let
     cargohold = [ "cargohold" "cargohold-integration" ];
     federator = [ "federator" "federator-integration" ];
     galley = [ "galley" "galley-integration" "galley-schema" "galley-migrate-data" ];
-    gundeck = [ "gundeck" "gundeck-integration" "gundeck-schema" ];
+    gundeck = [ "gundeck" "gundeck-integration" "gundeck-schema" "gundeck-migrate-data" ];
     proxy = [ "proxy" ];
     spar = [ "spar" "spar-integration" "spar-schema" "spar-migrate-data" ];
     stern = [ "stern" "stern-integration" ];

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -18,6 +18,7 @@
 , bytestring
 , bytestring-conversion
 , cassandra-util
+, conduit
 , containers
 , criterion
 , errors
@@ -153,8 +154,10 @@ mkDerivation {
     bytestring
     bytestring-conversion
     cassandra-util
+    conduit
     containers
     exceptions
+    extended
     gundeck-types
     HsOpenSSL
     http-client
@@ -175,6 +178,7 @@ mkDerivation {
     tasty-ant-xml
     tasty-hunit
     text
+    time
     tinylog
     types-common
     uuid

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -46,6 +46,7 @@ library
     Gundeck.Schema.Run
     Gundeck.Schema.V1
     Gundeck.Schema.V10
+    Gundeck.Schema.V11
     Gundeck.Schema.V2
     Gundeck.Schema.V3
     Gundeck.Schema.V4

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 3.0
 name:          gundeck
 version:       1.45.0
 synopsis:      Push Notification Hub
@@ -6,7 +6,7 @@ category:      Network
 author:        Wire Swiss GmbH
 maintainer:    Wire Swiss GmbH <backend@wire.com>
 copyright:     (c) 2017 Wire Swiss GmbH
-license:       AGPL-3
+license:       AGPL-3.0-only
 license-file:  LICENSE
 build-type:    Simple
 
@@ -110,7 +110,7 @@ library
     -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      aeson                  >=2.0.1.0
+    , aeson                  >=2.0.1.0
     , amazonka               >=2
     , amazonka-core          >=2
     , amazonka-sns           >=2
@@ -219,7 +219,7 @@ executable gundeck
     -Wunused-packages
 
   build-depends:
-      base
+    , base
     , gundeck
     , HsOpenSSL
     , imports
@@ -288,7 +288,7 @@ executable gundeck-integration
     -threaded -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      aeson
+    , aeson
     , async
     , base                   >=4   && <5
     , base16-bytestring      >=0.1
@@ -326,6 +326,81 @@ executable gundeck-integration
     , websockets             >=0.8
     , wire-api
     , yaml
+
+  default-language:   GHC2021
+
+executable gundeck-migrate-data
+  main-is:            ../main.hs
+  hs-source-dirs:     migrate-data/src
+  default-extensions:
+    AllowAmbiguousTypes
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DefaultSignatures
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    EmptyCase
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    MultiWayIf
+    NamedFieldPuns
+    NoImplicitPrelude
+    OverloadedRecordDot
+    OverloadedStrings
+    PackageImports
+    PatternSynonyms
+    PolyKinds
+    QuasiQuotes
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  ghc-options:
+    -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
+    -threaded -Wredundant-constraints -Wunused-packages
+
+  -- cabal-fmt: expand migrate-data/src
+  other-modules:
+    Gundeck.DataMigration
+    Gundeck.DataMigration.Types
+    Run
+    V1_DeleteApnsVoipTokens
+
+  build-depends:
+    , base
+    , cassandra-util
+    , conduit
+    , exceptions
+    , extended
+    , imports
+    , optparse-applicative
+    , text
+    , time
+    , tinylog
+    , types-common
+
+  if flag(static)
+    ld-options: -static
 
   default-language:   GHC2021
 
@@ -380,7 +455,7 @@ executable gundeck-schema
     -threaded -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      gundeck
+    , gundeck
     , imports
 
   if flag(static)
@@ -451,7 +526,7 @@ test-suite gundeck-tests
     -threaded -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      aeson
+    , aeson
     , aeson-pretty
     , amazonka
     , amazonka-core
@@ -540,7 +615,7 @@ benchmark gundeck-bench
     -Wredundant-constraints -Wunused-packages
 
   build-depends:
-      amazonka
+    , amazonka
     , base
     , criterion
     , gundeck

--- a/services/gundeck/migrate-data/main.hs
+++ b/services/gundeck/migrate-data/main.hs
@@ -1,0 +1,1 @@
+import Run

--- a/services/gundeck/migrate-data/src/Gundeck/DataMigration.hs
+++ b/services/gundeck/migrate-data/src/Gundeck/DataMigration.hs
@@ -61,7 +61,7 @@ cassandraSettingsParser =
     <*> ( C.Keyspace
             <$> Opts.strOption
               ( Opts.long "cassandra-keyspace"
-                  <> Opts.value "galley_test"
+                  <> Opts.value "gundeck_test"
               )
         )
     <*> ( (Opts.optional . Opts.strOption)

--- a/services/gundeck/migrate-data/src/Gundeck/DataMigration.hs
+++ b/services/gundeck/migrate-data/src/Gundeck/DataMigration.hs
@@ -1,0 +1,120 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Gundeck.DataMigration (cassandraSettingsParser, migrate) where
+
+import Cassandra qualified as C
+import Cassandra.Options
+import Cassandra.Util (defInitCassandra)
+import Control.Monad.Catch (finally)
+import Data.Text qualified as Text
+import Data.Time (UTCTime, getCurrentTime)
+import Gundeck.DataMigration.Types
+import Imports
+import Options.Applicative (Parser)
+import Options.Applicative qualified as Opts
+import System.Logger.Class (Logger)
+import System.Logger.Class qualified as Log
+
+data CassandraSettings = CassandraSettings
+  { cHost :: String,
+    cPort :: Word16,
+    cKeyspace :: C.Keyspace,
+    cTlsCa :: Maybe FilePath
+  }
+
+toCassandraOpts :: CassandraSettings -> CassandraOpts
+toCassandraOpts cas =
+  CassandraOpts
+    { _endpoint = Endpoint (Text.pack (cas.cHost)) (cas.cPort),
+      _keyspace = C.unKeyspace (cas.cKeyspace),
+      _filterNodesByDatacentre = Nothing,
+      _tlsCa = cas.cTlsCa
+    }
+
+cassandraSettingsParser :: Parser CassandraSettings
+cassandraSettingsParser =
+  CassandraSettings
+    <$> Opts.strOption
+      ( Opts.long "cassandra-host"
+          <> Opts.value "localhost"
+      )
+    <*> Opts.option
+      Opts.auto
+      ( Opts.long "cassandra-port"
+          <> Opts.value 9042
+      )
+    <*> ( C.Keyspace
+            <$> Opts.strOption
+              ( Opts.long "cassandra-keyspace"
+                  <> Opts.value "galley_test"
+              )
+        )
+    <*> ( (Opts.optional . Opts.strOption)
+            ( Opts.long "tls-ca-certificate-file"
+                <> Opts.help "Location of a PEM encoded list of CA certificates to be used when verifying the Cassandra server's certificate"
+            )
+        )
+
+migrate :: Logger -> CassandraSettings -> [Migration] -> IO ()
+migrate l cas ms = do
+  env <- mkEnv l cas
+  finally (go env) (cleanup env)
+  where
+    go env =
+      runMigrationAction env $
+        runMigrations ms
+
+mkEnv :: Logger -> CassandraSettings -> IO Env
+mkEnv l cas =
+  Env
+    <$> initCassandra
+    <*> initLogger
+  where
+    initCassandra = defInitCassandra (toCassandraOpts cas) l
+    initLogger = pure l
+
+-- | Runs only the migrations which need to run
+runMigrations :: [Migration] -> MigrationActionT IO ()
+runMigrations migrations = do
+  vmax <- latestMigrationVersion
+  let pendingMigrations = filter (\m -> version m > vmax) migrations
+  if null pendingMigrations
+    then info "No new migrations."
+    else info "New migrations found."
+  mapM_ runMigration pendingMigrations
+
+runMigration :: Migration -> MigrationActionT IO ()
+runMigration (Migration ver txt mig) = do
+  info $ "Running: [" <> show (migrationVersion ver) <> "] " <> Text.unpack txt
+  mig
+  persistVersion ver txt =<< liftIO getCurrentTime
+
+latestMigrationVersion :: MigrationActionT IO MigrationVersion
+latestMigrationVersion = MigrationVersion . maybe 0 fromIntegral <$> C.query1 cql (C.params C.LocalQuorum ())
+  where
+    cql :: C.QueryString C.R () (Identity Int32)
+    cql = "select version from data_migration where id=1 order by version desc limit 1"
+
+persistVersion :: MigrationVersion -> Text -> UTCTime -> MigrationActionT IO ()
+persistVersion (MigrationVersion v) desc time = C.write cql (C.params C.LocalQuorum (fromIntegral v, desc, time))
+  where
+    cql :: C.QueryString C.W (Int32, Text, UTCTime) ()
+    cql = "insert into data_migration (id, version, descr, date) values (1,?,?,?)"
+
+info :: Log.MonadLogger m => String -> m ()
+info = Log.info . Log.msg

--- a/services/gundeck/migrate-data/src/Gundeck/DataMigration/Types.hs
+++ b/services/gundeck/migrate-data/src/Gundeck/DataMigration/Types.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Gundeck.DataMigration.Types where
+
+import Cassandra qualified as C
+import Control.Monad.Catch (MonadThrow)
+import Imports
+import Numeric.Natural (Natural)
+import System.Logger qualified as Logger
+import System.Logger.Class (MonadLogger (..))
+
+data Migration = Migration
+  { version :: MigrationVersion,
+    text :: Text,
+    action :: MigrationActionT IO ()
+  }
+
+newtype MigrationVersion = MigrationVersion {migrationVersion :: Natural}
+  deriving (Show, Eq, Ord)
+
+newtype MigrationActionT m a = MigrationActionT {unMigrationAction :: ReaderT Env m a}
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadIO,
+      MonadThrow,
+      MonadReader Env,
+      MonadUnliftIO
+    )
+
+instance MonadTrans MigrationActionT where
+  lift = MigrationActionT . lift
+
+instance (MonadIO m, MonadThrow m) => C.MonadClient (MigrationActionT m) where
+  liftClient = liftCassandra
+  localState f = local (\env -> env {cassandraClientState = f $ cassandraClientState env})
+
+instance MonadIO m => MonadLogger (MigrationActionT m) where
+  log level f = do
+    env <- ask
+    Logger.log (logger env) level f
+
+data Env = Env
+  { cassandraClientState :: C.ClientState,
+    logger :: Logger.Logger
+  }
+
+runMigrationAction :: Env -> MigrationActionT m a -> m a
+runMigrationAction env action =
+  runReaderT (unMigrationAction action) env
+
+liftCassandra :: MonadIO m => C.Client a -> MigrationActionT m a
+liftCassandra m = do
+  env <- ask
+  lift $ C.runClient (cassandraClientState env) m
+
+cleanup :: (MonadIO m) => Env -> m ()
+cleanup env = do
+  C.shutdown (cassandraClientState env)
+  Logger.close (logger env)

--- a/services/gundeck/migrate-data/src/Run.hs
+++ b/services/gundeck/migrate-data/src/Run.hs
@@ -27,6 +27,6 @@ main :: IO ()
 main = do
   o <- execParser (info (helper <*> cassandraSettingsParser) desc)
   l <- Log.mkLogger Log.Debug Nothing Nothing
-  migrate l o [ V1_DeleteApnsVoipTokens.migration ]
+  migrate l o [V1_DeleteApnsVoipTokens.migration]
   where
     desc = header "Gundeck Cassandra Data Migrations" <> fullDesc

--- a/services/gundeck/migrate-data/src/Run.hs
+++ b/services/gundeck/migrate-data/src/Run.hs
@@ -1,0 +1,32 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Run where
+
+import Gundeck.DataMigration
+import Imports
+import Options.Applicative
+import System.Logger.Extended qualified as Log
+import V1_DeleteApnsVoipTokens qualified
+
+main :: IO ()
+main = do
+  o <- execParser (info (helper <*> cassandraSettingsParser) desc)
+  l <- Log.mkLogger Log.Debug Nothing Nothing
+  migrate l o [ V1_DeleteApnsVoipTokens.migration ]
+  where
+    desc = header "Gundeck Cassandra Data Migrations" <> fullDesc

--- a/services/gundeck/migrate-data/src/V1_DeleteApnsVoipTokens.hs
+++ b/services/gundeck/migrate-data/src/V1_DeleteApnsVoipTokens.hs
@@ -1,0 +1,90 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V1_DeleteApnsVoipTokens where
+
+import Cassandra
+import Conduit
+import Data.Conduit.Internal (zipSources)
+import Data.Conduit.List qualified as C
+import Data.Id
+import Gundeck.DataMigration.Types
+import Imports
+import System.Logger.Class qualified as Log
+import Data.Text qualified as Text
+
+migration :: Migration
+migration =
+  Migration
+    { version = MigrationVersion 1,
+      text = "Delete APNS_VOIP push tokens",
+      action =
+        runConduit $
+          zipSources
+            (C.sourceList [(1 :: Int32) ..])
+            getPushTokens
+            .| C.mapM
+              ( \(i, p) ->
+                  Log.info (Log.field "push tokens" (show (i * pageSize)))
+                    >> pure p
+              )
+            .| C.concatMap (filter isVoipToken)
+            .| C.map (\(uid, token, app, transport, _mArn)  -> (uid, token, app, transport))
+            .| C.mapM_ deletePushToken
+    }
+
+pageSize :: Int32
+pageSize = 1000
+
+----------------------------------------------------------------------------
+-- Queries
+
+-- | We do not use the push token types here because they will likely be
+-- changed in future breaking this migration.
+getPushTokens ::
+  MonadClient m =>
+  ConduitM () [(UserId, Text, Text, Int32, Maybe Text)] m ()
+getPushTokens = paginateC cql (paramsP LocalQuorum () pageSize) x5
+  where
+    cql :: PrepQuery R () (UserId, Text, Text, Int32, Maybe Text)
+    cql = "SELECT usr, ptoken, app, transport, arn FROM user_push"
+
+deletePushToken :: MonadClient m => (UserId, Text, Text, Int32) -> m ()
+deletePushToken pair =
+  retry x5 $ write cql (params LocalQuorum pair)
+  where
+    cql :: PrepQuery W (UserId, Text, Text, Int32) ()
+    cql = "DELETE FROM user_push where usr = ? AND ptoken = ? AND app = ? AND transport = ?"
+
+isVoipTransport :: Int32 -> Bool
+isVoipTransport 3 = True -- APNS_VOIP
+isVoipTransport 4 = True -- APNS_VOIP_SANDBOX
+isVoipTransport _ = False
+
+isVoipArn :: Text -> Bool
+isVoipArn arn = 
+  case Text.splitOn ":" arn of
+    ["arn", "aws", "sns", _region, _accountId, topic] -> 
+      case Text.splitOn "/" topic of
+        ("endpoint" : "APNS_VOIP" : _ ) -> True
+        ("endpoint" : "APNS_VOIP_SANDBOX" : _ ) -> True
+        _ -> False
+    _ -> False
+ 
+isVoipToken :: (UserId, Text, Text, Int32, Maybe Text) -> Bool
+isVoipToken (_, _, _, transport, mArn) =
+  isVoipTransport transport || maybe False isVoipArn mArn

--- a/services/gundeck/migrate-data/src/V1_DeleteApnsVoipTokens.hs
+++ b/services/gundeck/migrate-data/src/V1_DeleteApnsVoipTokens.hs
@@ -22,10 +22,10 @@ import Conduit
 import Data.Conduit.Internal (zipSources)
 import Data.Conduit.List qualified as C
 import Data.Id
+import Data.Text qualified as Text
 import Gundeck.DataMigration.Types
 import Imports
 import System.Logger.Class qualified as Log
-import Data.Text qualified as Text
 
 migration :: Migration
 migration =
@@ -43,7 +43,7 @@ migration =
                     >> pure p
               )
             .| C.concatMap (filter isVoipToken)
-            .| C.map (\(uid, token, app, transport, _mArn)  -> (uid, token, app, transport))
+            .| C.map (\(uid, token, app, transport, _mArn) -> (uid, token, app, transport))
             .| C.mapM_ deletePushToken
     }
 
@@ -76,15 +76,15 @@ isVoipTransport 4 = True -- APNS_VOIP_SANDBOX
 isVoipTransport _ = False
 
 isVoipArn :: Text -> Bool
-isVoipArn arn = 
+isVoipArn arn =
   case Text.splitOn ":" arn of
-    ["arn", "aws", "sns", _region, _accountId, topic] -> 
+    ["arn", "aws", "sns", _region, _accountId, topic] ->
       case Text.splitOn "/" topic of
-        ("endpoint" : "APNS_VOIP" : _ ) -> True
-        ("endpoint" : "APNS_VOIP_SANDBOX" : _ ) -> True
+        ("endpoint" : "APNS_VOIP" : _) -> True
+        ("endpoint" : "APNS_VOIP_SANDBOX" : _) -> True
         _ -> False
     _ -> False
- 
+
 isVoipToken :: (UserId, Text, Text, Int32, Maybe Text) -> Bool
 isVoipToken (_, _, _, transport, mArn) =
   isVoipTransport transport || maybe False isVoipArn mArn

--- a/services/gundeck/src/Gundeck/Schema/Run.hs
+++ b/services/gundeck/src/Gundeck/Schema/Run.hs
@@ -22,6 +22,7 @@ import Cassandra.Schema
 import Control.Exception (finally)
 import Gundeck.Schema.V1 qualified as V1
 import Gundeck.Schema.V10 qualified as V10
+import Gundeck.Schema.V11 qualified as V11
 import Gundeck.Schema.V2 qualified as V2
 import Gundeck.Schema.V3 qualified as V3
 import Gundeck.Schema.V4 qualified as V4
@@ -61,5 +62,6 @@ migrations =
     V7.migration,
     V8.migration,
     V9.migration,
-    V10.migration
+    V10.migration,
+    V11.migration
   ]

--- a/services/gundeck/src/Gundeck/Schema/V11.hs
+++ b/services/gundeck/src/Gundeck/Schema/V11.hs
@@ -1,0 +1,35 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Gundeck.Schema.V11 (migration) where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 11 "Create table `data_migration`" $ do
+  schema'
+    [r|
+        CREATE TABLE data_migration (
+            id      int,
+            version int,
+            descr   text,
+            date    timestamp,
+            PRIMARY KEY (id, version)
+        );
+        |]


### PR DESCRIPTION
This also introduces the concept of data-migrations in gundeck. They are run as post-install and post-upgrade hooks in cassandra-migrations helm chart, just like galley-migrate-data and spar-migrate-data.

https://wearezeta.atlassian.net/browse/WPB-9027

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
