### PR TITLE
[WPB-11386] Introduce length-preserving function mapRange to replace fmap.

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-11386-map-range
+++ b/changelog.d/3-bug-fixes/WPB-11386-map-range
@@ -1,1 +1,0 @@
-Introduce length-preserving function mapRange to replace Functor instance for Range data type.

--- a/changelog.d/3-bug-fixes/WPB-11386-map-range
+++ b/changelog.d/3-bug-fixes/WPB-11386-map-range
@@ -1,0 +1,1 @@
+Introduce length-preserving function mapRange to replace Functor instance for Range data type.

--- a/changelog.d/5-internal/WPB-11386-map-range
+++ b/changelog.d/5-internal/WPB-11386-map-range
@@ -1,0 +1,1 @@
+Introduce length-preserving function mapRange to replace Functor instance for Range data type.

--- a/libs/types-common/src/Data/Range.hs
+++ b/libs/types-common/src/Data/Range.hs
@@ -101,8 +101,8 @@ newtype Range (n :: Nat) (m :: Nat) a = Range
   }
   deriving (Eq, Ord, Show)
 
-mapRange :: (Functor f) => (a -> b) -> Range (n :: Nat) (m :: Nat) (f a) -> Range (n :: Nat) (m :: Nat) (f b)
-mapRange f (Range as) = Range (f <$> as)
+mapRange :: forall (n :: Nat) (m :: Nat) a b. (a -> b) -> Range n m [a] -> Range n m [b]
+mapRange f (Range as) = Range (f `map` as)
 
 toRange :: (n <= x, x <= m, KnownNat x, Num a) => Proxy x -> Range n m a
 toRange = Range . fromIntegral . natVal

--- a/libs/types-common/src/Data/Range.hs
+++ b/libs/types-common/src/Data/Range.hs
@@ -26,6 +26,7 @@
 module Data.Range
   ( Range,
     toRange,
+    mapRange,
     Within,
     Bounds (..),
     checked,
@@ -98,7 +99,10 @@ import Test.QuickCheck qualified as QC
 newtype Range (n :: Nat) (m :: Nat) a = Range
   { fromRange :: a
   }
-  deriving (Eq, Ord, Show, Functor)
+  deriving (Eq, Ord, Show)
+
+mapRange :: (Functor f) => (a -> b) -> Range (n :: Nat) (m :: Nat) (f a) -> Range (n :: Nat) (m :: Nat) (f b)
+mapRange f (Range as) = Range (f <$> as)
 
 toRange :: (n <= x, x <= m, KnownNat x, Num a) => Proxy x -> Range n m a
 toRange = Range . fromIntegral . natVal

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -326,7 +326,7 @@ notifyUserDeletionRemotes deleted = do
           pure ()
         Just rangedUcs -> do
           luidDeleted <- qualifyLocal' deleted
-          embed $ notifyUserDeleted luidDeleted (qualifyAs ucs ((fmap (fmap (qUnqualified . ucTo))) rangedUcs))
+          embed $ notifyUserDeleted luidDeleted (qualifyAs ucs (mapRange (qUnqualified . ucTo) rangedUcs))
           -- also sent connection cancelled events to the connections that are pending
           let remotePendingConnections = qualifyAs ucs <$> filter ((==) Sent . ucStatus) (fromRange rangedUcs)
           forM_ remotePendingConnections $ sendCancelledEvent luidDeleted


### PR DESCRIPTION
WPB-11386

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
