### PR TITLE
Allow nil rabbitmq CA in integration charts

### DIFF
--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -54,9 +54,11 @@ spec:
       secret:
         secretName: {{ (include "tlsSecretRef" .Values.config | fromYaml).name }}
     {{- end}}
+    {{- if .Values.config.rabbitmq.tlsCaSecretRef }}
     - name: "rabbitmq-ca"
       secret:
         secretName: {{ .Values.config.rabbitmq.tlsCaSecretRef.name }}
+    {{- end }}
   containers:
   - name: integration
     image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
@@ -122,8 +124,10 @@ spec:
     - name: "brig-cassandra"
       mountPath: "/etc/wire/brig/cassandra"
     {{- end }}
+    {{- if .Values.config.rabbitmq.tlsCaSecretRef }}
     - name: "rabbitmq-ca"
       mountPath: "/etc/wire/brig/rabbitmq-ca/"
+    {{- end }}
 
     env:
     # these dummy values are necessary for Amazonka's "Discover"

--- a/charts/galley/templates/tests/galley-integration.yaml
+++ b/charts/galley/templates/tests/galley-integration.yaml
@@ -45,9 +45,11 @@ spec:
       secret:
         secretName: {{ (include "tlsSecretRef" .Values.config | fromYaml).name }}
     {{- end }}
+    {{- if .Values.config.rabbitmq.tlsCaSecretRef }}
     - name: "rabbitmq-ca"
       secret:
         secretName: {{ .Values.config.rabbitmq.tlsCaSecretRef.name }}
+    {{- end }}
   containers:
   - name: integration
     image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
@@ -96,8 +98,10 @@ spec:
     - name: "galley-cassandra"
       mountPath: "/etc/wire/galley/cassandra"
     {{- end }}
+    {{- if .Values.config.rabbitmq.tlsCaSecretRef }}
     - name: "rabbitmq-ca"
       mountPath: "/etc/wire/galley/rabbitmq-ca/"
+    {{- end }}
     env:
     # these dummy values are necessary for Amazonka's "Discover"
     - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Allow nil rabbitmq tlsCaSecretRef in brig and galley integration charts.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
