### PR TITLE
coturn: Allow setting of K8s annotations at the Service

### DIFF
--- a/changelog.d/2-features/helm-coturn-service-annotations
+++ b/changelog.d/2-features/helm-coturn-service-annotations
@@ -1,0 +1,1 @@
+Allow setting of Kubernetes annotations for the `coturn` Service.

--- a/charts/coturn/templates/service.yaml
+++ b/charts/coturn/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   # Needs to be headless
   # See: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -115,3 +115,6 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 5
 
+service:
+  # Kubernetes annotations to be set at the Service
+  annotations: {}


### PR DESCRIPTION
This can e.g. be used to set external-dns annotations. Or, any other annotations (depending on the setup of the K8s cluster.) We'll be using it in our internal deployments to configure `external-dns`.

I've tested this manually on `sven-test` by pointing the `chart` of the Helm release to my local checkout.

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
