### PR TITLE
Fix hardcoded use of ciphersuite 1 when switching to mixed protocol

### DIFF
--- a/changelog.d/3-bug-fixes/mixed-ciphersuite
+++ b/changelog.d/3-bug-fixes/mixed-ciphersuite
@@ -1,0 +1,1 @@
+Fix hardcoded ciphersuite when switching to mixed

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -8,7 +8,9 @@ import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Read as T
 import MLS.Util
 import Notifications
 import SetupHelpers
@@ -101,6 +103,7 @@ testMixedProtocolUpgrade secondDomain = do
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "protocol" `shouldMatch` "mixed"
+    resp.json %. "epoch" `shouldMatchInt` 0
 
   bindResponse (putConversationProtocol alice qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 204
@@ -121,8 +124,9 @@ testMixedProtocolNonTeam secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 403
 
-testMixedProtocolAddUsers :: HasCallStack => Domain -> App ()
-testMixedProtocolAddUsers secondDomain = do
+testMixedProtocolAddUsers :: HasCallStack => Domain -> Ciphersuite -> App ()
+testMixedProtocolAddUsers secondDomain suite = do
+  setMLSCiphersuite suite
   (alice, tid, _) <- createTeam OwnDomain 1
   [bob, charlie] <- replicateM 2 (randomUser secondDomain def)
   connectUsers [alice, bob, charlie]
@@ -149,6 +153,11 @@ testMixedProtocolAddUsers secondDomain = do
     void $ sendAndConsumeCommitBundle mp
     n <- awaitMatch (\n -> nPayload n %. "type" `isEqual` "conversation.mls-welcome") ws
     nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode welcome)
+
+  bindResponse (getConversation alice qcnv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    (suiteCode, _) <- assertOne $ T.hexadecimal (T.pack suite.code)
+    resp.json %. "cipher_suite" `shouldMatchInt` suiteCode
 
 testMixedProtocolUserLeaves :: HasCallStack => Domain -> App ()
 testMixedProtocolUserLeaves secondDomain = do

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -143,6 +143,7 @@ testMixedProtocolAddUsers secondDomain suite = do
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
+    resp.json %. "epoch" `shouldMatchInt` 0
     createGroup alice1 resp.json
 
   traverse_ uploadNewKeyPackage [bob1]
@@ -156,6 +157,7 @@ testMixedProtocolAddUsers secondDomain suite = do
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
+    resp.json %. "epoch" `shouldMatchInt` 1
     (suiteCode, _) <- assertOne $ T.hexadecimal (T.pack suite.code)
     resp.json %. "cipher_suite" `shouldMatchInt` suiteCode
 

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -117,7 +117,6 @@ import Wire.API.Federation.API.Galley
 import Wire.API.Federation.API.Galley qualified as F
 import Wire.API.Federation.Error
 import Wire.API.FederationStatus
-import Wire.API.MLS.CipherSuite
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Team.Feature
 import Wire.API.Team.LegalHold
@@ -492,7 +491,7 @@ performAction tag origUser lconv action = do
     SConversationUpdateProtocolTag -> do
       case (protocolTag (convProtocol (tUnqualified lconv)), action, convTeam (tUnqualified lconv)) of
         (ProtocolProteusTag, ProtocolMixedTag, Just _) -> do
-          E.updateToMixedProtocol lcnv (convType (tUnqualified lconv)) MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+          E.updateToMixedProtocol lcnv (convType (tUnqualified lconv))
           pure (mempty, action)
         (ProtocolMixedTag, ProtocolMLSTag, Just tid) -> do
           mig <- getFeatureStatus @MlsMigrationConfig DontDoAuth tid

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -396,15 +396,14 @@ updateToMixedProtocol ::
     r =>
   Local ConvId ->
   ConvType ->
-  CipherSuiteTag ->
   Sem r ()
-updateToMixedProtocol lcnv ct cs = do
+updateToMixedProtocol lcnv ct = do
   let gid = convToGroupId . groupIdParts ct $ Conv <$> tUntagged lcnv
       epoch = Epoch 0
   embedClient . retry x5 . batch $ do
     setType BatchLogged
     setConsistency LocalQuorum
-    addPrepQuery Cql.updateToMixedConv (tUnqualified lcnv, ProtocolMixedTag, gid, epoch, cs)
+    addPrepQuery Cql.updateToMixedConv (tUnqualified lcnv, ProtocolMixedTag, gid, epoch)
   pure ()
 
 updateToMLSProtocol ::
@@ -493,9 +492,9 @@ interpretConversationStoreToCassandra = interpret $ \case
   ReleaseCommitLock gId epoch -> do
     logEffect "ConversationStore.ReleaseCommitLock"
     embedClient $ releaseCommitLock gId epoch
-  UpdateToMixedProtocol cid ct cs -> do
+  UpdateToMixedProtocol cid ct -> do
     logEffect "ConversationStore.UpdateToMixedProtocol"
-    updateToMixedProtocol cid ct cs
+    updateToMixedProtocol cid ct
   UpdateToMLSProtocol cid -> do
     logEffect "ConversationStore.UpdateToMLSProtocol"
     updateToMLSProtocol cid

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -267,9 +267,9 @@ insertMLSSelfConv =
       <> show (fromEnum ProtocolMLSTag)
       <> ", ?)"
 
-updateToMixedConv :: PrepQuery W (ConvId, ProtocolTag, GroupId, Epoch, CipherSuiteTag) ()
+updateToMixedConv :: PrepQuery W (ConvId, ProtocolTag, GroupId, Epoch) ()
 updateToMixedConv =
-  "insert into conversation (conv, protocol, group_id, epoch, cipher_suite) values (?, ?, ?, ?, ?)"
+  "insert into conversation (conv, protocol, group_id, epoch) values (?, ?, ?, ?)"
 
 updateToMLSConv :: PrepQuery W (ConvId, ProtocolTag) ()
 updateToMLSConv = "insert into conversation (conv, protocol) values (?, ?)"

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -101,7 +101,7 @@ data ConversationStore m a where
   SetGroupInfo :: ConvId -> GroupInfoData -> ConversationStore m ()
   AcquireCommitLock :: GroupId -> Epoch -> NominalDiffTime -> ConversationStore m LockAcquired
   ReleaseCommitLock :: GroupId -> Epoch -> ConversationStore m ()
-  UpdateToMixedProtocol :: Local ConvId -> ConvType -> CipherSuiteTag -> ConversationStore m ()
+  UpdateToMixedProtocol :: Local ConvId -> ConvType -> ConversationStore m ()
   UpdateToMLSProtocol :: Local ConvId -> ConversationStore m ()
 
 makeSem ''ConversationStore


### PR DESCRIPTION
Ciphersuite 1 was still used as the hardcoded ciphersuite for the newly created MLS group after a proteus → mixed transition. This made it impossible to use other ciphersuites for the MLS part of a mixed conversation.

https://wearezeta.atlassian.net/browse/WPB-9142

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
