### PR TITLE
Removed redundant MonadReader constraint.

### DIFF
--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -118,8 +118,7 @@ reAuthForNewClients :: ReAuthPolicy
 reAuthForNewClients count upsert = count > 0 && not upsert
 
 addClient ::
-  ( MonadReader Brig.App.Env (AppT r),
-    Member AuthenticationSubsystem r
+  ( Member AuthenticationSubsystem r
   ) =>
   Local UserId ->
   ClientId ->


### PR DESCRIPTION
Seems to be a mistake when rebasing a PR without aligning with develop ahead of time, weird.
