### PR TITLE
[chore] Replace pattern synomyn with ADT.

### DIFF
--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -224,7 +224,7 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
 
   -- when a user tries to join any mls conversation while being legalholded
   -- they receive a 409 stating that mls and legalhold are incompatible
-  case qusr `RelativeTo` lConvOrSubId of
+  case qusr `relativeTo` lConvOrSubId of
     Local luid ->
       when (isNothing convOrSub.mlsMeta.cnvmlsActiveData) do
         usrTeams <- getUserTeams (tUnqualified luid)


### PR DESCRIPTION
ADTs are simpler, easier to reason about and cover this specific case better, without us having to override completeness checks with pragmas.