### PR TITLE
proxy: Make sure Servant.Raw is the last thing in the servant API type

### DIFF
--- a/services/proxy/src/Proxy/Run.hs
+++ b/services/proxy/src/Proxy/Run.hs
@@ -43,10 +43,10 @@ import Servant qualified
 import Wire.API.Routes.Version
 import Wire.API.Routes.Version.Wai
 
-type CombinedAPI = PublicAPI Servant.:<|> InternalAPI
+type CombinedAPI = InternalAPI Servant.:<|> PublicAPI
 
 combinedSitemap :: Env -> Servant.ServerT CombinedAPI Proxy
-combinedSitemap env = P.servantSitemap env Servant.:<|> I.servantSitemap
+combinedSitemap env = I.servantSitemap Servant.:<|> P.servantSitemap env
 
 run :: Opts -> IO ()
 run o = do


### PR DESCRIPTION
Making it first causes all requests to be routed into the handler for Servant.Raw

Fixup for  https://github.com/wireapp/wire-server/pull/4296

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
