### PR TITLE
[WPB-10230] Prevent creating a user with no identity

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-10230
+++ b/changelog.d/3-bug-fixes/WPB-10230
@@ -1,0 +1,1 @@
+Disallow creating a user with no identity

--- a/docs/src/developer/developer/api-versioning.md
+++ b/docs/src/developer/developer/api-versioning.md
@@ -118,6 +118,8 @@ the version. In these example we assume that version `V6` should be finalized an
   - update `versionedSwaggerDocsAPI` so that the finalized version points to the pregenerated swagger
   - and `internalEndpointsSwaggerDocsAPI` so that the finalized version `V6`, the new version `V7`, as well as the unversioned path point to the swagger of the internal API, and the previous latest stable version V5 points to an empty swagger.
 - Set the version for `gDefaultAPIVersion` in `integration/test/Testlib/Env.hs` to 7.
+- Update the `TestCases Versioned` instance in
+  `integration/test/Testlib/HTTP.hs` to include the new version.
 - Consider updating the `backendApiVersion` value in Stern, which is
   unit-tested by checking if it is listed as supported in the response to `GET
   /api-version`.

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -174,3 +174,12 @@ testActivateAccountWithPhoneV5 = do
   activateUserV5 dom reqBody `bindResponse` \resp -> do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "invalid-phone"
+
+testRegisterUserWithoutIdentity :: (HasCallStack) => Versioned -> App ()
+testRegisterUserWithoutIdentity versioned = do
+  req <-
+    baseRequest OwnDomain Brig versioned "register"
+      <&> addJSONObject ["name" .= "User without face"]
+  submit "POST" req `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 403
+    resp.json %. "label" `shouldMatch` "missing-identity"

--- a/integration/test/Testlib/HTTP.hs
+++ b/integration/test/Testlib/HTTP.hs
@@ -26,6 +26,7 @@ import Network.URI (URI (..), URIAuth (..), parseURI)
 import Testlib.Assertions
 import Testlib.Env
 import Testlib.JSON
+import Testlib.PTest
 import Testlib.Types
 import Prelude
 
@@ -126,6 +127,20 @@ onFailureAddResponse r m = App $ do
 
 data Versioned = Versioned | Unversioned | ExplicitVersion Int
   deriving stock (Generic)
+
+instance TestCases Versioned where
+  mkTestCases =
+    pure
+      [ MkTestCase "[versioned]" Versioned,
+        MkTestCase "[unversioned]" Unversioned,
+        MkTestCase "[explicit-version=0]" (ExplicitVersion 0),
+        MkTestCase "[explicit-version=1]" (ExplicitVersion 1),
+        MkTestCase "[explicit-version=2]" (ExplicitVersion 2),
+        MkTestCase "[explicit-version=3]" (ExplicitVersion 3),
+        MkTestCase "[explicit-version=4]" (ExplicitVersion 4),
+        MkTestCase "[explicit-version=5]" (ExplicitVersion 5),
+        MkTestCase "[explicit-version=6]" (ExplicitVersion 6)
+      ]
 
 -- | If you don't know what domain is for or what you should put in there, try `rawBaseRequest
 -- OwnDomain ...`.

--- a/libs/wire-api/src/Wire/API/Error/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Error/Brig.hs
@@ -178,7 +178,7 @@ type instance MapError 'AllowlistError = 'StaticError 403 "unauthorized" "Unauth
 
 type instance MapError 'InvalidInvitationCode = 'StaticError 400 "invalid-invitation-code" "Invalid invitation code."
 
-type instance MapError 'MissingIdentity = 'StaticError 403 "missing-identity" "Using an invitation code requires registering the given email."
+type instance MapError 'MissingIdentity = 'StaticError 403 "missing-identity" "User has no identity (email, or SSO ID combined with an optional email)."
 
 type instance
   MapError 'BlacklistedEmail =

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -283,6 +283,10 @@ createUser ::
 createUser new = do
   email <- validateEmailAndPhone new
 
+  -- assert the new user has an identity
+  unless (isJust (newIdentity email (newUserSSOId new))) $
+    throwE RegisterErrorMissingIdentity
+
   -- get invitation and existing account
   (mNewTeamUser, teamInvitation, tid) <-
     case newUserTeam new of


### PR DESCRIPTION
There was never an assertion nor a test checking that a new user has to have an identity. This PR fixes that.

Tracked by https://wearezeta.atlassian.net/browse/WPB-10230.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
