### PR TITLE
Run tests with ElasticSearch 7

### DIFF
--- a/charts/elasticsearch-ephemeral/values.yaml
+++ b/charts/elasticsearch-ephemeral/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: elasticsearch
   # Keep this aligned with the Elastic Search version in wire-server-deploy!
-  tag: 6.8.23
+  tag: 7.17.24
 
 service:
   httpPort: 9200

--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -209,7 +209,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM quay.io/wire/elasticsearch:0.0.9-amd64
+        FROM elasticsearch:7.17.24
         RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install x-pack -b
         # this seems to be necessary to run X-Pack on Alpine (https://discuss.elastic.co/t/elasticsearch-failing-to-start-due-to-x-pack/85125/7)
         RUN rm -rf /usr/share/elasticsearch/plugins/x-pack/platform/linux-x86_64

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -95,8 +95,9 @@ let
     bloodhound = {
       src = fetchgit {
         url = "https://github.com/wireapp/bloodhound";
-        rev = "abf819a4a6ec7601f1e58cb8da13b2fdad377d9e";
-        hash = "sha256-m1O+F/mOJN5z5WNChmeyHP4dtmLRkl2YnLlTuwzRelk=";
+        # https://github.com/wireapp/bloodhound/tree/sventennie/es7-compatibility
+        rev = "78be105f8d67e3d083806a4c3797838183421e19";
+        hash = "sha256-oBWrJHnTZEj4fLJNHLSj3H1RI6aAwloiNUWBHjVq6QU=";
       };
     };
 


### PR DESCRIPTION
Trying to upgrade in small steps as the changeset for migrating to ES 8 (OS 2) became too big.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
