### PR TITLE
gundeck: Remove bulkPush config option

### DIFF
--- a/changelog.d/0-release-notes/gundeck-bulk-push
+++ b/changelog.d/0-release-notes/gundeck-bulk-push
@@ -1,0 +1,3 @@
+Config value `gundeck.config.bulkPush` has been removed. This is purely an
+internal change, in case the value was overriden to `false`, operators might see
+more spiky usage of CPU and memory from gundeck due to bulk processing.

--- a/charts/gundeck/templates/configmap.yaml
+++ b/charts/gundeck/templates/configmap.yaml
@@ -68,7 +68,6 @@ data:
     settings:
       httpPoolSize: 1024
       notificationTTL: {{ required "config.notificationTTL" .notificationTTL }}
-      bulkPush: {{ .bulkPush }}
       {{- if hasKey . "perNativePushConcurrency" }}
       perNativePushConcurrency: {{ .perNativePushConcurrency }}
       {{- end }}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -56,7 +56,6 @@ config:
   # # tlsCaSecretRef:
   # #   name: <secret-name>
   # #   key: <ca-attribute>
-  bulkPush: true
   aws:
     region: "eu-west-1"
   proxy: {}

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -373,7 +373,6 @@ gundeck:
       sqsEndpoint: http://fake-aws-sqs:4568
       snsEndpoint: http://fake-aws-sns:4575
     disabledAPIVersions: []
-    bulkPush: true
     setMaxConcurrentNativePushes:
       hard: 30
       soft: 10

--- a/services/gundeck/gundeck.integration.yaml
+++ b/services/gundeck/gundeck.integration.yaml
@@ -37,7 +37,6 @@ aws:
 settings:
   httpPoolSize: 1024
   notificationTTL: 24192200
-  bulkPush: true
   perNativePushConcurrency: 32
   sqsThrottleMillis: 1000
   maxConcurrentNativePushes:

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -57,9 +57,6 @@ data Settings = Settings
     _httpPoolSize :: !Int,
     -- | TTL (seconds) of stored notifications
     _notificationTTL :: !NotificationTTL,
-    -- | Use this option to group push notifications and send them in bulk to Cannon, instead
-    -- of in individual requests
-    _bulkPush :: !Bool,
     -- | Maximum number of concurrent threads calling SNS.
     _maxConcurrentNativePushes :: !(Maybe MaxConcurrentNativePushes),
     -- | Maximum number of parallel requests to SNS and cassandra

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -50,7 +50,7 @@ import Data.Set qualified as Set
 import Data.Text.Encoding qualified as T
 import Data.UUID qualified as UUID
 import Data.UUID.V4
-import Gundeck.Options hiding (bulkPush)
+import Gundeck.Options
 import Gundeck.Options qualified as O
 import Imports
 import Network.HTTP.Client qualified as Http

--- a/services/gundeck/test/unit/Push.hs
+++ b/services/gundeck/test/unit/Push.hs
@@ -21,7 +21,7 @@
 module Push where
 
 import Data.Aeson qualified as Aeson
-import Gundeck.Push (pushAll, pushAny)
+import Gundeck.Push (pushAll)
 import Gundeck.Push.Websocket as Web (bulkPush)
 import Imports
 import MockGundeck
@@ -83,11 +83,8 @@ pushAllProp env (Pretty pushes) =
   where
     ((), realst) = runMockGundeck env (pushAll pushes)
     ((), mockst) = runMockGundeck env (mockPushAll pushes)
-    (errs, oldst) = runMockGundeck env (pushAny pushes)
     props =
       [ (Aeson.eitherDecode . Aeson.encode) pushes === Right pushes,
         (Aeson.eitherDecode . Aeson.encode) env === Right env,
-        counterexample "real vs. mock:" $ realst === mockst,
-        counterexample "real vs. old:" $ realst === oldst,
-        counterexample "old errors:" $ isRight errs === True
+        counterexample "real vs. mock:" $ realst === mockst
       ]


### PR DESCRIPTION
It has been set to `true` for a few years now and seems to work well. It is being removed to reduce work for RabbitMq based notifications.

Related: https://github.com/wireapp/wire-server/pull/4272
Also: https://wearezeta.atlassian.net/browse/WPB-10308

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
