### PR TITLE
Add format paramter to mls public key endpoint

### DIFF
--- a/changelog.d/1-api-changes/jwk
+++ b/changelog.d/1-api-changes/jwk
@@ -1,0 +1,1 @@
+The `mls/public-key` endpoint now takes a `format` query parameter which can be either `raw` (default, for raw base64-encoded keys) or `jwk` (for JWK keys)

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -228,6 +228,11 @@ getMLSPublicKeys user = do
   req <- baseRequest user Galley Versioned "/mls/public-keys"
   submit "GET" req
 
+getMLSPublicKeysJWK :: (HasCallStack, MakesValue user) => user -> App Response
+getMLSPublicKeysJWK user = do
+  req <- baseRequest user Galley Versioned "/mls/public-keys"
+  submit "GET" $ addQueryParams [("format", "jwk")] req
+
 postMLSMessage :: (HasCallStack) => ClientIdentity -> ByteString -> App Response
 postMLSMessage cid msg = do
   req <- baseRequest cid Galley Versioned "/mls/messages"

--- a/integration/test/Test/MLS/Keys.hs
+++ b/integration/test/Test/MLS/Keys.hs
@@ -6,10 +6,20 @@ import qualified Data.ByteString.Char8 as B8
 import SetupHelpers
 import Testlib.Prelude
 
-testPublicKeys :: (HasCallStack) => App ()
-testPublicKeys = do
+testRawPublicKeys :: (HasCallStack) => App ()
+testRawPublicKeys = do
   u <- randomUserId OwnDomain
   keys <- getMLSPublicKeys u >>= getJSON 200
+
+  do
+    pubkeyS <- keys %. "removal.ed25519" & asString
+    pubkey <- assertOne . toList . B64U.decodeUnpadded $ B8.pack pubkeyS
+    B8.length pubkey `shouldMatchInt` 32
+
+testJWKPublicKeys :: (HasCallStack) => App ()
+testJWKPublicKeys = do
+  u <- randomUserId OwnDomain
+  keys <- getMLSPublicKeysJWK u >>= getJSON 200
 
   do
     keys %. "removal.ed25519.crv" `shouldMatch` "Ed25519"

--- a/integration/test/Test/MLS/Keys.hs
+++ b/integration/test/Test/MLS/Keys.hs
@@ -1,6 +1,7 @@
 module Test.MLS.Keys where
 
 import API.Galley
+import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Base64.URL as B64U
 import qualified Data.ByteString.Char8 as B8
 import SetupHelpers
@@ -13,8 +14,23 @@ testRawPublicKeys = do
 
   do
     pubkeyS <- keys %. "removal.ed25519" & asString
-    pubkey <- assertOne . toList . B64U.decodeUnpadded $ B8.pack pubkeyS
+    pubkey <- assertOne . toList . B64.decode $ B8.pack pubkeyS
     B8.length pubkey `shouldMatchInt` 32
+
+  do
+    pubkeyS <- keys %. "removal.ecdsa_secp256r1_sha256" & asString
+    pubkey <- assertOne . toList . B64.decode $ B8.pack pubkeyS
+    B8.length pubkey `shouldMatchInt` 65
+
+  do
+    pubkeyS <- keys %. "removal.ecdsa_secp384r1_sha384" & asString
+    pubkey <- assertOne . toList . B64.decode $ B8.pack pubkeyS
+    B8.length pubkey `shouldMatchInt` 97
+
+  do
+    pubkeyS <- keys %. "removal.ecdsa_secp521r1_sha512" & asString
+    pubkey <- assertOne . toList . B64.decode $ B8.pack pubkeyS
+    B8.length pubkey `shouldMatchInt` 133
 
 testJWKPublicKeys :: (HasCallStack) => App ()
 testJWKPublicKeys = do

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -110,23 +110,25 @@ type MLSMessagingAPI =
                :> MultiVerb1 'POST '[JSON] (Respond 201 "Commit accepted and forwarded" MLSMessageSendingStatus)
            )
     :<|> Named
-           "mls-public-keys-v6"
-           ( Summary "Get public keys used by the backend to sign external proposals"
-               :> From 'V5
-               :> Until 'V7
-               :> CanThrow 'MLSNotEnabled
-               :> "public-keys"
-               :> ZLocalUser
-               :> MultiVerb1 'GET '[JSON] (Respond 200 "Public keys" (MLSKeysByPurpose MLSPublicKeys))
-           )
-    :<|> Named
            "mls-public-keys"
            ( Summary "Get public keys used by the backend to sign external proposals"
-               :> From 'V7
+               :> Description
+                    "The format of the returned key is determined by the `format` query parameter:\n\
+                    \ - raw (default): base64-encoded raw public keys\n\
+                    \ - jwk: keys are nested objects in JWK format."
+               :> From 'V5
                :> CanThrow 'MLSNotEnabled
                :> "public-keys"
                :> ZLocalUser
-               :> MultiVerb1 'GET '[JSON] (Respond 200 "Public keys" (MLSKeysByPurpose MLSPublicKeysJWK))
+               :> QueryParam "format" MLSPublicKeyFormat
+               :> MultiVerb1
+                    'GET
+                    '[JSON]
+                    ( Respond
+                        200
+                        "Public keys"
+                        (MLSKeysByPurpose (MLSKeys SomeKey))
+                    )
            )
 
 type MLSAPI = LiftNamed ("mls" :> MLSMessagingAPI)

--- a/services/galley/src/Galley/API/Public/MLS.hs
+++ b/services/galley/src/Galley/API/Public/MLS.hs
@@ -27,5 +27,4 @@ mlsAPI :: API MLSAPI GalleyEffects
 mlsAPI =
   mkNamedAPI @"mls-message" (callsFed (exposeAnnotations postMLSMessageFromLocalUser))
     <@> mkNamedAPI @"mls-commit-bundle" (callsFed (exposeAnnotations postMLSCommitBundleFromLocalUser))
-    <@> mkNamedAPI @"mls-public-keys-v6" getMLSPublicKeys
-    <@> mkNamedAPI @"mls-public-keys" getMLSPublicKeysJWK
+    <@> mkNamedAPI @"mls-public-keys" getMLSPublicKeys


### PR DESCRIPTION
This removes the new endpoint for fetching JWK public keys, and replaces it with a backwards-compatible change on the existing endpoint, namely a query parameter determining the format (`raw` vs `jwk`).

https://wearezeta.atlassian.net/browse/WPB-10606

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
