### PR TITLE
WPB-10985 `crlProxy` attribute missing from mls E2EID team config

### DIFF
--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -245,6 +245,14 @@ galley:
               usersThreshold: 100
               clientsThreshold: 50
             lockStatus: locked
+        mlsE2EId:
+          defaults:
+            status: disabled
+            config:
+              verificationExpiration: 86400
+              acmeDiscoveryUrl: null
+              crlProxy: https://crlproxy.example.com
+            lockStatus: unlocked
         limitedEventFanout:
             defaults:
             status: disabled

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -112,7 +112,11 @@ testMlsE2EConfigCrlProxyNotRequiredInV5 = do
     resp.status `shouldMatchInt` 200
 
   -- Assert that the feature config got updated correctly
-  expectedResponse <- configWithoutCrlProxy & setField "lockStatus" "unlocked" & setField "ttl" "unlimited"
+  expectedResponse <-
+    configWithoutCrlProxy
+      & setField "lockStatus" "unlocked"
+      & setField "ttl" "unlimited"
+      & setField "config.crlProxy" "https://crlproxy.example.com"
   checkFeature "mlsE2EId" owner tid expectedResponse
 
 testSSODisabledByDefault :: HasCallStack => App ()
@@ -346,7 +350,8 @@ testAllFeatures = do
                   "config"
                     .= object
                       [ "verificationExpiration" .= A.Number 86400,
-                        "useProxyOnMobile" .= False
+                        "useProxyOnMobile" .= False,
+                        "crlProxy" .= "https://crlproxy.example.com"
                       ]
                 ],
             "mlsMigration"
@@ -631,7 +636,8 @@ mlsE2EIdConfig = do
           "config"
             .= object
               [ "verificationExpiration" .= A.Number 86400,
-                "useProxyOnMobile" .= False
+                "useProxyOnMobile" .= False,
+                "crlProxy" .= "https://crlproxy.example.com"
               ]
         ]
     mlsE2EIdConfig1 :: Value
@@ -913,7 +919,8 @@ testPatchE2EId = do
             "config"
               .= object
                 [ "verificationExpiration" .= A.Number 86400,
-                  "useProxyOnMobile" .= False
+                  "useProxyOnMobile" .= False,
+                  "crlProxy" .= "https://crlproxy.example.com"
                 ]
           ]
   _testPatch "mlsE2EId" True defCfg (object ["lockStatus" .= "locked"])

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -90,6 +90,7 @@ settings:
         config:
           verificationExpiration: 86400
           acmeDiscoveryUrl: null
+          crlProxy: https://crlproxy.example.com
         lockStatus: unlocked
     mlsMigration:
       defaults:

--- a/services/galley/src/Galley/Cassandra/GetAllTeamFeatureConfigs.hs
+++ b/services/galley/src/Galley/Cassandra/GetAllTeamFeatureConfigs.hs
@@ -372,8 +372,8 @@ instance MakeFeature MlsE2EIdConfig where
             defCfg
               { verificationExpiration =
                   maybe defCfg.verificationExpiration fromIntegral gracePeriod,
-                acmeDiscoveryUrl = acmeDiscoveryUrl,
-                crlProxy = crlProxy,
+                acmeDiscoveryUrl = acmeDiscoveryUrl <|> defCfg.acmeDiscoveryUrl,
+                crlProxy = crlProxy <|> defCfg.crlProxy,
                 useProxyOnMobile = fromMaybe defCfg.useProxyOnMobile useProxyOnMobile
               }
         )


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-10985
https://github.com/wireapp/wire-server/pull/4233

## Checklist

 - [ ] ~Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
