### PR TITLE
[weed] Added data-migration to weed route, removed more dead code.

### DIFF
--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -37,12 +37,10 @@ module Wire.API.Team.Feature
     Feature (..),
     forgetLock,
     withLockStatus,
-    withUnlocked,
     FeatureTTL,
     FeatureTTLDays,
     FeatureTTL' (..),
     FeatureTTLUnit (..),
-    convertFeatureTTLDaysToSeconds,
     EnforceAppLock (..),
     genericComputeFeature,
     IsFeatureConfig (..),
@@ -365,9 +363,6 @@ forgetLock ws = Feature ws.status ws.config
 withLockStatus :: LockStatus -> Feature a -> LockableFeature a
 withLockStatus ls (Feature s c) = LockableFeature s ls c
 
-withUnlocked :: Feature a -> LockableFeature a
-withUnlocked = withLockStatus LockStatusUnlocked
-
 instance (ToSchema cfg, IsFeatureConfig cfg) => ToSchema (Feature cfg) where
   schema =
     object name $
@@ -399,10 +394,6 @@ data FeatureTTLUnit = FeatureTTLUnitSeconds | FeatureTTLUnitDays
 type FeatureTTL = FeatureTTL' 'FeatureTTLUnitSeconds
 
 type FeatureTTLDays = FeatureTTL' 'FeatureTTLUnitDays
-
-convertFeatureTTLDaysToSeconds :: FeatureTTLDays -> FeatureTTL
-convertFeatureTTLDaysToSeconds FeatureTTLUnlimited = FeatureTTLUnlimited
-convertFeatureTTLDaysToSeconds (FeatureTTLSeconds d) = FeatureTTLSeconds (d * (60 * 60 * 24))
 
 instance Arbitrary FeatureTTL where
   arbitrary =

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -283,7 +283,6 @@ executable cargohold-integration
     , mmorph
     , mtl
     , optparse-applicative
-    , safe
     , servant-client
     , tagged                 >=0.8
     , tasty                  >=1.0

--- a/services/cargohold/default.nix
+++ b/services/cargohold/default.nix
@@ -46,7 +46,6 @@
 , prometheus-client
 , resourcet
 , retry
-, safe
 , servant
 , servant-client
 , servant-server
@@ -155,7 +154,6 @@ mkDerivation {
     mmorph
     mtl
     optparse-applicative
-    safe
     servant-client
     tagged
     tasty

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -16,32 +16,25 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module API.Util
-  ( randomUser,
-    downloadAsset,
+  ( downloadAsset,
     withMockFederator,
   )
 where
 
 import Bilge hiding (body, host, port)
-import qualified Bilge
 import CargoHold.Options
 import CargoHold.Run
 import Control.Lens hiding ((.=))
 import Control.Monad.Codensity
-import Data.Aeson (object, (.=))
-import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Conversion
 import Data.Default
 import Data.Id
 import Data.Qualified
-import Data.Text.Encoding (encodeUtf8)
 import qualified Data.UUID as UUID
-import Data.UUID.V4 (nextRandom)
 import Federator.MockServer
 import Imports hiding (head)
 import qualified Network.HTTP.Media as HTTP
 import Network.Wai.Utilities.MockServer
-import Safe (readNote)
 import TestSetup
 import Util.Options
 import Wire.API.Asset
@@ -51,27 +44,6 @@ import Wire.API.Asset
 -- The changes to the asset routes forbidding non-verified users from uploading
 -- assets breaks a lot of existing tests.
 --
--- FUTUREWORK: Move all the cargohold tests to the new integration test suite.
--- https://wearezeta.atlassian.net/browse/WPB-5382
-randomUser :: TestM UserId
-randomUser = do
-  (Endpoint (encodeUtf8 -> eHost) ePort) <- view tsBrig
-  e <- liftIO $ mkEmail "success" "simulator.amazonses.com"
-  let p =
-        object
-          [ "name" .= e,
-            "email" .= e,
-            "password" .= ("secret-8-chars-long-at-least" :: Text)
-          ]
-  r <- post (Bilge.host eHost . Bilge.port ePort . path "/i/users" . json p)
-  pure
-    . readNote "unable to parse Location header"
-    . C.unpack
-    $ getHeader' "Location" r
-  where
-    mkEmail loc dom = do
-      uid <- nextRandom
-      pure $ loc <> "+" <> UUID.toText uid <> "@" <> dom
 
 zUser :: UserId -> Request -> Request
 zUser = header "Z-User" . UUID.toASCIIBytes . toUUID

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -36,7 +36,6 @@ module Util.Core
 
     -- * Test helpers
     it,
-    fit,
     pending,
     pendingWith,
     shouldRespondWith,
@@ -292,15 +291,6 @@ it ::
   TestSpar () ->
   SpecWith TestEnv
 it msg bdy = Test.Hspec.it msg $ runReaderT bdy
-
-fit ::
-  (HasCallStack) =>
-  -- or, more generally:
-  -- MonadIO m, Example (TestEnv -> m ()), Arg (TestEnv -> m ()) ~ TestEnv
-  String ->
-  TestSpar () ->
-  SpecWith TestEnv
-fit msg bdy = Test.Hspec.fit msg $ runReaderT bdy
 
 pending :: (HasCallStack, MonadIO m) => m ()
 pending = liftIO Test.Hspec.pending

--- a/weeder.toml
+++ b/weeder.toml
@@ -35,8 +35,10 @@ roots = [ # may of the entries here are about general-purpose module
          "^Data.Range.rinc",
          "^Data.Range.rsingleton",
          "^Data.ZAuth.Validation.*$",
-         "^Galley.Types.UserList.ulDiff",
+         "^Galley.Cassandra.FeatureTH.generateSOPInstances$",
+         "^Galley.Cassandra.FeatureTH.generateTupleP$",
          "^Galley.Types.Teams.canSeePermsOf", # TODO: figure out why weeder is confused by let bindings with curried infix notation
+         "^Galley.Types.UserList.ulDiff",
          "^HTTP2.Client.Manager.*$",
          "^Imports.getChar",
          "^Imports.getContents",
@@ -44,6 +46,7 @@ roots = [ # may of the entries here are about general-purpose module
          "^Imports.putChar",
          "^Imports.readIO",
          "^Imports.readLn",
+         "^Imports.todo",
          "^Main.debugMainDebugExportFull", # move-team
          "^Main.debugMainExport", # move-team
          "^Main.debugMainImport", # move-team
@@ -108,6 +111,7 @@ roots = [ # may of the entries here are about general-purpose module
          "^Proto.Otr_Fields.vec'userIds",
          "^Proto.TeamEvents_Fields.currency",
          "^Proto.TeamEvents_Fields.vec'billingUser",
+         "^Run.main$",
          "^Spar.Sem.AReqIDStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
          "^Spar.Sem.AssIDStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
          "^Spar.Sem.ScimTokenStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?


### PR DESCRIPTION
It seems data-migration was the reason for the over 800 false positives after all. 