### PR TITLE
WPB 2690

### DIFF
--- a/changelog.d/2-features/WPB-2690-coturn-drain
+++ b/changelog.d/2-features/WPB-2690-coturn-drain
@@ -1,0 +1,1 @@
+charts/coturn: support putting coturn into 'drain' mode when terminating pods, denying new incoming client connections. This speeds up graceful coturn restarts significantly.

--- a/changelog.d/3-bug-fixes/tmp-pid
+++ b/changelog.d/3-bug-fixes/tmp-pid
@@ -1,0 +1,1 @@
+charts/coturn: use allowed dir to write PID file

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.46
+version: 0.0.74
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.42
+version: 0.0.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,9 +6,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.74
+version: 0.0.79
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.2-federation-wireapp.12
+appVersion: 4.6.2-federation-stefan-wireapp.10

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,9 +6,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.81
+version: 0.0.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.2-federation-stefan-wireapp.12
+appVersion: 4.6.2-federation-wireapp.16

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,9 +6,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.79
+version: 0.0.80
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.2-federation-stefan-wireapp.10
+appVersion: 4.6.2-federation-stefan-wireapp.11

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -6,9 +6,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.80
+version: 0.0.81
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.2-federation-stefan-wireapp.11
+appVersion: 4.6.2-federation-stefan-wireapp.12

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -26,6 +26,8 @@ data:
     ## don't turn on coturn's cli.
     no-cli
 
+    pidfile="/var/tmp/turnserver.pid"
+
     ## turn, stun.
     listening-ip={{ default "__COTURN_EXT_IP__" .Values.coturnTurnListenIP }}
     listening-port={{ .Values.coturnTurnListenPort }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -142,7 +142,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - exec /usr/local/bin/pre-stop-hook "$POD_IP" {{ .Values.coturnMetricsListenPort }}
+                  - "kill -s SIGUSR1 1; exec /usr/local/bin/pre-stop-hook \"$POD_IP\" {{ .Values.coturnMetricsListenPort }}"
           {{- end }}
 
           ports:

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -145,27 +145,6 @@ spec:
                   - /bin/sh
                   - -c
                   - "exec /usr/local/bin/pre-stop-hook \"$POD_IP\" {{ .Values.coturnMetricsListenPort }}"
-                  # - "
-                  #   (
-                  #     set -e
-                  #     echo \"prestop hook\"
-                  #     sleep 3
-                  #     pkill --signal SIGUSR1 -f \"/usr/bin/turnserver\"
-                  #     while pgrep -f \"/usr/bin/turnserver\" > /dev/null; do
-                  #         echo \"/usr/bin/turnserver is still running. Waiting...\"
-                  #         sleep 1
-                  #     done
-                  #     echo \"succces :)\"
-                  #   ) 2>&1 >> /tmp/prestop.txt
-                  #   sleep 3
-                  #   "
-                  # - "
-                  #   (
-                  #     echo \"prestop hook\"
-                  #     sleep 3
-                  #   ) 2>&1 >> /tmp/prestop.txt
-                  #   sleep 3
-                  #   "
           {{- end }}
 
           ports:

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -142,7 +142,28 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - "kill -s SIGUSR1 1; exec /usr/local/bin/pre-stop-hook \"$POD_IP\" {{ .Values.coturnMetricsListenPort }}"
+                  - "exec /usr/local/bin/pre-stop-hook \"$POD_IP\" {{ .Values.coturnMetricsListenPort }}"
+                  # - "
+                  #   (
+                  #     set -e
+                  #     echo \"prestop hook\"
+                  #     sleep 3
+                  #     pkill --signal SIGUSR1 -f \"/usr/bin/turnserver\"
+                  #     while pgrep -f \"/usr/bin/turnserver\" > /dev/null; do
+                  #         echo \"/usr/bin/turnserver is still running. Waiting...\"
+                  #         sleep 1
+                  #     done
+                  #     echo \"succces :)\"
+                  #   ) 2>&1 >> /tmp/prestop.txt
+                  #   sleep 3
+                  #   "
+                  # - "
+                  #   (
+                  #     echo \"prestop hook\"
+                  #     sleep 3
+                  #   ) 2>&1 >> /tmp/prestop.txt
+                  #   sleep 3
+                  #   "
           {{- end }}
 
           ports:

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -127,6 +127,8 @@ spec:
               readOnly: true
            {{- end }}
           command:
+            - /usr/bin/dumb-init
+            - --
             - /bin/sh
             - -c
             - |

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -93,11 +93,17 @@ metrics:
   serviceMonitor:
     enabled: false
 
-coturnGracefulTermination: true
+# This chart supports waiting for traffic to drain from coturn
+# before pods are actually terminated. Once in 'drain' mode, no new connections
+# are accepted, but old ones are kept alive.
+# If you have 2 or more replicas, it's recommended to set this to true,
+# and if you only have one coturn replica you may want this to be false, as
+# otherwise while the pod restarts, no new calls can be established.
+coturnGracefulTermination: false
 # Grace period for terminating coturn pods, after which they will be forcibly
 # terminated. This setting is only effective when coturnGracefulTermination is
 # set to true.
-coturnGracePeriodSeconds: 300
+coturnGracePeriodSeconds: 43200 # 12 hours
 
 livenessProbe:
   timeoutSeconds: 5

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -93,17 +93,11 @@ metrics:
   serviceMonitor:
     enabled: false
 
-# This chart optionally supports waiting for traffic to drain from coturn
-# before pods are terminated. Warning: coturn does not have any way to steer
-# incoming client traffic away from itself on its own, so this functionality
-# relies on external traffic management (e.g. service discovery for active coturn
-# instances) to prevent clients from sending new requests to pods which are in a
-# terminating state.
-coturnGracefulTermination: false
+coturnGracefulTermination: true
 # Grace period for terminating coturn pods, after which they will be forcibly
 # terminated. This setting is only effective when coturnGracefulTermination is
 # set to true.
-coturnGracePeriodSeconds: 86400 # one day
+coturnGracePeriodSeconds: 300
 
 livenessProbe:
   timeoutSeconds: 5


### PR DESCRIPTION
charts/coturn: support putting coturn into 'drain' mode when terminating pods, denying new incoming client connections. This speeds up graceful coturn restarts significantly. See related PR https://github.com/wireapp/coturn/pull/15 and https://github.com/wireapp/coturn/pull/12

drive-by fixes:
- use dumb-init to start the container to correctly handle signal handling in general
- write process PID to a writable file when running as non-root user


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
