### PR TITLE
Simplify user feature logic

### DIFF
--- a/changelog.d/5-internal/user-features
+++ b/changelog.d/5-internal/user-features
@@ -1,0 +1,1 @@
+Refactor user feature logic

--- a/services/galley/src/Galley/API/Public/Bot.hs
+++ b/services/galley/src/Galley/API/Public/Bot.hs
@@ -50,9 +50,6 @@ getBotConversation ::
     Member TeamFeatureStore r,
     Member (ErrorS 'AccessDenied) r,
     Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS OperationDenied) r,
-    Member (ErrorS 'NotATeamMember) r,
-    Member (ErrorS 'TeamNotFound) r,
     Member TeamStore r
   ) =>
   BotId ->

--- a/services/galley/src/Galley/API/Public/Bot.hs
+++ b/services/galley/src/Galley/API/Public/Bot.hs
@@ -26,7 +26,6 @@ import Galley.App
 import Galley.Effects
 import Galley.Effects qualified as E
 import Galley.Options
-import Imports hiding (head)
 import Polysemy
 import Polysemy.Input
 import Wire.API.Error
@@ -55,6 +54,6 @@ getBotConversation ::
   BotId ->
   ConvId ->
   Sem r BotConvView
-getBotConversation bid cnv =
-  Features.guardSecondFactorDisabled (botUserId bid) cnv $
-    Query.getBotConversation bid cnv
+getBotConversation bid cnv = do
+  Features.guardSecondFactorDisabled (botUserId bid) cnv
+  Query.getBotConversation bid cnv

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -19,6 +19,7 @@ module Galley.API.Public.Feature where
 
 import Galley.API.Teams
 import Galley.API.Teams.Features
+import Galley.API.Teams.Features.Get
 import Galley.App
 import Imports
 import Wire.API.Federation.API
@@ -72,16 +73,16 @@ featureAPI =
     <@> mkNamedAPI @'("get", LimitedEventFanoutConfig) (getFeatureStatus . DoAuth)
     <@> mkNamedAPI @"get-all-feature-configs-for-user" getAllFeatureConfigsForUser
     <@> mkNamedAPI @"get-all-feature-configs-for-team" getAllFeatureConfigsForTeam
-    <@> mkNamedAPI @'("get-config", LegalholdConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", SSOConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", SearchVisibilityAvailableConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", ValidateSAMLEmailsConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", DigitalSignaturesConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", AppLockConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", FileSharingConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", ClassifiedDomainsConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", ConferenceCallingConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", SelfDeletingMessagesConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", GuestLinksConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", SndFactorPasswordChallengeConfig) getFeatureStatusForUser
-    <@> mkNamedAPI @'("get-config", MLSConfig) getFeatureStatusForUser
+    <@> mkNamedAPI @'("get-config", LegalholdConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", SSOConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", SearchVisibilityAvailableConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", ValidateSAMLEmailsConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", DigitalSignaturesConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", AppLockConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", FileSharingConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", ClassifiedDomainsConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", ConferenceCallingConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", SelfDeletingMessagesConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", GuestLinksConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", SndFactorPasswordChallengeConfig) getSingleFeatureConfigForUser
+    <@> mkNamedAPI @'("get-config", MLSConfig) getSingleFeatureConfigForUser

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -21,7 +21,6 @@ module Galley.API.Teams.Features
     setFeatureStatus,
     setFeatureStatusInternal,
     patchFeatureStatusInternal,
-    getFeatureStatusForUser,
     getAllFeatureConfigsForTeam,
     getAllFeatureConfigsForUser,
     updateLockStatus,

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -524,7 +524,7 @@ instance GetFeatureConfig LimitedEventFanoutConfig where
 --
 -- This function exists to resolve a cyclic dependency.
 guardSecondFactorDisabled ::
-  forall r a.
+  forall r.
   ( Member TeamFeatureStore r,
     Member (Input Opts) r,
     Member (ErrorS 'AccessDenied) r,
@@ -533,9 +533,8 @@ guardSecondFactorDisabled ::
   ) =>
   UserId ->
   ConvId ->
-  Sem r a ->
-  Sem r a
-guardSecondFactorDisabled uid cid action = do
+  Sem r ()
+guardSecondFactorDisabled uid cid = do
   mTid <- fmap hush . runError @() $ do
     convData <- ConversationStore.getConversationMetadata cid >>= note ()
     tid <- note () convData.cnvmTeam
@@ -544,7 +543,7 @@ guardSecondFactorDisabled uid cid action = do
 
   tf <- getConfigForTeamUser @SndFactorPasswordChallengeConfig uid mTid
   case wsStatus tf of
-    FeatureStatusDisabled -> action
+    FeatureStatusDisabled -> pure ()
     FeatureStatusEnabled -> throwS @'AccessDenied
 
 featureEnabledForTeam ::


### PR DESCRIPTION
This is a refactoring of the user feature lookup logic. It removes a redundant team lookup and a gratuitous CPS.

Followup to #4164.

https://wearezeta.atlassian.net/browse/WPB-10323

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
