### PR TITLE
Move test documentation tags from proteus to MLS

### DIFF
--- a/changelog.d/4-docs/mls-test-tags
+++ b/changelog.d/4-docs/mls-test-tags
@@ -1,0 +1,1 @@
+Deleted proteus-specific test documentation tags and added some new tags to MLS tests

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -529,6 +529,10 @@ testFirstCommitAllowsPartialAdds = do
     resp.status `shouldMatchInt` 409
     resp.json %. "label" `shouldMatch` "mls-client-mismatch"
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+--
+-- This test verifies that the server rejects a commit containing add proposals
+-- that only add a proper subset of the set of clients of a user.
 testAddUserPartial :: (HasCallStack) => App ()
 testAddUserPartial = do
   [alice, bob, charlie] <- createAndConnectUsers (replicate 3 OwnDomain)
@@ -555,6 +559,8 @@ testAddUserPartial = do
 
   err <- postMLSCommitBundle mp.sender (mkBundle mp) >>= getJSON 409
   err %. "label" `shouldMatch` "mls-client-mismatch"
+
+-- @END
 
 -- | admin removes user from a conversation but doesn't list all clients
 testRemoveClientsIncomplete :: (HasCallStack) => App ()
@@ -741,6 +747,10 @@ testPropExistingConv = do
   res <- createAddProposals alice1 [bob] >>= traverse sendAndConsumeMessage >>= assertOne
   shouldBeEmpty (res %. "events")
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+--
+-- This test verifies that the server rejects any commit that does not
+-- reference all pending proposals in an MLS group.
 testCommitNotReferencingAllProposals :: (HasCallStack) => App ()
 testCommitNotReferencingAllProposals = do
   users@[_alice, bob, charlie] <- createAndConnectUsers (replicate 3 OwnDomain)
@@ -764,6 +774,8 @@ testCommitNotReferencingAllProposals = do
   bindResponse (postMLSCommitBundle alice1 (mkBundle commit)) $ \resp -> do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "mls-commit-missing-references"
+
+-- @END
 
 testUnsupportedCiphersuite :: (HasCallStack) => App ()
 testUnsupportedCiphersuite = do

--- a/integration/test/Test/MLS/Message.hs
+++ b/integration/test/Test/MLS/Message.hs
@@ -26,9 +26,14 @@ import Notifications
 import SetupHelpers
 import Testlib.Prelude
 
--- | Test happy case of federated MLS message sending in both directions.
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+-- This test verifies whether a message actually gets sent all the way to
+-- cannon.
+
 testApplicationMessage :: (HasCallStack) => App ()
 testApplicationMessage = do
+  -- Test happy case of federated MLS message sending in both directions.
+
   -- local alice and alex, remote bob
   [alice, alex, bob, betty] <-
     createUsers
@@ -54,6 +59,8 @@ testApplicationMessage = do
     -- bob sends a message
     void $ createApplicationMessage bob1 "hey" >>= sendAndConsumeMessage
     traverse_ (awaitMatch isNewMLSMessageNotif) wss
+
+-- @END
 
 testAppMessageSomeReachable :: (HasCallStack) => App ()
 testAppMessageSomeReachable = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -495,8 +495,6 @@ postCryptoMessageVerifyMsgSentAndRejectIfMissingClient = do
       liftIO $ assertBool "unexpected equal clients" (bc /= bc2)
       assertNoMsg wsB2 (wsAssertOtr qconv qalice ac bc cipher)
 
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies basic mismatch behavior of the the JSON endpoint.
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysJson :: TestM ()
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysJson = do
   (alice, ac) <- randomUserWithClient (head someLastPrekeys)
@@ -520,8 +518,6 @@ postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysJson = do
   liftIO $ do
     Map.keys (userClientMap (getUserClientPrekeyMap p)) @=? [eve]
     Map.keys <$> Map.lookup eve (userClientMap (getUserClientPrekeyMap p)) @=? Just [ec]
-
--- @END
 
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto :: TestM ()
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto = do
@@ -813,11 +809,6 @@ postMessageQualifiedLocalOwningBackendRedundantAndDeletedClients = do
       -- Wait less for no message
       WS.assertNoEvent (1 # Second) [wsNonMember]
 
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- Sets up a conversation on Backend A known as "owning backend". One of the
--- users from Backend A will send the message but have a missing client. It is
--- expected that the message will be sent except when it is specifically
--- requested to report on missing clients of a user.
 postMessageQualifiedLocalOwningBackendIgnoreMissingClients :: TestM ()
 postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
   -- WS receive timeout
@@ -939,8 +930,6 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
               [(qUnqualified deeRemote, Set.singleton deeClient)]
       assertMismatchQualified mempty expectedMissing mempty mempty mempty
     WS.assertNoEvent (1 # Second) [wsBob, wsChad]
-
--- @END
 
 postMessageQualifiedLocalOwningBackendFailedToSendClients :: TestM ()
 postMessageQualifiedLocalOwningBackendFailedToSendClients = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -409,9 +409,6 @@ postConvWithUnreachableRemoteUsers rbs = do
         groupConvs
     WS.assertNoEvent (3 # Second) [wsAlice, wsAlex] -- TODO: sometimes, (at least?) one of these users gets a "connection accepted" event.
 
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies whether a message actually gets sent all the way to
--- cannon.
 postCryptoMessageVerifyMsgSentAndRejectIfMissingClient :: TestM ()
 postCryptoMessageVerifyMsgSentAndRejectIfMissingClient = do
   localDomain <- viewFederationDomain
@@ -498,8 +495,6 @@ postCryptoMessageVerifyMsgSentAndRejectIfMissingClient = do
       liftIO $ assertBool "unexpected equal clients" (bc /= bc2)
       assertNoMsg wsB2 (wsAssertOtr qconv qalice ac bc cipher)
 
--- @END
-
 -- @SF.Separation @TSFI.RESTfulAPI @S2
 -- This test verifies basic mismatch behavior of the the JSON endpoint.
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysJson :: TestM ()
@@ -528,8 +523,6 @@ postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysJson = do
 
 -- @END
 
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies basic mismatch behaviour of the protobuf endpoint.
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto :: TestM ()
 postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto = do
   (alice, ac) <- randomUserWithClient (head someLastPrekeys)
@@ -556,8 +549,6 @@ postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto = do
     Map.keys (userClientMap (getUserClientPrekeyMap p)) @=? [eve]
     Map.keys <$> Map.lookup eve (userClientMap (getUserClientPrekeyMap p)) @=? Just [ec]
 
--- @END
-
 -- | This test verifies behaviour when an unknown client posts the message. Only
 -- tests the Protobuf endpoint.
 postCryptoMessageNotAuthorizeUnknownClient :: TestM ()
@@ -573,10 +564,6 @@ postCryptoMessageNotAuthorizeUnknownClient = do
   postProtoOtrMessage alice (ClientId 0x172618352518396) conv m
     !!! const 403 === statusCode
 
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies the following scenario.
--- A client sends a message to all clients of a group and one more who is not part of the group.
--- The server must not send this message to client ids not part of the group.
 postMessageClientNotInGroupDoesNotReceiveMsg :: TestM ()
 postMessageClientNotInGroupDoesNotReceiveMsg = do
   localDomain <- viewFederationDomain
@@ -599,11 +586,6 @@ postMessageClientNotInGroupDoesNotReceiveMsg = do
     checkEveGetsMsg
     checkChadDoesNotGetMsg
 
--- @END
-
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies that when a client sends a message not to all clients of a group then the server should reject the message and sent a notification to the sender (412 Missing clients).
--- The test is somewhat redundant because this is already tested as part of other tests already. This is a stand alone test that solely tests the behavior described above.
 postMessageRejectIfMissingClients :: TestM ()
 postMessageRejectIfMissingClients = do
   (sender, senderClient) : allReceivers <- randomUserWithClient `traverse` someLastPrekeys
@@ -629,11 +611,6 @@ postMessageRejectIfMissingClients = do
     mkMsg :: ByteString -> (UserId, ClientId) -> (UserId, ClientId, Text)
     mkMsg text (uid, clientId) = (uid, clientId, toBase64Text text)
 
--- @END
-
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- This test verifies behaviour under various values of ignore_missing and
--- report_missing. Only tests the JSON endpoint.
 postCryptoMessageVerifyCorrectResponseIfIgnoreAndReportMissingQueryParam :: TestM ()
 postCryptoMessageVerifyCorrectResponseIfIgnoreAndReportMissingQueryParam = do
   (alice, ac) <- randomUserWithClient (head someLastPrekeys)
@@ -689,12 +666,6 @@ postCryptoMessageVerifyCorrectResponseIfIgnoreAndReportMissingQueryParam = do
   where
     listToByteString = BS.intercalate "," . map toByteString'
 
--- @END
-
--- @SF.Separation @TSFI.RESTfulAPI @S2
--- Sets up a conversation on Backend A known as "owning backend". One of the
--- users from Backend A will send the message but have a missing client. It is
--- expected that the message will not be sent.
 postMessageQualifiedLocalOwningBackendMissingClients :: TestM ()
 postMessageQualifiedLocalOwningBackendMissingClients = do
   -- Cannon for local users
@@ -751,8 +722,6 @@ postMessageQualifiedLocalOwningBackendMissingClients = do
                 ]
       assertMismatchQualified mempty expectedMissing mempty mempty mempty
     WS.assertNoEvent (1 # Second) [wsBob, wsChad]
-
--- @END
 
 -- | Sets up a conversation on Backend A known as "owning backend". One of the
 -- users from Backend A will send the message, it is expected that message will

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -252,6 +252,9 @@ postMLSConvOk = do
     qcid <- assertConv rsp RegularConv (Just alice) qalice [] (Just nameMaxSize) Nothing
     checkConvCreateEvent (qUnqualified qcid) wsA
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+--
+-- This test verifies that a user must be a member of an MLS conversation in order to send messages to it.
 testSenderNotInConversation :: TestM ()
 testSenderNotInConversation = do
   -- create users
@@ -278,6 +281,8 @@ testSenderNotInConversation = do
           <!! const 404 === statusCode
 
     liftIO $ Wai.label err @?= "no-conversation"
+
+-- @END
 
 testAddUserWithBundle :: TestM ()
 testAddUserWithBundle = do
@@ -665,6 +670,10 @@ testLocalToRemoteNonMember = do
             const (Just "no-conversation-member")
               === fmap Wai.label . responseJsonError
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+--
+-- This test verifies that only the members of an MLS conversation are allowed
+-- to join via external commit.
 testExternalCommitNotMember :: TestM ()
 testExternalCommitNotMember = do
   [alice, bob] <- createAndConnectUsers (replicate 2 Nothing)
@@ -682,6 +691,8 @@ testExternalCommitNotMember = do
     bundle <- createBundle mp
     localPostCommitBundle (mpSender mp) bundle
       !!! const 404 === statusCode
+
+-- @END
 
 testExternalCommitSameClient :: TestM ()
 testExternalCommitSameClient = do


### PR DESCRIPTION
Move test doc tags from proteus to MLS

Deleted some of the documentation start and ending tags from Proteus
tests and added them to some of the MLS tests.

Deleted tags from:
- `postCryptoMessageVerifyMsgSentAndRejectIfMissingClient`
- `postCryptoMessageVerifyRejectMissingClientAndRepondMissingPrekeysJson`
- `postCryptoMessageVerifyRejectMissingClientAndRespondMissingPrekeysProto`
- `postMessageClientNotInGroupDoesNotReceiveMsg`
- `postMessageRejectIfMissingClients`
- `postCryptoMessageVerifyCorrectResponseIfIgnoreAndReportMissingQueryParam`
- `postMessageQualifiedLocalOwningBackendMissingClients`

Added tags to

- `testSenderNotInConversation`
- `testApplicationMessage`
- `testExternalCommitNotMember `
- `testCommitNotReferencingAllProposals `
- `testAddUserPartial`

Also generalised `testAccessUpdateGuestRemoved` to work with both MLS and Proteus conversations.

https://wearezeta.atlassian.net/browse/WPB-10894

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
