### PR TITLE
[feat] add security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Haskell vulnerabilities
+on:
+  pull_request:
+    branches: [ "develop" ]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  haskell-security:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.8'
+
+      # FUTUREWORK(mangoiv): this  should be pinned to a "stable" version as soon as released
+      - name: Run Haskell Security Action
+        uses: blackheaven/haskell-security-action@55e78bbbb19df58059c474ac9131882d0d22ecbc
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/5-internal/security-workflow
+++ b/changelog.d/5-internal/security-workflow
@@ -1,0 +1,1 @@
+add a haskell github action to check vulnerabilities of the used haskell libraries


### PR DESCRIPTION
This workflow checks the haskell security advisories database for vulnerabilities and reports them in the security / code scan tab. 

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
