### PR TITLE
Concurrently fetch user profiles from the DB

### DIFF
--- a/changelog.d/5-internal/optimize-list-users
+++ b/changelog.d/5-internal/optimize-list-users
@@ -1,0 +1,1 @@
+Optimize getting a lot of users by concurrently getting target users


### PR DESCRIPTION
The endpoint typically takes 0.5-1 second to respond with ~200 users. It is called by the webapp on boot for every known user (not sure why) making UX very slow. 

Here is a chart from prod showing response times for this particular endpoint:

![image](https://github.com/wireapp/wire-server/assets/649161/263bfcaf-dac4-4621-a8f2-c0e690a135ee)


Local tests show about 70% reduction in response time.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
