### PR TITLE
WPB-9495: nginz: configure extra origins

### DIFF
--- a/changelog.d/5-internal/WPB-9495
+++ b/changelog.d/5-internal/WPB-9495
@@ -1,1 +1,1 @@
-nginz: Added extra_allowlisted_origins to `nginx_conf` value
+nginz: Added `allowlisted_fqdn_origins` to `nginx_conf` value

--- a/changelog.d/5-internal/WPB-9495
+++ b/changelog.d/5-internal/WPB-9495
@@ -1,0 +1,1 @@
+nginz: Added extra_allowlisted_origins to `nginx_conf` value

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -146,9 +146,9 @@ http {
     {{ range $origin := .Values.nginx_conf.randomport_allowlisted_origins }}
       "~^https?://{{ $origin }}(:[0-9]{2,5})?$" "$http_origin";
     {{ end }}
-    {{/* Allow additional specific origins, if present */}}
-    {{- range $origin := .Values.nginx_conf.extra_allowlisted_origins }}
-      "https://{{ $origin }} "$http_origin";
+    {{/* Allow additional origin FQDNs, if present */}}
+    {{- range $origin := .Values.nginx_conf.allowlisted_fqdn_origins }}
+      "https://{{ $origin }}" "$http_origin";
     {{- end }}
   }
 

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -150,6 +150,9 @@ http {
     {{- range $origin := .Values.nginx_conf.allowlisted_fqdn_origins }}
       "https://{{ $origin }}" "$http_origin";
     {{- end }}
+    {{- if and .Values.nginx_conf.allowlisted_fqdn_origins (not (eq .Values.nginx_conf.env  "staging")) -}}
+    {{ fail "allowlisted_fqdn_origins is only cleared for usage in staging."}}
+    {{- end }}
   }
 
 

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -146,7 +146,11 @@ http {
     {{ range $origin := .Values.nginx_conf.randomport_allowlisted_origins }}
       "~^https?://{{ $origin }}(:[0-9]{2,5})?$" "$http_origin";
     {{ end }}
-   }
+    {{/* Allow additional specific origins, if present */}}
+    {{- range $origin := .Values.nginx_conf.extra_allowlisted_origins }}
+      "https://{{ $origin }} "$http_origin";
+    {{- end }}
+  }
 
 
   #

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -78,6 +78,9 @@ nginx_conf:
     - webapp
     - teams
     - account
+  # Fully-qualified domain names from which to allow Cross-Origin Requests
+  # (they are **not** combined with 'external_env_domain')
+  allowlisted_fqdn_origins: []
 
   # The origins from which we allow CORS requests at random ports. This is
   # useful for testing with HTTP proxies and should not be used in production.


### PR DESCRIPTION
This adds a new key `allowlisted_fqdn_origins` to the `nginx_conf` value of the `nginz` chart.
The purpose is to add more domain name entries in the `cors_header` map of the nginx config in test/dev/staging environments.

Made use of by https://github.com/zinfra/cailleach/pull/2147

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
