### PR TITLE
[chore] Deleted dangling phone references in Brig

### DIFF
--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -901,7 +901,7 @@ changePhone ::
 changePhone _ _ _ = pure . Just $ Public.InvalidNewPhone
 
 removePhone :: UserId -> Handler r (Maybe Public.RemoveIdentityError)
-removePhone self = lift . exceptTToMaybe $ API.removePhone self
+removePhone _ = (lift . pure) Nothing
 
 removeEmail ::
   ( Member (Embed HttpClientIO) r,

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -709,7 +709,7 @@ toLocale l _ = l
 -- activated.
 --
 -- The reason it's just a "precaution" is that we /also/ have an invariant that having an
--- email or phone in the database means the user has to be activated.
+-- email in the database means the user has to be activated.
 toIdentity ::
   -- | Whether the user is activated
   Bool ->


### PR DESCRIPTION
Brig.API.User still had functions referencing phones unnecessarily.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
