### PR TITLE
coturn: Add IP configuration options

### DIFF
--- a/changelog.d/2-features/coturn-params
+++ b/changelog.d/2-features/coturn-params
@@ -1,0 +1,1 @@
+Introduce more configuration options to the `coturn` helm chart

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -30,7 +30,9 @@ data:
     listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnListenIP }}
     listening-port={{ .Values.coturnTurnListenPort }}
     relay-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnRelayIP }}
+    {{- if .Values.coturnTurnExternalIP }}
     external-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnExternalIP }}
+    {{- end }}
     realm=dummy.io
     no-stun-backward-compatibility
     secure-stun

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -29,14 +29,15 @@ data:
     ## turn, stun.
     listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnListenIP }}
     listening-port={{ .Values.coturnTurnListenPort }}
-    relay-ip=__COTURN_EXT_IP__
+    relay-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnRelayIP }}
+    external-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnExternalIP }}
     realm=dummy.io
     no-stun-backward-compatibility
     secure-stun
     no-rfc5780
 
     ## prometheus metrics
-    prometheus-ip=__COTURN_POD_IP__
+    prometheus-ip={{ default "__COTURN_POD_IP__" .Values.coturnPrometheusIP }}
     prometheus-port={{ .Values.coturnMetricsListenPort }}
 
     ## logs
@@ -87,7 +88,7 @@ data:
 
     {{- if .Values.federate.enabled }}
     ### federation setup
-    federation-listening-ip=__COTURN_EXT_IP__
+    federation-listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnFederationListeningIP }}
     federation-listening-port={{ .Values.federate.port }}
     federation-no-dtls={{ not .Values.federate.dtls.enabled }}
     {{- if .Values.federate.dtls.enabled }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -100,6 +100,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
@@ -132,7 +136,7 @@ spec:
             - |
               set -e
               EXTERNAL_IP=$(cat /external-ip/ip)
-              sed -Ee "s;__COTURN_EXT_IP__;$EXTERNAL_IP;g" -e "s;__COTURN_POD_IP__;$POD_IP;g" /coturn-template/coturn.conf.template > /coturn-config/turnserver.conf
+              sed -Ee "s;__COTURN_EXT_IP__;$EXTERNAL_IP;g" -e "s;__COTURN_POD_IP__;$POD_IP;g" -e "s;__COTURN_HOST_IP__;$HOST_IP;g" /coturn-template/coturn.conf.template > /coturn-config/turnserver.conf
               sed -Ee 's/^/static-auth-secret=/' /secrets/zrest_secret.txt >> /coturn-config/turnserver.conf
               exec /usr/bin/turnserver -c /coturn-config/turnserver.conf
           {{- if .Values.coturnGracefulTermination }}

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -28,9 +28,9 @@ coturnTurnTlsListenPort: 5349
 
 # coturnTurnListenIP: "1.2.3.4" # can also be __COTURN_EXT_IP__, __COTURN_POD_IP__,__COTURN_HOST_IP__
 coturnTurnExternalIP: null
-# coturnTurnRelayIP: 
-# coturnPrometheusIP: 
-# coturnFederationListeningIP: 
+# coturnTurnRelayIP:
+# coturnPrometheusIP:
+# coturnFederationListeningIP:
 
 tls:
   enabled: false

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -27,7 +27,7 @@ coturnMetricsListenPort: 9641
 coturnTurnTlsListenPort: 5349
 
 # coturnTurnListenIP: "1.2.3.4" # can also be __COTURN_EXT_IP__, __COTURN_POD_IP__,__COTURN_HOST_IP__
-# coturnTurnExternalIP:
+coturnTurnExternalIP: null
 # coturnTurnRelayIP: 
 # coturnPrometheusIP: 
 # coturnFederationListeningIP: 

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -26,9 +26,11 @@ coturnTurnListenPort: 3478
 coturnMetricsListenPort: 9641
 coturnTurnTlsListenPort: 5349
 
-# If you need to specify which IP Coturn should bind to.
-# This will typically be the IP of the kubenode.
-# coturnTurnListenIP: "182.168.22.133"
+# coturnTurnListenIP: "1.2.3.4" # can also be __COTURN_EXT_IP__, __COTURN_POD_IP__,__COTURN_HOST_IP__
+# coturnTurnExternalIP:
+# coturnTurnRelayIP: 
+# coturnPrometheusIP: 
+# coturnFederationListeningIP: 
 
 tls:
   enabled: false


### PR DESCRIPTION
This PR adds configuration options in the `coturn` helm chart for settings
- `relay-ip`
- `external-ip`
- `prometheus-ip`
- `federation-listening-ip`

It also adds a `__COTURN_HOST_IP__` template variable which will be substitued by the host ip of the `k8s` node that is running coturn.

This PR is backwards-compatible to `values.yaml` files written for version of this helm charts without this PR: new variables have defaults that match their previous hardcoded value.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
