### PR TITLE
brig: Remove unnecessary List1 Event when pushing notifications

### DIFF
--- a/libs/wire-subsystems/src/Wire/NotificationSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/NotificationSubsystem.hs
@@ -45,7 +45,7 @@ data NotificationSubsystem m a where
   -- send notifications is not critical.
   --
   -- See 'Polysemy.Async' to know more about the 'Maybe'
-  PushNotificationsAsync :: [Push] -> NotificationSubsystem m (Async (Maybe ()))
+  PushNotificationAsync :: Push -> NotificationSubsystem m (Async (Maybe ()))
   CleanupUser :: UserId -> NotificationSubsystem m ()
   UnregisterPushClient :: UserId -> ClientId -> NotificationSubsystem m ()
   GetPushTokens :: UserId -> NotificationSubsystem m [PushToken]

--- a/libs/wire-subsystems/src/Wire/NotificationSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/NotificationSubsystem/Interpreter.hs
@@ -42,7 +42,7 @@ runNotificationSubsystemGundeck ::
 runNotificationSubsystemGundeck cfg = interpret $ \case
   PushNotifications ps -> runInputConst cfg $ pushImpl ps
   PushNotificationsSlowly ps -> runInputConst cfg $ pushSlowlyImpl ps
-  PushNotificationsAsync ps -> runInputConst cfg $ pushAsyncImpl ps
+  PushNotificationAsync ps -> runInputConst cfg $ pushAsyncImpl ps
   CleanupUser uid -> GundeckAPIAccess.userDeleted uid
   UnregisterPushClient uid cid -> GundeckAPIAccess.unregisterPushClient uid cid
   GetPushTokens uid -> GundeckAPIAccess.getPushTokens uid
@@ -75,11 +75,11 @@ pushAsyncImpl ::
     Member (Final IO) r,
     Member P.TinyLog r
   ) =>
-  [Push] ->
+  Push ->
   Sem r (Async (Maybe ()))
-pushAsyncImpl ps = async $ do
+pushAsyncImpl p = async $ do
   reqId <- inputs requestId
-  errorToIOFinal @SomeException (fromExceptionSem @SomeException $ pushImpl ps) >>= \case
+  errorToIOFinal @SomeException (fromExceptionSem @SomeException $ pushImpl [p]) >>= \case
     Left e ->
       P.err $
         Log.msg (Log.val "Error while pushing notifications")

--- a/libs/wire-subsystems/test/unit/Wire/NotificationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/NotificationSubsystem/InterpreterSpec.hs
@@ -228,9 +228,8 @@ spec = describe "NotificationSubsystem.Interpreter" do
                 pushJson = payload1,
                 _pushApsData = Nothing
               }
-          pushes = [push1]
       (_, attemptedPushes, logs) <- runMiniStackAsync mockConfig $ do
-        thread <- pushAsyncImpl pushes
+        thread <- pushAsyncImpl push1
         await thread
 
       attemptedPushes `shouldBe` [[toV2Push push1]]

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -287,7 +287,7 @@ onUserDeleted ::
 onUserDeleted origDomain udcn = lift $ do
   let deletedUser = toRemoteUnsafe origDomain udcn.user
       connections = udcn.connections
-      event = pure . UserEvent $ UserDeleted (tUntagged deletedUser)
+      event = UserEvent $ UserDeleted (tUntagged deletedUser)
   acceptedLocals <-
     map csv2From
       . filter (\x -> csv2Status x == Accepted)

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -360,7 +360,7 @@ notify event orig route conn recipients = do
           & pushConn .~ conn
           & pushRoute .~ route
           & pushApsData .~ toApsData event
-  void $ pushNotificationsAsync [push]
+  void $ pushNotificationAsync push
 
 notifySelf ::
   (Member NotificationSubsystem r) =>


### PR DESCRIPTION
Brig only ever pushes 1 notification at a time. Also remove the list from corresponding call the the NotificationSubsystem.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
