### PR TITLE
WPB-10660 Enable and deploy background worker in non federation environments

### DIFF
--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -96,7 +96,6 @@ dependencies:
   repository: "file://../background-worker"
   tags:
     - background-worker
-    - federation
     - haskellServices
     - services
 - name: integration

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -17,8 +17,10 @@ import Imports
 import Network.AMQP qualified as Q
 import Network.AMQP.Extended
 import Network.AMQP.Lifted qualified as QL
-import Network.RabbitMqAdmin
+import Network.RabbitMqAdmin hiding (adminClient)
+import Network.RabbitMqAdmin qualified as RabbitMqAdmin
 import Prometheus
+import Servant.Client qualified as Servant
 import System.Logger.Class qualified as Log
 import UnliftIO
 import Wire.API.Federation.API
@@ -197,8 +199,8 @@ pairedMaximumOn f = maximumBy (compare `on` snd) . map (id &&& f)
 -- FUTUREWORK: Recosider using 1 channel for many consumers. It shouldn't matter
 -- for a handful of remote domains.
 -- Consumers is passed in explicitly so that cleanup code has a reference to the consumer tags.
-startPusher :: IORef (Map Domain (Q.ConsumerTag, MVar ())) -> Q.Channel -> AppT IO ()
-startPusher consumersRef chan = do
+startPusher :: RabbitMqAdmin.AdminAPI (Servant.AsClientT IO) -> IORef (Map Domain (Q.ConsumerTag, MVar ())) -> Q.Channel -> AppT IO ()
+startPusher adminClient consumersRef chan = do
   -- This ensures that we receive notifications 1 by 1 which ensures they are
   -- delivered in order.
   markAsWorking BackendNotificationPusher
@@ -221,7 +223,7 @@ startPusher consumersRef chan = do
     ]
     $ forever
     $ do
-      remotes <- getRemoteDomains
+      remotes <- getRemoteDomains adminClient
       ensureConsumers consumersRef chan remotes
       threadDelay timeBeforeNextRefresh
 
@@ -259,8 +261,8 @@ ensureConsumer consumers chan domain = do
     -- let us come down this path if there is an old consumer.
     liftIO $ forM_ oldTag $ Q.cancelConsumer chan . fst
 
-getRemoteDomains :: AppT IO [Domain]
-getRemoteDomains = do
+getRemoteDomains :: RabbitMqAdmin.AdminAPI (Servant.AsClientT IO) -> AppT IO [Domain]
+getRemoteDomains adminClient = do
   -- Jittered exponential backoff with 10ms as starting delay and 60s as max
   -- cumulative delay. When this is reached, the operation fails.
   --
@@ -279,9 +281,8 @@ getRemoteDomains = do
   where
     go :: AppT IO [Domain]
     go = do
-      client <- asks rabbitmqAdminClient
       vhost <- asks rabbitmqVHost
-      queues <- liftIO $ listQueuesByVHost client vhost
+      queues <- liftIO $ listQueuesByVHost adminClient vhost
       let notifQueuesSuffixes = mapMaybe (\q -> Text.stripPrefix "backend-notifications." q.name) queues
       catMaybes <$> traverse (\d -> either (\e -> logInvalidDomain d e >> pure Nothing) (pure . Just) $ mkDomain d) notifQueuesSuffixes
     logInvalidDomain d e =
@@ -290,7 +291,7 @@ getRemoteDomains = do
           . Log.field "queue" ("backend-notifications." <> d)
           . Log.field "error" e
 
-startWorker :: RabbitMqAdminOpts -> AppT IO (IORef (Maybe Q.Channel), IORef (Map Domain (Q.ConsumerTag, MVar ())))
+startWorker :: AmqpEndpoint -> AppT IO (IORef (Maybe Q.Channel), IORef (Map Domain (Q.ConsumerTag, MVar ())))
 startWorker rabbitmqOpts = do
   env <- ask
   -- These are used in the POSIX signal handlers, so we need to make
@@ -304,22 +305,28 @@ startWorker rabbitmqOpts = do
       clearRefs = do
         atomicWriteIORef chanRef Nothing
         atomicWriteIORef consumersRef mempty
-  -- We can fire and forget this thread because it keeps respawning itself using the 'onConnectionClosedHandler'.
-  void $
-    async $
-      liftIO $
-        openConnectionWithRetries env.logger (demoteOpts rabbitmqOpts) $
-          RabbitMqHooks
-            { -- The exception handling in `openConnectionWithRetries` won't open a new
-              -- connection on an explicit close call.
-              onNewChannel = \chan -> do
-                atomicWriteIORef chanRef $ pure chan
-                runAppT env $ startPusher consumersRef chan,
-              onChannelException = \_ -> do
-                clearRefs
-                runAppT env $ markAsNotWorking BackendNotificationPusher,
-              onConnectionClose = do
-                clearRefs
-                runAppT env $ markAsNotWorking BackendNotificationPusher
-            }
+  case env.rabbitmqAdminClient of
+    Nothing ->
+      Log.info $
+        Log.msg $
+          Log.val "RabbitMQ admin client not available, skipping backend notification pusher."
+    Just client ->
+      -- We can fire and forget this thread because it keeps respawning itself using the 'onConnectionClosedHandler'.
+      void $
+        async $
+          liftIO $
+            openConnectionWithRetries env.logger rabbitmqOpts $
+              RabbitMqHooks
+                { -- The exception handling in `openConnectionWithRetries` won't open a new
+                  -- connection on an explicit close call.
+                  onNewChannel = \chan -> do
+                    atomicWriteIORef chanRef $ pure chan
+                    runAppT env $ startPusher client consumersRef chan,
+                  onChannelException = \_ -> do
+                    clearRefs
+                    runAppT env $ markAsNotWorking BackendNotificationPusher,
+                  onConnectionClose = do
+                    clearRefs
+                    runAppT env $ markAsNotWorking BackendNotificationPusher
+                }
   pure (chanRef, consumersRef)

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -8,6 +8,7 @@ import Data.Metrics.Servant qualified as Metrics
 import Data.Text qualified as T
 import Imports
 import Network.AMQP qualified as Q
+import Network.AMQP.Extended (demoteOpts)
 import Network.Wai.Utilities.Server
 import Servant
 import Servant.Server.Generic
@@ -21,7 +22,8 @@ import Wire.BackgroundWorker.Options
 run :: Opts -> IO ()
 run opts = do
   env <- mkEnv opts
-  (notifChanRef, notifConsumersRef) <- runAppT env $ BackendNotificationPusher.startWorker opts.rabbitmq
+  let amqpEP = either id demoteOpts opts.rabbitmq.unRabbitMqOpts
+  (notifChanRef, notifConsumersRef) <- runAppT env $ BackendNotificationPusher.startWorker amqpEP
   let -- cleanup will run in a new thread when the signal is caught, so we need to use IORefs and
       -- specific exception types to message threads to clean up
       l = logger env

--- a/services/background-worker/src/Wire/BackgroundWorker/Options.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Options.hs
@@ -11,7 +11,7 @@ data Opts = Opts
     logFormat :: !(Maybe (Last LogFormat)),
     backgroundWorker :: !Endpoint,
     federatorInternal :: !Endpoint,
-    rabbitmq :: !RabbitMqAdminOpts,
+    rabbitmq :: !RabbitMqOpts,
     -- | Seconds, Nothing for no timeout
     defederationTimeout :: Maybe Int,
     backendNotificationPusher :: BackendNotificationsConfig
@@ -37,3 +37,13 @@ data BackendNotificationsConfig = BackendNotificationsConfig
   deriving (Show, Generic)
 
 instance FromJSON BackendNotificationsConfig
+
+newtype RabbitMqOpts = RabbitMqOpts {unRabbitMqOpts :: Either AmqpEndpoint RabbitMqAdminOpts}
+  deriving (Show)
+
+instance FromJSON RabbitMqOpts where
+  parseJSON v =
+    RabbitMqOpts
+      <$> ( (Right <$> parseJSON v)
+              <|> (Left <$> parseJSON v)
+          )

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -390,7 +390,7 @@ data Opts = Opts
     -- | SFT Federation
     multiSFT :: !(Maybe Bool),
     -- | RabbitMQ settings, required when federation is enabled.
-    rabbitmq :: !(Maybe RabbitMqOpts),
+    rabbitmq :: !(Maybe AmqpEndpoint),
     -- | AWS settings
     aws :: !AWSOpts,
     -- | Enable Random Prekey Strategy

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -182,7 +182,7 @@ data Opts = Opts
     -- | Federator endpoint
     _federator :: !(Maybe Endpoint),
     -- | RabbitMQ settings, required when federation is enabled.
-    _rabbitmq :: !(Maybe RabbitMqOpts),
+    _rabbitmq :: !(Maybe AmqpEndpoint),
     -- | Disco URL
     _discoUrl :: !(Maybe Text),
     -- | Other settings


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
