### PR TITLE
Refactor CSV export

### DIFF
--- a/changelog.d/1-api-changes/add-columns-to-export
+++ b/changelog.d/1-api-changes/add-columns-to-export
@@ -1,0 +1,1 @@
+The team CSV export endpoint has gained two extra columns: `last_active` and `status`. The streaming behaviour has also been improved.

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -100,6 +100,7 @@ library
     API.GundeckInternal
     API.Nginz
     API.Spar
+    API.Stern
     MLS.Util
     Notifications
     RunAllTests

--- a/integration/test/API/Stern.hs
+++ b/integration/test/API/Stern.hs
@@ -1,11 +1,5 @@
 module API.Stern where
 
-import API.BrigCommon
-import API.Common
-import qualified Data.Aeson as Aeson
-import Data.Aeson.Types (Pair)
-import Data.Function
-import Data.Maybe
 import Testlib.Prelude
 
 getTeamActivity :: (HasCallStack, MakesValue domain) => domain -> String -> App Response

--- a/integration/test/API/Stern.hs
+++ b/integration/test/API/Stern.hs
@@ -1,0 +1,14 @@
+module API.Stern where
+
+import API.BrigCommon
+import API.Common
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Pair)
+import Data.Function
+import Data.Maybe
+import Testlib.Prelude
+
+getTeamActivity :: (HasCallStack, MakesValue domain) => domain -> String -> App Response
+getTeamActivity domain tid =
+  baseRequest domain Stern Unversioned (joinHttpPath ["team-activity-info", tid])
+    >>= submit "GET"

--- a/integration/test/Test/Client.hs
+++ b/integration/test/Test/Client.hs
@@ -6,12 +6,10 @@ import API.Brig
 import qualified API.Brig as API
 import API.BrigCommon
 import API.Gundeck
-import API.Stern
 import Control.Lens hiding ((.=))
 import Control.Monad.Codensity
 import Control.Monad.Reader
 import Data.Aeson hiding ((.=))
-import qualified Data.ByteString.Char8 as B8
 import Data.ProtoLens.Labels ()
 import Data.Time.Clock.POSIX
 import Data.Time.Clock.System
@@ -43,30 +41,6 @@ testClientLastActive = do
       . utcTimeToPOSIXSeconds
       <$> parseTimeM False defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" tm1
   assertBool "last_active is earlier than expected" $ ts1 >= now
-
-testTeamActivity :: (HasCallStack) => App ()
-testTeamActivity = do
-  (alice, tid, [bob, charlie]) <- createTeam OwnDomain 3
-  [alice1, _alice2] <- replicateM 2 $ addClient alice def >>= getJSON 201
-  [_bob1, _bob2] <- replicateM 2 $ addClient bob def >>= getJSON 201
-  charlie1 <- addClient charlie def >>= getJSON 201
-
-  for_ [(alice, alice1), (charlie, charlie1)] $ \(u, cl) -> do
-    clientId <- cl %. "id" & asString
-    void $ getNotifications u def {client = Just clientId}
-
-  let row (u, t) = do
-        uid <- u %. "id" & asString
-        pure (uid, t)
-
-  expectedRows <- sort <$> traverse row [(alice, True), (bob, False), (charlie, True)]
-
-  bindResponse (getTeamActivity alice tid) $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    for_ (zip (sort (B8.lines resp.body)) expectedRows) $ \(r, (uid, active)) -> do
-      let [actualUser, timestamp] = B8.split ',' r
-      B8.unpack actualUser `shouldMatch` uid
-      B8.null timestamp `shouldMatch` not active
 
 testListClientsIfBackendIsOffline :: (HasCallStack) => App ()
 testListClientsIfBackendIsOffline = do

--- a/integration/test/Test/Client.hs
+++ b/integration/test/Test/Client.hs
@@ -51,11 +51,6 @@ testTeamActivity = do
   [_bob1, _bob2] <- replicateM 2 $ addClient bob def >>= getJSON 201
   charlie1 <- addClient charlie def >>= getJSON 201
 
-  now <-
-    formatTime defaultTimeLocale "%Y-%m-%d"
-      . systemToUTCTime
-      <$> liftIO getSystemTime
-
   for_ [(alice, alice1), (charlie, charlie1)] $ \(u, cl) -> do
     clientId <- cl %. "id" & asString
     void $ getNotifications u def {client = Just clientId}
@@ -68,8 +63,8 @@ testTeamActivity = do
 
   bindResponse (getTeamActivity alice tid) $ \resp -> do
     resp.status `shouldMatchInt` 200
-    for_ (zip (sort (B8.lines resp.body)) expectedRows) $ \(row, (uid, active)) -> do
-      let [actualUser, timestamp] = B8.split ',' row
+    for_ (zip (sort (B8.lines resp.body)) expectedRows) $ \(r, (uid, active)) -> do
+      let [actualUser, timestamp] = B8.split ',' r
       B8.unpack actualUser `shouldMatch` uid
       B8.null timestamp `shouldMatch` not active
 

--- a/integration/test/Test/Teams.hs
+++ b/integration/test/Test/Teams.hs
@@ -343,6 +343,7 @@ testTeamMemberCsvExport = do
       (if numClients > 0 then shouldNotMatch else shouldMatch)
         (parseField 13)
         ""
+      parseField 14 `shouldMatch` "active"
   where
     unquote :: String -> String
     unquote ('\'' : x) = x

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -14,7 +14,6 @@ import qualified Data.Aeson.Diff as AD
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import Data.Aeson.Lens (_Array, _Object)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BS
 import Data.Char

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -14,6 +14,7 @@ import qualified Data.Aeson.Diff as AD
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import Data.Aeson.Lens (_Array, _Object)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BS
 import Data.Char

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -57,6 +57,7 @@
 , iso3166-country-codes
 , iso639
 , jose
+, kan-extensions
 , lens
 , lib
 , memory
@@ -165,6 +166,7 @@ mkDerivation {
     iso3166-country-codes
     iso639
     jose
+    kan-extensions
     lens
     memory
     metrics-wai

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -47,7 +47,6 @@ import Data.CommaSeparatedList
 import Data.Domain (Domain)
 import Data.Handle (Handle)
 import Data.Id as Id
-import Data.Json.Util
 import Data.OpenApi (HasInfo (info), HasTitle (title), OpenApi)
 import Data.OpenApi qualified as S
 import Data.Qualified (Qualified)
@@ -603,14 +602,6 @@ type UserAPI =
   UpdateUserLocale
     :<|> DeleteUserLocale
     :<|> GetDefaultLocale
-    :<|> Named
-           "get-activity-timestamp"
-           ( Summary "Get the last activity timestamp of a user"
-               :> "users"
-               :> Capture "uid" UserId
-               :> "activity"
-               :> MultiVerb1 'GET '[JSON] (Respond 200 "Activity" (Maybe UTCTimeMillis))
-           )
     :<|> Named
            "get-user-export-data"
            ( Summary "Get user export data"

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -77,6 +77,7 @@ import Wire.API.Routes.Internal.LegalHold qualified as LegalHoldInternalAPI
 import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
 import Wire.API.Routes.Public (ZUser)
+import Wire.API.Team.Export (TeamExportUser)
 import Wire.API.Team.Feature
 import Wire.API.Team.Invitation (Invitation)
 import Wire.API.Team.LegalHold.Internal
@@ -609,6 +610,14 @@ type UserAPI =
                :> Capture "uid" UserId
                :> "activity"
                :> MultiVerb1 'GET '[JSON] (Respond 200 "Activity" (Maybe UTCTimeMillis))
+           )
+    :<|> Named
+           "get-user-export-data"
+           ( Summary "Get user export data"
+               :> "users"
+               :> Capture "uid" UserId
+               :> "export-data"
+               :> MultiVerb1 'GET '[JSON] (Respond 200 "User export data" (Maybe TeamExportUser))
            )
 
 type UpdateUserLocale =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -47,6 +47,7 @@ import Data.CommaSeparatedList
 import Data.Domain (Domain)
 import Data.Handle (Handle)
 import Data.Id as Id
+import Data.Json.Util
 import Data.OpenApi (HasInfo (info), HasTitle (title), OpenApi)
 import Data.OpenApi qualified as S
 import Data.Qualified (Qualified)
@@ -601,6 +602,14 @@ type UserAPI =
   UpdateUserLocale
     :<|> DeleteUserLocale
     :<|> GetDefaultLocale
+    :<|> Named
+           "get-activity-timestamp"
+           ( Summary "Get the last activity timestamp of a user"
+               :> "users"
+               :> Capture "uid" UserId
+               :> "activity"
+               :> MultiVerb1 'GET '[JSON] (Respond 200 "Activity" (Maybe UTCTimeMillis))
+           )
 
 type UpdateUserLocale =
   Summary

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Spar.hs
@@ -31,7 +31,7 @@ type InternalAPI =
     :> ( "status" :> Get '[JSON] NoContent
            :<|> "teams" :> Capture "team" TeamId :> DeleteNoContent
            :<|> "sso" :> "settings" :> ReqBody '[JSON] SsoSettings :> Put '[JSON] NoContent
-           :<|> "scim" :> "userinfos" :> ReqBody '[JSON] UserSet :> Post '[JSON] ScimUserInfos
+           :<|> "scim" :> "userinfo" :> Capture "user" UserId :> Post '[JSON] ScimUserInfo
        )
 
 swaggerDoc :: OpenApi

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -110,9 +110,9 @@ type RespondEmpty s desc = RespondAs '() s desc ()
 
 -- | A type to describe a streaming 'MultiVerb' response.
 --
--- Includes status code, description, framing strategy and content type. Note
--- that the handler return type is hardcoded to be 'SourceIO ByteString'.
-data RespondStreaming (s :: Nat) (desc :: Symbol) (framing :: Type) (ct :: Type)
+-- Includes status code, description and content type. Note that the handler
+-- return type is hardcoded to be 'SourceIO ByteString'.
+data RespondStreaming (s :: Nat) (desc :: Symbol) (ct :: Type)
 
 -- | The result of parsing a response as a union alternative of type 'a'.
 --
@@ -268,14 +268,14 @@ instance
       mempty
         & S.description .~ Text.pack (symbolVal (Proxy @desc))
 
-type instance ResponseType (RespondStreaming s desc framing ct) = SourceIO ByteString
+type instance ResponseType (RespondStreaming s desc ct) = SourceIO ByteString
 
 instance
   (Accept ct, KnownStatus s) =>
-  IsResponse cs (RespondStreaming s desc framing ct)
+  IsResponse cs (RespondStreaming s desc ct)
   where
-  type ResponseStatus (RespondStreaming s desc framing ct) = s
-  type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
+  type ResponseStatus (RespondStreaming s desc ct) = s
+  type ResponseBody (RespondStreaming s desc ct) = SourceIO ByteString
   responseRender _ x =
     pure . addContentType @ct $
       Response
@@ -289,7 +289,7 @@ instance
     guard (responseStatusCode resp == statusVal (Proxy @s))
     pure $ responseBody resp
 
-instance (KnownSymbol desc) => IsSwaggerResponse (RespondStreaming s desc framing ct) where
+instance (KnownSymbol desc) => IsSwaggerResponse (RespondStreaming s desc ct) where
   responseSwagger =
     pure $
       mempty

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
@@ -80,7 +80,6 @@ type AssetStreaming =
   RespondStreaming
     200
     "Asset returned directly with content type `application/octet-stream`"
-    NoFraming
     OctetStream
 
 type GetAsset =

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -17,6 +17,7 @@
 
 module Wire.API.Team.Export (TeamExportUser (..), quoted, unquoted) where
 
+import Data.Aeson qualified as A
 import Data.Aeson qualified as Aeson
 import Data.Attoparsec.ByteString.Lazy (parseOnly)
 import Data.ByteString.Char8 qualified as C
@@ -26,6 +27,8 @@ import Data.Handle (Handle)
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis)
 import Data.Misc (HttpsUrl)
+import Data.OpenApi qualified as OpenApi
+import Data.Schema
 import Data.Vector (fromList)
 import Imports
 import Test.QuickCheck
@@ -53,6 +56,25 @@ data TeamExportUser = TeamExportUser
   }
   deriving (Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform TeamExportUser)
+  deriving (A.ToJSON, A.FromJSON, OpenApi.ToSchema) via (Schema TeamExportUser)
+
+instance ToSchema TeamExportUser where
+  schema =
+    object "TeamExportUser" $
+      TeamExportUser
+        <$> tExportDisplayName .= field "display_name" schema
+        <*> tExportHandle .= maybe_ (optField "handle" schema)
+        <*> tExportEmail .= maybe_ (optField "email" schema)
+        <*> tExportRole .= maybe_ (optField "role" schema)
+        <*> tExportCreatedOn .= maybe_ (optField "created_on" schema)
+        <*> tExportInvitedBy .= maybe_ (optField "invited_by" schema)
+        <*> tExportIdpIssuer .= maybe_ (optField "idp_issuer" schema)
+        <*> tExportManagedBy .= field "managed_by" schema
+        <*> tExportSAMLNamedId .= field "saml_name_id" schema
+        <*> tExportSCIMExternalId .= field "scim_external_id" schema
+        <*> tExportSCIMRichInfo .= maybe_ (optField "scim_rich_info" schema)
+        <*> tExportUserId .= field "user_id" schema
+        <*> tExportNumDevices .= field "num_devices" schema
 
 instance ToNamedRecord TeamExportUser where
   toNamedRecord row =

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -22,6 +22,7 @@
 module Wire.API.Team.Member
   ( -- * TeamMember
     TeamMember,
+    newTeamMember,
     mkTeamMember,
     userId,
     permissions,

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -28,7 +28,6 @@ module Wire.API.User
     qualifiedUserIdListObjectSchema,
     LimitedQualifiedUserIdList (..),
     ScimUserInfo (..),
-    ScimUserInfos (..),
     UserSet (..),
     -- Profiles
     UserProfile (..),
@@ -1338,18 +1337,6 @@ instance ToSchema ScimUserInfo where
           .= field "id" schema
         <*> suiCreatedOn
           .= maybe_ (optField "created_on" schema)
-
-newtype ScimUserInfos = ScimUserInfos {scimUserInfos :: [ScimUserInfo]}
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ScimUserInfos)
-  deriving (ToJSON, FromJSON, S.ToSchema) via (Schema ScimUserInfos)
-
-instance ToSchema ScimUserInfos where
-  schema =
-    object "ScimUserInfos" $
-      ScimUserInfos
-        <$> scimUserInfos
-          .= field "scim_user_infos" (array schema)
 
 -------------------------------------------------------------------------------
 -- UserSet

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -714,6 +714,7 @@ test-suite wire-api-tests
     , tasty-hunit
     , tasty-quickcheck
     , text
+    , time
     , types-common           >=0.16
     , unliftio
     , uuid

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -300,6 +300,7 @@ library
     , iso3166-country-codes      >=0.2
     , iso639                     >=0.1
     , jose
+    , kan-extensions
     , lens                       >=4.12
     , memory
     , metrics-wai

--- a/libs/wire-subsystems/default.nix
+++ b/libs/wire-subsystems/default.nix
@@ -15,6 +15,7 @@
 , bloodhound
 , bytestring
 , bytestring-conversion
+, case-insensitive
 , cassandra-util
 , conduit
 , containers
@@ -104,6 +105,7 @@ mkDerivation {
     bloodhound
     bytestring
     bytestring-conversion
+    case-insensitive
     cassandra-util
     conduit
     containers

--- a/libs/wire-subsystems/src/Wire/UserStore.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore.hs
@@ -6,6 +6,7 @@ import Cassandra (PageWithState (..), PagingState)
 import Data.Default
 import Data.Handle
 import Data.Id
+import Data.Time.Clock
 import Imports
 import Polysemy
 import Polysemy.Error
@@ -67,6 +68,7 @@ data UserStore m a where
   IsActivated :: UserId -> UserStore m Bool
   LookupLocale :: UserId -> UserStore m (Maybe (Maybe Language, Maybe Country))
   UpdateUserTeam :: UserId -> TeamId -> UserStore m ()
+  GetActivityTimestamps :: UserId -> UserStore m [Maybe UTCTime]
 
 makeSem ''UserStore
 

--- a/libs/wire-subsystems/src/Wire/UserStore.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore.hs
@@ -11,6 +11,7 @@ import Imports
 import Polysemy
 import Polysemy.Error
 import Wire.API.User
+import Wire.API.User.RichInfo
 import Wire.Arbitrary
 import Wire.StoredUser
 import Wire.UserStore.IndexUser
@@ -69,6 +70,7 @@ data UserStore m a where
   LookupLocale :: UserId -> UserStore m (Maybe (Maybe Language, Maybe Country))
   UpdateUserTeam :: UserId -> TeamId -> UserStore m ()
   GetActivityTimestamps :: UserId -> UserStore m [Maybe UTCTime]
+  GetRichInfo :: UserId -> UserStore m (Maybe RichInfoAssocList)
 
 makeSem ''UserStore
 

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -21,6 +21,7 @@ import Polysemy
 import Polysemy.Error
 import Wire.API.Federation.Error
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti (TeamStatus)
+import Wire.API.Team.Export (TeamExportUser)
 import Wire.API.Team.Feature
 import Wire.API.Team.Member (IsPerm (..), TeamMember)
 import Wire.API.User
@@ -145,6 +146,7 @@ data UserSubsystem m a where
   InternalUpdateSearchIndex :: UserId -> UserSubsystem m ()
   InternalFindTeamInvitation :: Maybe EmailKey -> InvitationCode -> UserSubsystem m StoredInvitation
   GetUserActivityTimestamp :: UserId -> UserSubsystem m (Maybe UTCTime)
+  GetUserExportData :: UserId -> UserSubsystem m (Maybe TeamExportUser)
 
 -- | the return type of 'CheckHandle'
 data CheckHandleResp

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -15,6 +15,7 @@ import Data.Id
 import Data.Misc
 import Data.Qualified
 import Data.Range
+import Data.Time.Clock
 import Imports
 import Polysemy
 import Polysemy.Error
@@ -143,6 +144,7 @@ data UserSubsystem m a where
   -- migration this would just be an internal detail of the subsystem
   InternalUpdateSearchIndex :: UserId -> UserSubsystem m ()
   InternalFindTeamInvitation :: Maybe EmailKey -> InvitationCode -> UserSubsystem m StoredInvitation
+  GetUserActivityTimestamp :: UserId -> UserSubsystem m (Maybe UTCTime)
 
 -- | the return type of 'CheckHandle'
 data CheckHandleResp

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -15,7 +15,6 @@ import Data.Id
 import Data.Misc
 import Data.Qualified
 import Data.Range
-import Data.Time.Clock
 import Imports
 import Polysemy
 import Polysemy.Error
@@ -145,7 +144,6 @@ data UserSubsystem m a where
   -- migration this would just be an internal detail of the subsystem
   InternalUpdateSearchIndex :: UserId -> UserSubsystem m ()
   InternalFindTeamInvitation :: Maybe EmailKey -> InvitationCode -> UserSubsystem m StoredInvitation
-  GetUserActivityTimestamp :: UserId -> UserSubsystem m (Maybe UTCTime)
   GetUserExportData :: UserId -> UserSubsystem m (Maybe TeamExportUser)
 
 -- | the return type of 'CheckHandle'

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -923,9 +923,9 @@ acceptTeamInvitationImpl luid pw code = do
   generateUserEvent uid Nothing (teamUpdated uid tid)
 
 getUserActivityTimestampImpl :: (Member UserStore r) => UserId -> Sem r (Maybe UTCTime)
-getUserActivityTimestampImpl =
-  fmap
-    ( maximum
-        . (Nothing :) -- make sure the list of timestamps is non-empty
-    )
-    . getActivityTimestamps
+getUserActivityTimestampImpl uid = do
+  ts <- getActivityTimestamps uid
+  pure $
+    maximum
+      -- make sure the list of timestamps is non-empty)
+      (Nothing : ts)

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -156,7 +156,6 @@ runUserSubsystem authInterpreter = interpret $
         acceptTeamInvitationImpl luid pwd code
     InternalFindTeamInvitation mEmailKey code ->
       internalFindTeamInvitationImpl mEmailKey code
-    GetUserActivityTimestamp uid -> getUserActivityTimestampImpl uid
     GetUserExportData uid -> getUserExportDataImpl uid
 
 scimExtId :: StoredUser -> Maybe Text
@@ -947,15 +946,6 @@ acceptTeamInvitationImpl luid pw code = do
   deleteInvitation inv.teamId inv.invitationId
   syncUserIndex uid
   generateUserEvent uid Nothing (teamUpdated uid tid)
-
--- TODO: remove
-getUserActivityTimestampImpl :: (Member UserStore r) => UserId -> Sem r (Maybe UTCTime)
-getUserActivityTimestampImpl uid = do
-  ts <- getActivityTimestamps uid
-  pure $
-    maximum
-      -- make sure the list of timestamps is non-empty)
-      (Nothing : ts)
 
 getUserExportDataImpl :: (Member UserStore r) => UserId -> Sem r (Maybe TeamExportUser)
 getUserExportDataImpl uid = fmap hush . runError @() $ do

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -981,5 +981,6 @@ getUserExportDataImpl uid = fmap hush . runError @() $ do
         tExportSCIMRichInfo = fmap RichInfo mRichInfo,
         tExportUserId = uid,
         tExportNumDevices = numClients,
-        tExportLastActive = lastActive
+        tExportLastActive = lastActive,
+        tExportStatus = su.status
       }

--- a/libs/wire-subsystems/test/unit/Wire/MiniBackend.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MiniBackend.hs
@@ -400,7 +400,7 @@ interpretMaybeFederationStackState maybeFederationAPIAccess localBackend teamMem
       authSubsystemInterpreter = interpretAuthenticationSubsystem userSubsystemInterpreter
 
       userSubsystemInterpreter :: InterpreterFor UserSubsystem (MiniBackendLowerEffects `Append` r)
-      userSubsystemInterpreter = runUserSubsystem cfg authSubsystemInterpreter
+      userSubsystemInterpreter = runUserSubsystem authSubsystemInterpreter
    in sequentiallyPerformConcurrency
         . noOpLogger
         . maybeFederationAPIAccess

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
@@ -72,6 +72,7 @@ inMemoryUserStoreInterpreter = interpret $ \case
       map
         (\u -> if u.id == uid then u {teamId = Just tid} :: StoredUser else u)
   GetActivityTimestamps _ -> pure []
+  GetRichInfo _ -> error "rich info not implemented"
 
 storedUserToIndexUser :: StoredUser -> IndexUser
 storedUserToIndexUser storedUser =

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
@@ -71,6 +71,7 @@ inMemoryUserStoreInterpreter = interpret $ \case
     modify $
       map
         (\u -> if u.id == uid then u {teamId = Just tid} :: StoredUser else u)
+  GetActivityTimestamps _ -> pure []
 
 storedUserToIndexUser :: StoredUser -> IndexUser
 storedUserToIndexUser storedUser =

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -156,6 +156,7 @@ library
     , bloodhound
     , bytestring
     , bytestring-conversion
+    , case-insensitive
     , cassandra-util
     , conduit
     , containers

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -57,7 +57,6 @@ import Data.Domain (Domain)
 import Data.Handle
 import Data.HavePendingInvitations
 import Data.Id as Id
-import Data.Json.Util
 import Data.Map.Strict qualified as Map
 import Data.Qualified
 import Data.Set qualified as Set
@@ -268,7 +267,6 @@ userAPI =
   updateLocale
     :<|> deleteLocale
     :<|> getDefaultUserLocale
-    :<|> Named @"get-activity-timestamp" getUserActivityTimestampH
     :<|> Named @"get-user-export-data" getUserExportDataH
 
 clientAPI :: ServerT BrigIRoutes.ClientAPI (Handler r)
@@ -804,16 +802,6 @@ checkHandleInternalH h = lift $ liftSem do
 
 getContactListH :: UserId -> (Handler r) UserIds
 getContactListH uid = lift . wrapClient $ UserIds <$> API.lookupContactList uid
-
-getUserActivityTimestampH ::
-  (Member UserSubsystem r) =>
-  UserId ->
-  Handler r (Maybe UTCTimeMillis)
-getUserActivityTimestampH =
-  lift
-    . liftSem
-    . fmap (fmap toUTCTimeMillis)
-    . getUserActivityTimestamp
 
 getUserExportDataH ::
   (Member UserSubsystem r) =>

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -57,6 +57,7 @@ import Data.Domain (Domain)
 import Data.Handle
 import Data.HavePendingInvitations
 import Data.Id as Id
+import Data.Json.Util
 import Data.Map.Strict qualified as Map
 import Data.Qualified
 import Data.Set qualified as Set
@@ -266,6 +267,7 @@ userAPI =
   updateLocale
     :<|> deleteLocale
     :<|> getDefaultUserLocale
+    :<|> Named @"get-activity-timestamp" getUserActivityTimestampH
 
 clientAPI :: ServerT BrigIRoutes.ClientAPI (Handler r)
 clientAPI = Named @"update-client-last-active" updateClientLastActive
@@ -800,3 +802,13 @@ checkHandleInternalH h = lift $ liftSem do
 
 getContactListH :: UserId -> (Handler r) UserIds
 getContactListH uid = lift . wrapClient $ UserIds <$> API.lookupContactList uid
+
+getUserActivityTimestampH ::
+  (Member UserSubsystem r) =>
+  UserId ->
+  Handler r (Maybe UTCTimeMillis)
+getUserActivityTimestampH =
+  lift
+    . liftSem
+    . fmap (fmap toUTCTimeMillis)
+    . getUserActivityTimestamp

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -112,7 +112,7 @@ import Wire.Rpc
 import Wire.Sem.Concurrency
 import Wire.TeamInvitationSubsystem
 import Wire.UserKeyStore
-import Wire.UserStore
+import Wire.UserStore as UserStore
 import Wire.UserSubsystem
 import Wire.UserSubsystem qualified as UserSubsystem
 import Wire.UserSubsystem.Error
@@ -764,8 +764,10 @@ updateClientLastActive u c = do
             }
   lift . wrapClient $ Data.updateClientLastActive u c now
 
-getRichInfoH :: UserId -> (Handler r) RichInfo
-getRichInfoH uid = RichInfo . fromMaybe mempty <$> lift (wrapClient $ API.lookupRichInfo uid)
+getRichInfoH :: (Member UserStore r) => UserId -> Handler r RichInfo
+getRichInfoH uid =
+  RichInfo . fromMaybe mempty
+    <$> lift (liftSem $ UserStore.getRichInfo uid)
 
 getRichInfoMultiH :: Maybe (CommaSeparatedList UserId) -> (Handler r) [(UserId, RichInfo)]
 getRichInfoMultiH (maybe [] fromCommaSeparatedList -> uids) =

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -83,6 +83,7 @@ import Wire.API.Routes.FederationDomainConfig
 import Wire.API.Routes.Internal.Brig qualified as BrigIRoutes
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Named
+import Wire.API.Team.Export
 import Wire.API.Team.Feature
 import Wire.API.User
 import Wire.API.User.Activation
@@ -268,6 +269,7 @@ userAPI =
     :<|> deleteLocale
     :<|> getDefaultUserLocale
     :<|> Named @"get-activity-timestamp" getUserActivityTimestampH
+    :<|> Named @"get-user-export-data" getUserExportDataH
 
 clientAPI :: ServerT BrigIRoutes.ClientAPI (Handler r)
 clientAPI = Named @"update-client-last-active" updateClientLastActive
@@ -812,3 +814,9 @@ getUserActivityTimestampH =
     . liftSem
     . fmap (fmap toUTCTimeMillis)
     . getUserActivityTimestamp
+
+getUserExportDataH ::
+  (Member UserSubsystem r) =>
+  UserId ->
+  Handler r (Maybe TeamExportUser)
+getUserExportDataH = lift . liftSem . getUserExportData

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -170,6 +170,7 @@ import Wire.TeamInvitationSubsystem
 import Wire.UserKeyStore
 import Wire.UserSearch.Types
 import Wire.UserStore (UserStore)
+import Wire.UserStore qualified as UserStore
 import Wire.UserSubsystem hiding (checkHandle, checkHandles)
 import Wire.UserSubsystem qualified as User
 import Wire.UserSubsystem.Error
@@ -657,7 +658,13 @@ getClientCapabilities uid cid = do
   mclient <- lift (API.lookupLocalClient uid cid)
   maybe (throwStd (errorToWai @'E.ClientNotFound)) (pure . Public.clientCapabilities) mclient
 
-getRichInfo :: (Member UserSubsystem r) => Local UserId -> UserId -> Handler r Public.RichInfoAssocList
+getRichInfo ::
+  ( Member UserSubsystem r,
+    Member UserStore r
+  ) =>
+  Local UserId ->
+  UserId ->
+  Handler r Public.RichInfoAssocList
 getRichInfo lself user = do
   let luser = qualifyAs lself user
   -- Check that both users exist and the requesting user is allowed to see rich info of the
@@ -671,7 +678,7 @@ getRichInfo lself user = do
     (Just t1, Just t2) | t1 == t2 -> pure ()
     _ -> throwStd insufficientTeamPermissions
   -- Query rich info
-  wrapClientE $ fromMaybe mempty <$> API.lookupRichInfo (tUnqualified luser)
+  lift $ liftSem $ fold <$> UserStore.getRichInfo (tUnqualified luser)
 
 getSupportedProtocols ::
   (Member UserSubsystem r) =>

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -35,7 +35,6 @@ module Brig.API.User
     getLegalHoldStatus,
     Data.lookupName,
     Data.lookupUser,
-    Data.lookupRichInfo,
     Data.lookupRichInfoMultiUsers,
     removeEmail,
     revokeIdentity,

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -134,6 +134,7 @@ type BrigLowerLevelEffects =
      PropertyStore,
      SFT,
      ConnectionStore InternalPaging,
+     Input UserSubsystemConfig,
      Input VerificationCodeThrottleTTL,
      Input UTCTime,
      Input (Local ()),
@@ -213,7 +214,7 @@ runBrigToIO e (AppT ma) = do
 
       -- These interpreters depend on each other, we use let recursion to solve that.
       userSubsystemInterpreter :: (Members BrigLowerLevelEffects r) => InterpreterFor UserSubsystem r
-      userSubsystemInterpreter = runUserSubsystem userSubsystemConfig authSubsystemInterpreter
+      userSubsystemInterpreter = runUserSubsystem authSubsystemInterpreter
 
       authSubsystemInterpreter :: (Members BrigLowerLevelEffects r) => InterpreterFor AuthenticationSubsystem r
       authSubsystemInterpreter = interpretAuthenticationSubsystem userSubsystemInterpreter
@@ -251,6 +252,7 @@ runBrigToIO e (AppT ma) = do
               . runInputConst (toLocalUnsafe e.settings.federationDomain ())
               . runInputSem (embed getCurrentTime)
               . runInputConst (fromIntegral $ Opt.twoFACodeGenerationDelaySecs e.settings)
+              . runInputConst userSubsystemConfig
               . connectionStoreToCassandra
               . interpretSFT e.httpManager
               . interpretPropertyStoreCassandra e.casClient

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -374,6 +374,7 @@ lookupName u =
   fmap runIdentity
     <$> retry x1 (query1 nameSelect (params LocalQuorum (Identity u)))
 
+-- TODO: remove this
 lookupRichInfo :: (MonadClient m) => UserId -> m (Maybe RichInfoAssocList)
 lookupRichInfo u =
   fmap runIdentity

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -35,7 +35,6 @@ module Brig.Data.User
     lookupUser,
     lookupUsers,
     lookupName,
-    lookupRichInfo,
     lookupRichInfoMultiUsers,
     lookupUserTeam,
     lookupServiceUsers,
@@ -374,12 +373,6 @@ lookupName u =
   fmap runIdentity
     <$> retry x1 (query1 nameSelect (params LocalQuorum (Identity u)))
 
--- TODO: remove this
-lookupRichInfo :: (MonadClient m) => UserId -> m (Maybe RichInfoAssocList)
-lookupRichInfo u =
-  fmap runIdentity
-    <$> retry x1 (query1 richInfoSelect (params LocalQuorum (Identity u)))
-
 -- | Returned rich infos are in the same order as users
 lookupRichInfoMultiUsers :: (MonadClient m) => [UserId] -> m [(UserId, RichInfo)]
 lookupRichInfoMultiUsers users = do
@@ -522,9 +515,6 @@ nameSelect = "SELECT name FROM user WHERE id = ?"
 
 authSelect :: PrepQuery R (Identity UserId) (Maybe Password, Maybe AccountStatus)
 authSelect = "SELECT password, status FROM user WHERE id = ?"
-
-richInfoSelect :: PrepQuery R (Identity UserId) (Identity RichInfoAssocList)
-richInfoSelect = "SELECT json FROM rich_info WHERE user = ?"
 
 richInfoSelectMulti :: PrepQuery R (Identity [UserId]) (UserId, Maybe RichInfoAssocList)
 richInfoSelectMulti = "SELECT user, json FROM rich_info WHERE user in ?"

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -19,7 +19,6 @@
 , bytestring
 , bytestring-conversion
 , call-stack
-, case-insensitive
 , cassandra-util
 , cassava
 , cereal
@@ -148,7 +147,6 @@ mkDerivation {
     brig-types
     bytestring
     bytestring-conversion
-    case-insensitive
     cassandra-util
     cassava
     comonad
@@ -189,7 +187,6 @@ mkDerivation {
     resourcet
     retry
     safe-exceptions
-    saml2-web-sso
     servant
     servant-client
     servant-server

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -78,7 +78,6 @@
 , resourcet
 , retry
 , safe-exceptions
-, saml2-web-sso
 , servant
 , servant-client
 , servant-client-core

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -122,6 +122,7 @@ library
     Galley.API.Push
     Galley.API.Query
     Galley.API.Teams
+    Galley.API.Teams.Export
     Galley.API.Teams.Features
     Galley.API.Teams.Features.Get
     Galley.API.Teams.Notifications

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -301,7 +301,6 @@ library
     , brig-types                            >=0.73.1
     , bytestring                            >=0.9
     , bytestring-conversion                 >=0.2
-    , case-insensitive
     , cassandra-util                        >=0.16.2
     , cassava                               >=0.5.2
     , comonad
@@ -342,7 +341,6 @@ library
     , resourcet                             >=1.1
     , retry                                 >=0.5
     , safe-exceptions                       >=0.1
-    , saml2-web-sso                         >=0.20
     , servant
     , servant-client
     , servant-server

--- a/services/galley/src/Galley/API/Public/TeamMember.hs
+++ b/services/galley/src/Galley/API/Public/TeamMember.hs
@@ -18,6 +18,7 @@
 module Galley.API.Public.TeamMember where
 
 import Galley.API.Teams
+import Galley.API.Teams.Export qualified as Export
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.TeamMember
@@ -31,4 +32,4 @@ teamMemberAPI =
     <@> mkNamedAPI @"delete-team-member" deleteTeamMember
     <@> mkNamedAPI @"delete-non-binding-team-member" deleteNonBindingTeamMember
     <@> mkNamedAPI @"update-team-member" updateTeamMember
-    <@> mkNamedAPI @"get-team-members-csv" getTeamMembersCSV
+    <@> mkNamedAPI @"get-team-members-csv" Export.getTeamMembersCSV

--- a/services/galley/src/Galley/API/Teams/Export.hs
+++ b/services/galley/src/Galley/API/Teams/Export.hs
@@ -82,10 +82,7 @@ getUserRecord cache member = do
     let mFromInvitation = snd <$> member ^. invitation
     case mFromInvitation of
       Just ts -> pure $ Just ts
-      Nothing -> do
-        -- TODO: make this a single user query
-        suis <- Spar.lookupScimUserInfos [uid]
-        pure $ listToMaybe suis >>= suiCreatedOn
+      Nothing -> suiCreatedOn <$> Spar.lookupScimUserInfo uid
   -- look up inviter handle from the cache
   let mInviterId = fst <$> member ^. invitation
   invitedBy <- join <$> traverse (lookupInviter cache) mInviterId

--- a/services/galley/src/Galley/API/Teams/Export.hs
+++ b/services/galley/src/Galley/API/Teams/Export.hs
@@ -1,0 +1,23 @@
+module Galley.API.Teams.Export (getUserRecord) where
+
+import Control.Lens ((^.))
+import Galley.Effects
+import Galley.Effects.BrigAccess
+import Imports
+import Polysemy
+import Wire.API.Error
+import Wire.API.Error.Galley
+import Wire.API.Team.Export
+import Wire.API.Team.Member
+
+getUserRecord ::
+  ( Member (ErrorS TeamMemberNotFound) r,
+    Member BrigAccess r
+  ) =>
+  TeamMember ->
+  Sem r TeamExportUser
+getUserRecord member = do
+  let uid = member ^. userId
+  export <- getUserExportData uid >>= noteS @TeamMemberNotFound
+  -- TODO
+  pure export

--- a/services/galley/src/Galley/API/Teams/Export.hs
+++ b/services/galley/src/Galley/API/Teams/Export.hs
@@ -1,38 +1,56 @@
-module Galley.API.Teams.Export (getUserRecord) where
+module Galley.API.Teams.Export (getTeamMembersCSV) where
 
+import Control.Concurrent
+import Control.Concurrent.Async qualified as Async
+import Control.Error (MaybeT (MaybeT, runMaybeT))
 import Control.Lens (view, (^.))
+import Control.Monad.Codensity
+import Data.ByteString (toStrict)
+import Data.ByteString.Builder
+import Data.Csv
+import Data.Id
+import Data.Qualified (Local, tUnqualified)
+import Debug.Trace
 import Galley.Effects
 import Galley.Effects.BrigAccess
 import Galley.Effects.SparAccess qualified as Spar
-import Imports
+import Galley.Effects.TeamMemberStore (listTeamMembers)
+import Galley.Effects.TeamStore
+import Imports hiding (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Polysemy
+import Polysemy.Async
+import Polysemy.Resource
 import Wire.API.Error
 import Wire.API.Error.Galley
+import Wire.API.Routes.LowLevelStream (LowLevelStreamingBody)
 import Wire.API.Team.Export
 import Wire.API.Team.Member
 import Wire.API.User (ScimUserInfo (suiCreatedOn), User (..))
+import Wire.Sem.Concurrency
+import Wire.Sem.Concurrency.IO
+import Wire.Sem.Paging qualified as E
+import Wire.Sem.Paging.Cassandra (InternalPaging)
 
 getUserRecord ::
-  ( Member (ErrorS TeamMemberNotFound) r,
-    Member BrigAccess r,
+  ( Member BrigAccess r,
     Member Spar.SparAccess r
   ) =>
   TeamMember ->
-  Sem r TeamExportUser
-getUserRecord member = do
+  Sem r (Maybe TeamExportUser)
+getUserRecord member = runMaybeT do
   let uid = member ^. userId
-  export <- getUserExportData uid >>= noteS @TeamMemberNotFound
+  export <- MaybeT $ getUserExportData uid
   mCreatedOn <- do
     let mFromInvitation = snd <$> member ^. invitation
     case mFromInvitation of
       Just ts -> pure $ Just ts
       Nothing -> do
         -- TODO: make this a single user query
-        suis <- Spar.lookupScimUserInfos [uid]
+        suis <- lift $ Spar.lookupScimUserInfos [uid]
         pure $ listToMaybe suis >>= suiCreatedOn
   -- TODO: optimize!
   let mInviterId = fst <$> member ^. invitation
-  users <- getUsers (maybeToList mInviterId)
+  users <- lift $ getUsers (maybeToList mInviterId)
   let invitedBy = listToMaybe users >>= userHandle
   pure
     export
@@ -40,3 +58,78 @@ getUserRecord member = do
         tExportRole = permissionsRole . view permissions $ member,
         tExportCreatedOn = mCreatedOn
       }
+
+getTeamMembersCSV ::
+  forall r.
+  ( Member BrigAccess r,
+    Member (ErrorS 'AccessDenied) r,
+    Member (TeamMemberStore InternalPaging) r,
+    Member TeamStore r,
+    Member (Final IO) r,
+    Member SparAccess r
+  ) =>
+  Local UserId ->
+  TeamId ->
+  Sem r LowLevelStreamingBody
+getTeamMembersCSV lusr tid = do
+  getTeamMember tid (tUnqualified lusr) >>= \case
+    Nothing -> throwS @'AccessDenied
+    Just member -> unless (member `hasPermission` DownloadTeamMembersCsv) $ throwS @'AccessDenied
+
+  chan <- embedFinal newChan
+
+  let encodeRow r = encodeDefaultOrderedByNameWith customEncodeOptions [r]
+  let produceTeamExportUsers = do
+        embedFinal $ writeChan chan (Just headerLine)
+        E.withChunks (\mps -> listTeamMembers @InternalPaging tid mps maxBound) $
+          \members -> unsafePooledForConcurrentlyN_ 8 members $ \member -> do
+            mRecord <- getUserRecord member
+            let mRow = encodeRow <$> mRecord
+            when (isJust mRow) $
+              embedFinal $
+                writeChan chan mRow
+
+  -- In case an exception is thrown inside the producer thread, the response
+  -- will not contain a correct error message, but rather be an http error such
+  -- as 'InvalidChunkHeaders'. The exception however still reaches the
+  -- middleware and is being tracked in logging and metrics.
+  let producerThread =
+        produceTeamExportUsers
+          `finally` embedFinal (writeChan chan Nothing)
+
+  asyncToIOFinal . resourceToIOFinal . unsafelyPerformConcurrency @_ @Unsafe $ do
+    -- Here we should really capture the Wai continuation and run the finaliser
+    -- after that. Unfortunately, this is not really possible with Servant,
+    -- because the continuation is not exposed by the Handler monad. The best
+    -- we can do is return a Codensity value with the correct finaliser, but
+    -- that still leaves a short window between when the resource is acquired
+    -- and when the finaliser is installed where the resource might be leaked.
+    -- I don't have a good solution for that.
+    bracketOnError
+      (async producerThread)
+      cancel
+      $ \producer -> do
+        pure $ do
+          void $ Codensity $ \k -> do
+            r <- k ()
+            Async.cancel producer
+            pure r
+          pure $ \write flush -> do
+            let go = do
+                  traceM "write chunk"
+                  readChan chan >>= \case
+                    Nothing -> write "" >> flush
+                    Just line -> write (byteString (toStrict line)) >> flush >> go
+            go
+
+headerLine :: LByteString
+headerLine = encodeDefaultOrderedByNameWith (customEncodeOptions {encIncludeHeader = True}) ([] :: [TeamExportUser])
+
+customEncodeOptions :: EncodeOptions
+customEncodeOptions =
+  EncodeOptions
+    { encDelimiter = fromIntegral (ord ','),
+      encUseCrLf = True, -- to be compatible with Mac and Windows
+      encIncludeHeader = False, -- (so we can flush when the header is on the wire)
+      encQuoting = QuoteAll
+    }

--- a/services/galley/src/Galley/API/Teams/Export.hs
+++ b/services/galley/src/Galley/API/Teams/Export.hs
@@ -1,23 +1,42 @@
 module Galley.API.Teams.Export (getUserRecord) where
 
-import Control.Lens ((^.))
+import Control.Lens (view, (^.))
 import Galley.Effects
 import Galley.Effects.BrigAccess
+import Galley.Effects.SparAccess qualified as Spar
 import Imports
 import Polysemy
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Team.Export
 import Wire.API.Team.Member
+import Wire.API.User (ScimUserInfo (suiCreatedOn), User (..))
 
 getUserRecord ::
   ( Member (ErrorS TeamMemberNotFound) r,
-    Member BrigAccess r
+    Member BrigAccess r,
+    Member Spar.SparAccess r
   ) =>
   TeamMember ->
   Sem r TeamExportUser
 getUserRecord member = do
   let uid = member ^. userId
   export <- getUserExportData uid >>= noteS @TeamMemberNotFound
-  -- TODO
-  pure export
+  mCreatedOn <- do
+    let mFromInvitation = snd <$> member ^. invitation
+    case mFromInvitation of
+      Just ts -> pure $ Just ts
+      Nothing -> do
+        -- TODO: make this a single user query
+        suis <- Spar.lookupScimUserInfos [uid]
+        pure $ listToMaybe suis >>= suiCreatedOn
+  -- TODO: optimize!
+  let mInviterId = fst <$> member ^. invitation
+  users <- getUsers (maybeToList mInviterId)
+  let invitedBy = listToMaybe users >>= userHandle
+  pure
+    export
+      { tExportInvitedBy = invitedBy,
+        tExportRole = permissionsRole . view permissions $ member,
+        tExportCreatedOn = mCreatedOn
+      }

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -35,6 +35,7 @@ module Galley.Effects.BrigAccess
     deleteUser,
     getContactList,
     getRichInfoMultiUser,
+    getUserExportData,
 
     -- * Teams
     getSize,
@@ -71,6 +72,7 @@ import Wire.API.Error.Galley
 import Wire.API.MLS.CipherSuite
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti qualified as Multi
+import Wire.API.Team.Export
 import Wire.API.Team.Feature
 import Wire.API.Team.Size
 import Wire.API.User.Auth.ReAuth
@@ -126,6 +128,7 @@ data BrigAccess m a where
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatus SearchVisibilityInboundConfig ->
     BrigAccess m ()
+  GetUserExportData :: UserId -> BrigAccess m (Maybe TeamExportUser)
 
 makeSem ''BrigAccess
 

--- a/services/galley/src/Galley/Effects/SparAccess.hs
+++ b/services/galley/src/Galley/Effects/SparAccess.hs
@@ -25,6 +25,6 @@ import Wire.API.User (ScimUserInfo)
 
 data SparAccess m a where
   DeleteTeam :: TeamId -> SparAccess m ()
-  LookupScimUserInfos :: [UserId] -> SparAccess m [ScimUserInfo]
+  LookupScimUserInfo :: UserId -> SparAccess m ScimUserInfo
 
 makeSem ''SparAccess

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -128,9 +128,9 @@ interpretSparAccess = interpret $ \case
   DeleteTeam tid -> do
     logEffect "SparAccess.DeleteTeam"
     embedApp $ deleteTeam tid
-  LookupScimUserInfos uids -> do
-    logEffect "SparAccess.LookupScimUserInfos"
-    embedApp $ lookupScimUserInfos uids
+  LookupScimUserInfo uid -> do
+    logEffect "SparAccess.LookupScimUserInfo"
+    embedApp $ lookupScimUserInfo uid
 
 interpretBotAccess ::
   ( Member (Embed IO) r,

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -83,6 +83,9 @@ interpretBrigAccess = interpret $ \case
   GetRichInfoMultiUser uids -> do
     logEffect "BrigAccess.GetRichInfoMultiUser"
     embedApp $ getRichInfoMultiUser uids
+  GetUserExportData uid -> do
+    logEffect "BrigAccess.GetUserExportData"
+    embedApp $ getUserExportData uid
   GetSize tid -> do
     logEffect "BrigAccess.GetSize"
     embedApp $ getSize tid

--- a/services/galley/src/Galley/Intra/Spar.hs
+++ b/services/galley/src/Galley/Intra/Spar.hs
@@ -17,19 +17,18 @@
 
 module Galley.Intra.Spar
   ( deleteTeam,
-    lookupScimUserInfos,
+    lookupScimUserInfo,
   )
 where
 
 import Bilge
 import Data.ByteString.Conversion
 import Data.Id
-import Data.Set qualified as Set
 import Galley.Intra.Util
 import Galley.Monad
 import Imports
 import Network.HTTP.Types.Method
-import Wire.API.User (ScimUserInfo, UserSet (..), scimUserInfos)
+import Wire.API.User (ScimUserInfo)
 
 -- | Notify Spar that a team is being deleted.
 deleteTeam :: TeamId -> App ()
@@ -40,11 +39,10 @@ deleteTeam tid = do
       . expect2xx
 
 -- | Get the SCIM user info for a user.
-lookupScimUserInfos :: [UserId] -> App [ScimUserInfo]
-lookupScimUserInfos uids = do
+lookupScimUserInfo :: UserId -> App (ScimUserInfo)
+lookupScimUserInfo uid = do
   response <-
     call Spar $
       method POST
-        . paths ["i", "scim", "userinfos"]
-        . json (UserSet $ Set.fromList uids)
-  pure $ foldMap scimUserInfos $ responseJsonMaybe response
+        . paths ["i", "scim", "userinfos", toByteString' uid]
+  responseJsonError response

--- a/services/galley/src/Galley/Intra/Spar.hs
+++ b/services/galley/src/Galley/Intra/Spar.hs
@@ -39,10 +39,10 @@ deleteTeam tid = do
       . expect2xx
 
 -- | Get the SCIM user info for a user.
-lookupScimUserInfo :: UserId -> App (ScimUserInfo)
+lookupScimUserInfo :: UserId -> App ScimUserInfo
 lookupScimUserInfo uid = do
   response <-
     call Spar $
       method POST
-        . paths ["i", "scim", "userinfos", toByteString' uid]
+        . paths ["i", "scim", "userinfo", toByteString' uid]
   responseJsonError response

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -30,6 +30,7 @@ module Galley.Intra.User
     getContactList,
     chunkify,
     getRichInfoMultiUser,
+    getUserExportData,
     getAccountConferenceCallingConfigClient,
     updateSearchVisibilityInbound,
   )
@@ -66,6 +67,7 @@ import Wire.API.Routes.Internal.Brig qualified as IAPI
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti qualified as Multi
 import Wire.API.Routes.Named
+import Wire.API.Team.Export
 import Wire.API.Team.Feature
 import Wire.API.User
 import Wire.API.User.Auth.ReAuth
@@ -236,6 +238,16 @@ getRichInfoMultiUser = chunkify $ \uids -> do
         . queryItem "ids" (toByteString' (List uids))
         . expect2xx
   parseResponse (mkError status502 "server-error: could not parse response to `GET brig:/i/users/rich-info`") resp
+
+-- | Calls 'Brig.API.Internal.getUserExportDataH'
+getUserExportData :: UserId -> App (Maybe TeamExportUser)
+getUserExportData uid = do
+  resp <-
+    call Brig $
+      method GET
+        . paths ["i/users", toByteString' uid, "export-data"]
+        . expect2xx
+  parseResponse (mkError status502 "server-error: could not parse response to `GET brig:/i/users/:uid/export-data`") resp
 
 getAccountConferenceCallingConfigClient :: (HasCallStack) => UserId -> App (Feature ConferenceCallingConfig)
 getAccountConferenceCallingConfigClient uid =

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -54,7 +54,6 @@ import Data.HavePendingInvitations
 import Data.Id
 import Data.Proxy
 import Data.Range
-import qualified Data.Set as Set
 import Data.Text.Encoding.Error
 import qualified Data.Text.Lazy as T
 import Data.Text.Lazy.Encoding
@@ -791,8 +790,7 @@ internalPutSsoSettings SsoSettings {defaultSsoCode = Just code} =
     *> DefaultSsoCode.store code
       $> NoContent
 
-internalGetScimUserInfo :: (Member ScimUserTimesStore r) => UserSet -> Sem r ScimUserInfos
-internalGetScimUserInfo (UserSet uids) = do
-  results <- ScimUserTimesStore.readMulti (Set.toList uids)
-  let scimUserInfos = results <&> (\(uid, t, _) -> ScimUserInfo uid (Just t))
-  pure $ ScimUserInfos scimUserInfos
+internalGetScimUserInfo :: (Member ScimUserTimesStore r) => UserId -> Sem r ScimUserInfo
+internalGetScimUserInfo uid = do
+  t <- fmap fst <$> ScimUserTimesStore.read uid
+  pure $ ScimUserInfo uid t

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -22,6 +22,7 @@
 , http-client-tls
 , http-types
 , imports
+, kan-extensions
 , lens
 , lens-aeson
 , lib
@@ -42,6 +43,7 @@
 , tasty-ant-xml
 , tasty-hunit
 , text
+, time
 , tinylog
 , transformers
 , types-common
@@ -73,6 +75,7 @@ mkDerivation {
     http-client
     http-types
     imports
+    kan-extensions
     lens
     mtl
     openapi3
@@ -83,6 +86,7 @@ mkDerivation {
     servant-swagger-ui
     split
     text
+    time
     tinylog
     transformers
     types-common

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -22,7 +22,6 @@
 , http-client-tls
 , http-types
 , imports
-, kan-extensions
 , lens
 , lens-aeson
 , lib
@@ -75,7 +74,6 @@ mkDerivation {
     http-client
     http-types
     imports
-    kan-extensions
     lens
     mtl
     openapi3

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -52,6 +52,7 @@ import Data.Text.Encoding qualified as T
 import Data.Text.Encoding.Error
 import Data.Text.Lazy qualified as LT
 import Data.Text.Lazy.Encoding qualified as LT
+import Data.Time.Format
 import Debug.Trace
 import GHC.TypeLits (KnownSymbol)
 import Imports hiding (head)
@@ -481,7 +482,12 @@ getTeamActivityInfo tid = do
               ( Just
                   ( toByteString' user
                       <> ","
-                      <> B8.pack (maybe mempty show tm)
+                      <> B8.pack
+                        ( maybe
+                            mempty
+                            (formatTime defaultTimeLocale "%Y-%m-%d")
+                            tm
+                        )
                   )
               )
           writeChan chan Nothing

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -473,7 +473,6 @@ getTeamActivityInfo tid = do
     chan <- liftIO newChan
     let runThread :: IO () = do
           pooledForConcurrentlyN_ 8 memList $ \user -> do
-            -- get user info
             tm <-
               runHandler env (Intra.getActivityTimestamp user)
                 >>= either throwIO pure

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -482,8 +482,7 @@ getTeamActivityInfo tid = do
                   ( toByteString' user
                       <> ","
                       <> B8.pack
-                        ( maybe
-                            mempty
+                        ( foldMap
                             (formatTime defaultTimeLocale "%Y-%m-%d")
                             tm
                         )

--- a/tools/stern/src/Stern/API/Routes.hs
+++ b/tools/stern/src/Stern/API/Routes.hs
@@ -43,7 +43,7 @@ import Wire.API.OAuth
 import Wire.API.Routes.CSV
 import Wire.API.Routes.Internal.Brig.Connection (ConnectionStatus)
 import Wire.API.Routes.Internal.Brig.EJPD qualified as EJPD
-import Wire.API.Routes.MultiVerb
+import Wire.API.Routes.LowLevelStream
 import Wire.API.Routes.Named
 import Wire.API.SwaggerHelper (cleanupSwagger)
 import Wire.API.Team.Feature
@@ -445,8 +445,7 @@ type SternAPI =
            ( Summary "List user IDs and the timestamp of their last activity"
                :> "team-activity-info"
                :> Capture "tid" TeamId
-               -- :> LowLevelStream GET 200 '[] "Output CSV" CSV
-               :> MultiVerb1 GET '[CSV] (RespondStreaming 200 "Output CSV" CSV)
+               :> LowLevelStream GET 200 '[] "Output CSV" CSV
            )
 
 -------------------------------------------------------------------------------

--- a/tools/stern/src/Stern/API/Routes.hs
+++ b/tools/stern/src/Stern/API/Routes.hs
@@ -40,8 +40,10 @@ import Servant.Swagger.UI
 import Stern.Types
 import Wire.API.CustomBackend
 import Wire.API.OAuth
+import Wire.API.Routes.CSV
 import Wire.API.Routes.Internal.Brig.Connection (ConnectionStatus)
 import Wire.API.Routes.Internal.Brig.EJPD qualified as EJPD
+import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
 import Wire.API.SwaggerHelper (cleanupSwagger)
 import Wire.API.Team.Feature
@@ -437,6 +439,14 @@ type SternAPI =
                :> "clients"
                :> Capture "id" OAuthClientId
                :> Delete '[JSON] ()
+           )
+    :<|> Named
+           "get-team-activity-info"
+           ( Summary "List user IDs and the timestamp of their last activity"
+               :> "team-activity-info"
+               :> Capture "tid" TeamId
+               -- :> LowLevelStream GET 200 '[] "Output CSV" CSV
+               :> MultiVerb1 GET '[CSV] (RespondStreaming 200 "Output CSV" CSV)
            )
 
 -------------------------------------------------------------------------------

--- a/tools/stern/src/Stern/API/Routes.hs
+++ b/tools/stern/src/Stern/API/Routes.hs
@@ -40,10 +40,8 @@ import Servant.Swagger.UI
 import Stern.Types
 import Wire.API.CustomBackend
 import Wire.API.OAuth
-import Wire.API.Routes.CSV
 import Wire.API.Routes.Internal.Brig.Connection (ConnectionStatus)
 import Wire.API.Routes.Internal.Brig.EJPD qualified as EJPD
-import Wire.API.Routes.LowLevelStream
 import Wire.API.Routes.Named
 import Wire.API.SwaggerHelper (cleanupSwagger)
 import Wire.API.Team.Feature
@@ -439,13 +437,6 @@ type SternAPI =
                :> "clients"
                :> Capture "id" OAuthClientId
                :> Delete '[JSON] ()
-           )
-    :<|> Named
-           "get-team-activity-info"
-           ( Summary "List user IDs and the timestamp of their last activity"
-               :> "team-activity-info"
-               :> Capture "tid" TeamId
-               :> LowLevelStream GET 200 '[] "Output CSV" CSV
            )
 
 -------------------------------------------------------------------------------

--- a/tools/stern/src/Stern/App.hs
+++ b/tools/stern/src/Stern/App.hs
@@ -124,6 +124,9 @@ runAppT e (AppT ma) = runReaderT ma e
 
 type Handler = ExceptT Error App
 
+runHandler :: Env -> Handler a -> IO (Either Error a)
+runHandler env = runAppT env . runExceptT
+
 type Continue m = Response -> m ResponseReceived
 
 userMsg :: UserId -> Msg -> Msg

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -38,6 +38,7 @@ module Stern.Intra
     setStatusBindingTeam,
     deleteBindingTeam,
     deleteBindingTeamForce,
+    getTeamMembers,
     getTeamInfo,
     getUserBindingTeam,
     isBlacklisted,

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -67,6 +67,7 @@ module Stern.Intra
     getOAuthClient,
     updateOAuthClient,
     deleteOAuthClient,
+    getActivityTimestamp,
   )
 where
 
@@ -93,6 +94,7 @@ import Data.Text.Encoding
 import Data.Text.Encoding.Error
 import Data.Text.Lazy as LT (pack)
 import Data.Text.Lazy.Encoding qualified as TL
+import Data.Time.Clock
 import Imports
 import Network.HTTP.Types (urlEncode)
 import Network.HTTP.Types.Method
@@ -1035,6 +1037,20 @@ deleteOAuthClient cid = do
         b
         ( method DELETE
             . Bilge.paths ["i", "oauth", "clients", toByteString' cid]
+            . expect2xx
+        )
+  parseResponse (mkError status502 "bad-upstream") r
+
+getActivityTimestamp :: UserId -> Handler (Maybe UTCTime)
+getActivityTimestamp uid = do
+  b <- asks (.brig)
+  r <-
+    catchRpcErrors $
+      rpc'
+        "brig"
+        b
+        ( method GET
+            . Bilge.paths ["i", "users", toByteString' uid, "activity"]
             . expect2xx
         )
   parseResponse (mkError status502 "bad-upstream") r

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -97,6 +97,7 @@ library
     , servant-swagger-ui
     , split                  >=0.2
     , text                   >=1.1
+    , time
     , tinylog                >=0.10
     , transformers           >=0.3
     , types-common           >=0.4.13

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -86,6 +86,7 @@ library
     , http-client            >=0.7
     , http-types             >=0.8
     , imports
+    , kan-extensions
     , lens                   >=4.4
     , mtl                    >=2.1
     , openapi3

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -86,7 +86,6 @@ library
     , http-client            >=0.7
     , http-types             >=0.8
     , imports
-    , kan-extensions
     , lens                   >=4.4
     , mtl                    >=2.1
     , openapi3


### PR DESCRIPTION
This adds `last_active` and `status` columns to the team CSV export. It also includes a refactoring of the export handler. I manually tested performance of the new handler, and for 500 users it's very similar to before despite the extra query. For larger teams it should be comparatively faster.

We have had a discussion on whether or not to make a new version of this endpoint. Adding columns at the end of the previous CSV format is quite unlikely to break scripts, so in the end I decided *not* to make a new version and keep things simple. In the future, we might consider further improving the export functionality by making it asynchronous for large teams, and possibly making columns user-selectable.

https://wearezeta.atlassian.net/browse/WPB-11368

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
