### PR TITLE
Fix repeated with-rtsopts option

### DIFF
--- a/changelog.d/3-bug-fixes/repeated-rtsopts
+++ b/changelog.d/3-bug-fixes/repeated-rtsopts
@@ -1,0 +1,1 @@
+GHC does not support repeated --with-rtsopts options, and it simply applies the last one. This means many of the baked-in options were actually not being passed, including -N for some of the services and -T for cannon.

--- a/services/background-worker/background-worker.cabal
+++ b/services/background-worker/background-worker.cabal
@@ -110,7 +110,7 @@ executable background-worker
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
     -funbox-strict-fields -Wredundant-constraints -Wunused-packages
-    -threaded -with-rtsopts=-N -with-rtsopts=-T -rtsopts
+    -threaded "-with-rtsopts=-N -T" -rtsopts
 
   default-extensions:
     AllowAmbiguousTypes

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -357,7 +357,7 @@ executable brig
   main-is:       exec/Main.hs
   other-modules: Paths_brig
   ghc-options:
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -357,8 +357,8 @@ executable brig
   main-is:       exec/Main.hs
   other-modules: Paths_brig
   ghc-options:
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
     , base

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -166,9 +166,8 @@ executable cannon
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
-    -with-rtsopts=-M1g -with-rtsopts=-ki4k -Wredundant-constraints
-    -Wunused-packages
+    -threaded -rtsopts "-with-rtsopts=-N -T -M1g -ki4k"
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -205,7 +205,7 @@ executable federator
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -threaded "-with-rtsopts=-N1 -T" -rtsopts -Wredundant-constraints
+    -threaded "-with-rtsopts=-N -T" -rtsopts -Wredundant-constraints
     -Wunused-packages
 
   build-depends:

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -205,8 +205,8 @@ executable federator
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -threaded -with-rtsopts=-N1 -with-rtsopts=-T -rtsopts
-    -Wredundant-constraints -Wunused-packages
+    -threaded "-with-rtsopts=-N1 -T" -rtsopts -Wredundant-constraints
+    -Wunused-packages
 
   build-depends:
       base

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -252,8 +252,7 @@ executable spar
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -j
     -Wno-redundant-constraints -Werror -threaded -rtsopts
-    "-with-rtsopts=-N -T" -Wredundant-constraints
-    -Wunused-packages
+    "-with-rtsopts=-N -T" -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -252,7 +252,7 @@ executable spar
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -j
     -Wno-redundant-constraints -Werror -threaded -rtsopts
-    -with-rtsopts=-N -with-rtsopts=-T -Wredundant-constraints
+    "-with-rtsopts=-N -T" -Wredundant-constraints
     -Wunused-packages
 
   build-depends:

--- a/tools/db/auto-whitelist/auto-whitelist.cabal
+++ b/tools/db/auto-whitelist/auto-whitelist.cabal
@@ -62,7 +62,7 @@ executable auto-whitelist
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/auto-whitelist/auto-whitelist.cabal
+++ b/tools/db/auto-whitelist/auto-whitelist.cabal
@@ -62,8 +62,8 @@ executable auto-whitelist
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/db/find-undead/find-undead.cabal
+++ b/tools/db/find-undead/find-undead.cabal
@@ -62,8 +62,8 @@ executable find-undead
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       aeson

--- a/tools/db/find-undead/find-undead.cabal
+++ b/tools/db/find-undead/find-undead.cabal
@@ -62,7 +62,7 @@ executable find-undead
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/inconsistencies/inconsistencies.cabal
+++ b/tools/db/inconsistencies/inconsistencies.cabal
@@ -65,8 +65,8 @@ executable inconsistencies
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       aeson

--- a/tools/db/inconsistencies/inconsistencies.cabal
+++ b/tools/db/inconsistencies/inconsistencies.cabal
@@ -65,7 +65,7 @@ executable inconsistencies
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
+++ b/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
@@ -64,7 +64,7 @@ executable migrate-sso-feature-flag
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
+++ b/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
@@ -64,8 +64,8 @@ executable migrate-sso-feature-flag
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/db/move-team/move-team.cabal
+++ b/tools/db/move-team/move-team.cabal
@@ -65,8 +65,8 @@ library
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       aeson
@@ -144,8 +144,8 @@ executable move-team
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base
@@ -210,8 +210,8 @@ executable move-team-generate
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/db/move-team/move-team.cabal
+++ b/tools/db/move-team/move-team.cabal
@@ -65,7 +65,7 @@ library
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:
@@ -144,7 +144,7 @@ executable move-team
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:
@@ -210,7 +210,7 @@ executable move-team-generate
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/repair-brig-clients-table/repair-brig-clients-table.cabal
+++ b/tools/db/repair-brig-clients-table/repair-brig-clients-table.cabal
@@ -64,7 +64,7 @@ executable repair-brig-clients-table
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/repair-brig-clients-table/repair-brig-clients-table.cabal
+++ b/tools/db/repair-brig-clients-table/repair-brig-clients-table.cabal
@@ -64,8 +64,8 @@ executable repair-brig-clients-table
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/db/service-backfill/service-backfill.cabal
+++ b/tools/db/service-backfill/service-backfill.cabal
@@ -62,7 +62,7 @@ executable service-backfill
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:

--- a/tools/db/service-backfill/service-backfill.cabal
+++ b/tools/db/service-backfill/service-backfill.cabal
@@ -62,8 +62,8 @@ executable service-backfill
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/fedcalls/fedcalls.cabal
+++ b/tools/fedcalls/fedcalls.cabal
@@ -59,8 +59,8 @@ executable fedcalls
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
-    -rtsopts -Wredundant-constraints -Wunused-packages
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T" -rtsopts
+    -Wredundant-constraints -Wunused-packages
 
   build-depends:
       base

--- a/tools/fedcalls/fedcalls.cabal
+++ b/tools/fedcalls/fedcalls.cabal
@@ -59,7 +59,7 @@ executable fedcalls
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
+    -funbox-strict-fields -threaded "-with-rtsopts=-N -T"
     -rtsopts -Wredundant-constraints -Wunused-packages
 
   build-depends:


### PR DESCRIPTION
GHC does not support repeated `--with-rtsopts` options, and it simply applies the last one. This means many of the baked-in options were actually not being passed, including `-N` for some of the services and `-T` for cannon.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
