### PR TITLE
upgrade to latest stable rabbitmq

### DIFF
--- a/changelog.d/2-features/upgrade-rabbitmq
+++ b/changelog.d/2-features/upgrade-rabbitmq
@@ -1,0 +1,1 @@
+Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`).

--- a/changelog.d/2-features/upgrade-rabbitmq
+++ b/changelog.d/2-features/upgrade-rabbitmq
@@ -1,4 +1,4 @@
 Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`). Please
-note that this major version upgrade (`3.11.x` to `3.13.x`) may need special
+note that this minor version upgrade (`3.11.x` to `3.13.x`) may need special
 treatment regarding existing RabbitMQ instances. See
 https://www.rabbitmq.com/docs/upgrade#rabbitmq-version-upgradability

--- a/changelog.d/2-features/upgrade-rabbitmq
+++ b/changelog.d/2-features/upgrade-rabbitmq
@@ -1,1 +1,4 @@
-Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`).
+Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`). Please
+note that this major version upgrade (`3.11.x` to `3.13.x`) may need special
+treatment regarding existing RabbitMQ instances. See
+https://www.rabbitmq.com/docs/upgrade#rabbitmq-version-upgradability

--- a/changelog.d/2-features/upgrade-rabbitmq
+++ b/changelog.d/2-features/upgrade-rabbitmq
@@ -1,4 +1,6 @@
 Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`). Please
-note that this minor version upgrade (`3.11.x` to `3.13.x`) may need special
-treatment regarding existing RabbitMQ instances. See
-https://www.rabbitmq.com/docs/upgrade#rabbitmq-version-upgradability
+note that this minor RabbitMQ version upgrade (`3.11.x` to `3.13.x`) may need
+special treatment regarding existing RabbitMQ instances. See
+https://www.rabbitmq.com/docs/upgrade#rabbitmq-version-upgradability . The major
+Helm chart version upgrade may (depending on your setup/values) need attention
+as well: https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq#upgrading

--- a/charts/rabbitmq/requirements.yaml
+++ b/charts/rabbitmq/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: rabbitmq
-  version: 11.13.0
+  version: 14.6.9
   repository: https://charts.bitnami.com/bitnami

--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -262,7 +262,7 @@ services:
 
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq:3.11-management-alpine
+    image: rabbitmq:3.13.7-management-alpine
     environment:
       - RABBITMQ_USERNAME
       - RABBITMQ_PASSWORD


### PR DESCRIPTION
Use latest stable RabbitMQ version (`3.13.7`) and Helm chart (`14.6.9`) - one is implied by the other.

This is compatible to our backend:
- I ran tests locally against a docker-compose deployment
- The Helmfile deployment for the CI test runs uses the chart: https://github.com/wireapp/wire-server/blob/sventennie%2Fupgrade-to-latest-stable-rabbitmq/hack/helmfile.yaml#L160

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
