### PR TITLE
update nixpkgs once more

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a3fc4cf736b7d2d288d7a8bf775ac8d4c0920b4",
-        "sha256": "1ibmc6iijim53bpi1wc1b295l579wzxgs8ynmsi0ldgjrxhgli1a",
+        "rev": "106e145e1d4583d1e2bb20e54947d15ad55e75e1",
+        "sha256": "0pqhgyrqf30zjlsyzyqada4znyahdanxwf7h74k8xds08y98kslf",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/4a3fc4cf736b7d2d288d7a8bf775ac8d4c0920b4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/106e145e1d4583d1e2bb20e54947d15ad55e75e1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
We need to pull in https://github.com/NixOS/nixpkgs/pull/323823 such that we can build justStaticExecutables for enableExecutableProfiling

## Checklist

 - n/a Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
