### PR TITLE
federator: Expect a client certificate to be the certificate chain

### DIFF
--- a/changelog.d/3-bug-fixes/federator-client-cert-chain
+++ b/changelog.d/3-bug-fixes/federator-client-cert-chain
@@ -1,0 +1,3 @@
+federator: Expect a client certificate to be the certificate chain
+
+Without this openssl doesn't forward to whole chain causing mTLS to not succeed.

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -344,7 +344,7 @@ mkSSLContext settings = do
   ctx <- mkSSLContextWithoutCert settings
 
   Polysemy.fromExceptionVia @SomeException (InvalidClientCertificate . displayException) $
-    SSL.contextSetCertificateFile ctx (clientCertificate settings)
+    SSL.contextSetCertificateChainFile ctx (clientCertificate settings)
 
   Polysemy.fromExceptionVia @SomeException (InvalidClientPrivateKey . displayException) $
     SSL.contextSetPrivateKeyFile ctx (clientPrivateKey settings)


### PR DESCRIPTION
Without this openssl doesn't forward to whole chain causing mTLS to not succeed.

Backport of #4089 

https://wearezeta.atlassian.net/browse/WPB-9692

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
