### PR TITLE
Remove FUTUREWORK about openapi3/swagger.

### DIFF
--- a/services/brig/src/Brig/API/Public/Swagger.hs
+++ b/services/brig/src/Brig/API/Public/Swagger.hs
@@ -129,31 +129,6 @@ emptySwagger =
       & S.info . S.description
         ?~ "There is no Swagger documentation for this version. Please refer to v5 or later."
 
-{- FUTUREWORK(fisx): there are a few things that need to be fixed before this schema collection
-   is of any practical use!
-
-- `ToSchema` instances of team notifications are wrong.  To do this right, search
-  schema-profunctor tutorial for bind/dispatch, and consult conversation events for
-  examples.
-
-- swagger2 doesn't handle types with the same name from different models well; it silently
-  drops the second definition, which is what you want only if there are no name clashes as
-  in our case with three types called `Event` and three types called `EventType`.  We have
-  solved this by rendering the three event types seperately and returning each
-  declarations list in a super-list.  For a better work-around, check
-  https://github.com/GetShopTV/swagger2/issues/14.
-
-- The different `EventData` constructors all have different json schema that partially
-  overlap.  Our schemas only represent the union of all those constructors, rather than a
-  list of cases.  There may be a better way even in swagger v2:
-  https://swagger.io/specification/v2/ (look for "polymorphism")
-
-- (wire cloud) expose end-point via nginz (only on staging).
-
-- Document how this works in
-  https://docs.wire.com/understand/api-client-perspective/swagger.html
-
-tracked in https://wearezeta.atlassian.net/browse/FS-1008 -}
 eventNotificationSchemas :: [S.Definitions S.Schema]
 eventNotificationSchemas = fst . (`S.runDeclare` mempty) <$> renderAll
   where


### PR DESCRIPTION
some parts of it were outdated or wrong, and what was valid is now tracked in WPB-10315, WPB-10316.

## Checklist

 - [x] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
