### PR TITLE
[WPB-8881] Move email update and remove operations to effects

### DIFF
--- a/changelog.d/5-internal/WPB-8881
+++ b/changelog.d/5-internal/WPB-8881
@@ -1,0 +1,1 @@
+Move email update and remove operations to effects

--- a/libs/wire-api/src/Wire/API/Error/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Error/Brig.hs
@@ -67,6 +67,7 @@ data BrigError
   | NameManagedByScim
   | HandleManagedByScim
   | LocaleManagedByScim
+  | EmailManagedByScim
   | LastIdentity
   | NoPassword
   | ChangePasswordMustDiffer
@@ -246,6 +247,8 @@ type instance MapError 'NameManagedByScim = 'StaticError 403 "managed-by-scim" "
 type instance MapError 'HandleManagedByScim = 'StaticError 403 "managed-by-scim" "Updating handle is not allowed, because it is managed by SCIM, or E2EId is enabled"
 
 type instance MapError 'LocaleManagedByScim = 'StaticError 403 "managed-by-scim" "Updating locale is not allowed, because it is managed by SCIM, or E2EId is enabled"
+
+type instance MapError 'EmailManagedByScim = 'StaticError 403 "managed-by-scim" "Updating email is not allowed, because it is managed by SCIM, or E2EId is enabled"
 
 type instance MapError 'LastIdentity = 'StaticError 403 "last-identity" "The last user identity cannot be removed."
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -363,7 +363,7 @@ type SelfAPI =
           :> Description
                "Your email address can only be removed if you also have a \
                \phone number."
-          :> ZUser
+          :> ZLocalUser
           :> "self"
           :> "email"
           :> MultiVerb 'DELETE '[JSON] RemoveIdentityResponses (Maybe RemoveIdentityError)

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -1517,7 +1517,6 @@ instance (res ~ ChangePhoneResponses) => AsUnion res (Maybe ChangePhoneError) wh
 
 data RemoveIdentityError
   = LastIdentity
-  | NoPassword
   | NoIdentity
   deriving (Generic)
   deriving (AsUnion RemoveIdentityErrorResponses) via GenericAsUnion RemoveIdentityErrorResponses RemoveIdentityError
@@ -1526,7 +1525,6 @@ instance GSOP.Generic RemoveIdentityError
 
 type RemoveIdentityErrorResponses =
   [ ErrorResponse 'E.LastIdentity,
-    ErrorResponse 'E.NoPassword,
     ErrorResponse 'E.NoIdentity
   ]
 

--- a/libs/wire-api/src/Wire/API/User/Activation.hs
+++ b/libs/wire-api/src/Wire/API/User/Activation.hs
@@ -32,6 +32,9 @@ module Wire.API.User.Activation
 
     -- * SendActivationCode
     SendActivationCode (..),
+
+    -- * Activation
+    Activation (..),
   )
 where
 
@@ -211,3 +214,12 @@ instance ToSchema SendActivationCode where
       objectDesc =
         description
           ?~ "Data for requesting an email code to be sent. 'email' must be present."
+
+--  | The information associated with the pending activation of an 'EmailKey'.
+data Activation = Activation
+  { -- | An opaque key for the original 'EmailKey' pending activation.
+    activationKey :: !ActivationKey,
+    -- | The confidential activation code.
+    activationCode :: !ActivationCode
+  }
+  deriving (Eq, Show)

--- a/libs/wire-subsystems/src/Wire/ActivationCodeStore.hs
+++ b/libs/wire-subsystems/src/Wire/ActivationCodeStore.hs
@@ -21,10 +21,19 @@ module Wire.ActivationCodeStore where
 import Data.Id
 import Imports
 import Polysemy
+import Util.Timeout
 import Wire.API.User.Activation
 import Wire.UserKeyStore
 
 data ActivationCodeStore :: Effect where
   LookupActivationCode :: EmailKey -> ActivationCodeStore m (Maybe (Maybe UserId, ActivationCode))
+  -- | Create a new pending activation for a given 'EmailKey'.
+  NewActivation ::
+    EmailKey ->
+    -- | The timeout for the activation code.
+    Timeout ->
+    -- | The user with whom to associate the activation code.
+    Maybe UserId ->
+    ActivationCodeStore m Activation
 
 makeSem ''ActivationCodeStore

--- a/libs/wire-subsystems/src/Wire/ActivationCodeStore.hs
+++ b/libs/wire-subsystems/src/Wire/ActivationCodeStore.hs
@@ -27,8 +27,8 @@ import Wire.UserKeyStore
 
 data ActivationCodeStore :: Effect where
   LookupActivationCode :: EmailKey -> ActivationCodeStore m (Maybe (Maybe UserId, ActivationCode))
-  -- | Create a new pending activation for a given 'EmailKey'.
-  NewActivation ::
+  -- | Create a code for a new pending activation for a given 'EmailKey'
+  NewActivationCode ::
     EmailKey ->
     -- | The timeout for the activation code.
     Timeout ->

--- a/libs/wire-subsystems/src/Wire/ActivationCodeStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/ActivationCodeStore/Cassandra.hs
@@ -1,30 +1,62 @@
-module Wire.ActivationCodeStore.Cassandra where
+module Wire.ActivationCodeStore.Cassandra (interpretActivationCodeStoreToCassandra) where
 
 import Cassandra
 import Data.Id
+import Data.Text (pack)
 import Data.Text.Ascii qualified as Ascii
 import Data.Text.Encoding qualified as T
 import Imports
+import OpenSSL.BN (randIntegerZeroToNMinusOne)
 import OpenSSL.EVP.Digest
 import Polysemy
 import Polysemy.Embed
+import Text.Printf (printf)
+import Util.Timeout
 import Wire.API.User.Activation
+import Wire.API.User.EmailAddress
 import Wire.ActivationCodeStore
-import Wire.UserKeyStore (EmailKey, emailKeyUniq)
+import Wire.UserKeyStore
 
 interpretActivationCodeStoreToCassandra :: (Member (Embed IO) r) => ClientState -> InterpreterFor ActivationCodeStore r
 interpretActivationCodeStoreToCassandra casClient =
   interpret $
-    runEmbedded (runClient casClient) . \case
-      LookupActivationCode ek -> embed do
+    runEmbedded (runClient casClient) . embed . \case
+      LookupActivationCode ek -> do
         liftIO (mkActivationKey ek)
           >>= retry x1 . query1 cql . params LocalQuorum . Identity
+      NewActivation ek timeout uid -> newActivationImpl ek timeout uid
   where
     cql :: PrepQuery R (Identity ActivationKey) (Maybe UserId, ActivationCode)
     cql =
-      [sql| 
+      [sql|
       SELECT user, code FROM activation_keys WHERE key = ?
       |]
+
+-- | Create a new pending activation for a given 'EmailKey'.
+newActivationImpl ::
+  (MonadClient m) =>
+  EmailKey ->
+  -- | The timeout for the activation code.
+  Timeout ->
+  -- | The user with whom to associate the activation code.
+  Maybe UserId ->
+  m Activation
+newActivationImpl uk timeout u = do
+  let typ = "email"
+      key = fromEmail (emailKeyOrig uk)
+  code <- liftIO $ genCode
+  insert typ key code
+  where
+    insert t k c = do
+      key <- liftIO $ mkActivationKey uk
+      retry x5 . write keyInsert $ params LocalQuorum (key, t, k, c, u, maxAttempts, round timeout)
+      pure $ Activation key c
+    genCode =
+      ActivationCode . Ascii.unsafeFromText . pack . printf "%06d"
+        <$> randIntegerZeroToNMinusOne 1000000
+
+--------------------------------------------------------------------------------
+-- Utilities
 
 mkActivationKey :: EmailKey -> IO ActivationKey
 mkActivationKey k = do
@@ -35,3 +67,13 @@ mkActivationKey k = do
       . digestBS d
       . T.encodeUtf8
       $ emailKeyUniq k
+
+keyInsert :: PrepQuery W (ActivationKey, Text, Text, ActivationCode, Maybe UserId, Int32, Int32) ()
+keyInsert =
+  "INSERT INTO activation_keys \
+  \(key, key_type, key_text, code, user, retries) VALUES \
+  \(?  , ?       , ?       , ?   , ?   , ?      ) USING TTL ?"
+
+-- | Max. number of activation attempts per 'ActivationKey'.
+maxAttempts :: Int32
+maxAttempts = 3

--- a/libs/wire-subsystems/src/Wire/ActivationCodeStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/ActivationCodeStore/Cassandra.hs
@@ -24,7 +24,7 @@ interpretActivationCodeStoreToCassandra casClient =
       LookupActivationCode ek -> do
         liftIO (mkActivationKey ek)
           >>= retry x1 . query1 cql . params LocalQuorum . Identity
-      NewActivation ek timeout uid -> newActivationImpl ek timeout uid
+      NewActivationCode ek timeout uid -> newActivationCodeImpl ek timeout uid
   where
     cql :: PrepQuery R (Identity ActivationKey) (Maybe UserId, ActivationCode)
     cql =
@@ -33,7 +33,7 @@ interpretActivationCodeStoreToCassandra casClient =
       |]
 
 -- | Create a new pending activation for a given 'EmailKey'.
-newActivationImpl ::
+newActivationCodeImpl ::
   (MonadClient m) =>
   EmailKey ->
   -- | The timeout for the activation code.
@@ -41,7 +41,7 @@ newActivationImpl ::
   -- | The user with whom to associate the activation code.
   Maybe UserId ->
   m Activation
-newActivationImpl uk timeout u = do
+newActivationCodeImpl uk timeout u = do
   let typ = "email"
       key = fromEmail (emailKeyOrig uk)
   code <- liftIO $ genCode

--- a/libs/wire-subsystems/src/Wire/UserStore.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore.hs
@@ -74,6 +74,7 @@ data UserStore m a where
   GetActivityTimestamps :: UserId -> UserStore m [Maybe UTCTime]
   GetRichInfo :: UserId -> UserStore m (Maybe RichInfoAssocList)
   GetUserAuthenticationInfo :: UserId -> UserStore m (Maybe (Maybe Password, AccountStatus))
+  DeleteEmail :: UserId -> UserStore m ()
 
 makeSem ''UserStore
 

--- a/libs/wire-subsystems/src/Wire/UserStore.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore.hs
@@ -54,6 +54,7 @@ data UserStore m a where
   GetIndexUsersPaginated :: Int32 -> Maybe PagingState -> UserStore m (PageWithState IndexUser)
   GetUsers :: [UserId] -> UserStore m [StoredUser]
   UpdateUser :: UserId -> StoredUserUpdate -> UserStore m ()
+  UpdateEmailUnvalidated :: UserId -> EmailAddress -> UserStore m ()
   UpdateUserHandleEither :: UserId -> StoredUserHandleUpdate -> UserStore m (Either StoredUserUpdateError ())
   DeleteUser :: User -> UserStore m ()
   -- | This operation looks up a handle but is guaranteed to not give you stale locks.

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -201,9 +201,9 @@ getLocalUserAccountByUserKey :: (Member UserSubsystem r) => Local EmailKey -> Se
 getLocalUserAccountByUserKey q@(tUnqualified -> ek) =
   listToMaybe <$> getAccountsByEmailNoFilter (qualifyAs q [emailKeyOrig ek])
 
--- | Call 'changeEmail' and process result: if email changes to itself, succeed,
--- if not, send validation email.
-changeSelfEmail ::
+-- | Call 'createEmailChangeToken' and process result: if email changes to
+-- itself, succeed, if not, send validation email.
+requestEmailChange ::
   ( Member BlockListStore r,
     Member UserKeyStore r,
     Member EmailSubsystem r,
@@ -265,7 +265,7 @@ changeEmail actTimeout lusr email updateOrigin = do
     _ -> do
       unless (userManagedBy usr /= ManagedByScim || updateOrigin == UpdateOriginScim) $
         throw UserSubsystemEmailManagedByScim
-      act <- newActivation ek actTimeout (Just u)
+      act <- newActivationCode ek actTimeout (Just u)
       pure $ ChangeEmailNeedsActivation (usr, act, email)
 
 ------------------------------------------

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -18,19 +18,26 @@ import Data.Range
 import Imports
 import Polysemy
 import Polysemy.Error
+import Util.Timeout
 import Wire.API.Federation.Error
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti (TeamStatus)
 import Wire.API.Team.Export (TeamExportUser)
 import Wire.API.Team.Feature
 import Wire.API.Team.Member (IsPerm (..), TeamMember)
 import Wire.API.User
+import Wire.API.User.Activation
 import Wire.API.User.Search
+import Wire.ActivationCodeStore
 import Wire.Arbitrary
+import Wire.BlockListStore
+import Wire.BlockListStore qualified as BlockListStore
+import Wire.EmailSubsystem
 import Wire.GalleyAPIAccess (GalleyAPIAccess)
 import Wire.GalleyAPIAccess qualified as GalleyAPIAccess
 import Wire.InvitationStore
-import Wire.UserKeyStore (EmailKey, emailKeyOrig)
+import Wire.UserKeyStore
 import Wire.UserSearch.Types
+import Wire.UserStore
 import Wire.UserSubsystem.Error (UserSubsystemError (..))
 
 -- | Who is performing this update operation / who is allowed to?  (Single source of truth:
@@ -87,6 +94,14 @@ data GetBy = MkGetBy
 
 instance Default GetBy where
   def = MkGetBy NoPendingInvitations [] []
+
+-- | Outcome of email change invariant checks.
+data ChangeEmailResult
+  = -- | The request was successful, user needs to verify the new email address
+    ChangeEmailNeedsActivation !(User, Activation, EmailAddress)
+  | -- | The user asked to change the email address to the one already owned
+    ChangeEmailIdempotent
+  deriving (Show)
 
 data UserSubsystem m a where
   -- | First arg is for authorization only.
@@ -180,6 +195,73 @@ getLocalAccountBy includePendingInvitations uid =
 getLocalUserAccountByUserKey :: (Member UserSubsystem r) => Local EmailKey -> Sem r (Maybe User)
 getLocalUserAccountByUserKey q@(tUnqualified -> ek) =
   listToMaybe <$> getAccountsByEmailNoFilter (qualifyAs q [emailKeyOrig ek])
+
+-- | Call 'changeEmail' and process result: if email changes to itself, succeed,
+-- if not, send validation email.
+changeSelfEmail ::
+  ( Member BlockListStore r,
+    Member UserKeyStore r,
+    Member EmailSubsystem r,
+    Member UserSubsystem r,
+    Member UserStore r,
+    Member (Error UserSubsystemError) r,
+    Member ActivationCodeStore r
+  ) =>
+  Timeout ->
+  Local UserId ->
+  EmailAddress ->
+  UpdateOriginType ->
+  Sem r ChangeEmailResponse
+changeSelfEmail actTimeout lusr email allowScim = do
+  let u = tUnqualified lusr
+  changeEmail actTimeout lusr email allowScim >>= \case
+    ChangeEmailIdempotent ->
+      pure ChangeEmailResponseIdempotent
+    ChangeEmailNeedsActivation (usr, adata, en) -> do
+      sendOutEmail usr adata en
+      updateEmailUnvalidated u email
+      internalUpdateSearchIndex u
+      pure ChangeEmailResponseNeedsActivation
+  where
+    sendOutEmail usr adata en = do
+      (maybe sendActivationMail (const sendEmailAddressUpdateMail) usr.userIdentity)
+        en
+        (userDisplayName usr)
+        (activationKey adata)
+        (activationCode adata)
+        (Just (userLocale usr))
+
+-- | Prepare changing the email (checking a number of invariants).
+changeEmail ::
+  ( Member BlockListStore r,
+    Member UserKeyStore r,
+    Member (Error UserSubsystemError) r,
+    Member UserSubsystem r,
+    Member ActivationCodeStore r
+  ) =>
+  Timeout ->
+  Local UserId ->
+  EmailAddress ->
+  UpdateOriginType ->
+  Sem r ChangeEmailResult
+changeEmail actTimeout lusr email updateOrigin = do
+  let ek = mkEmailKey email
+      u = tUnqualified lusr
+  blocklisted <- BlockListStore.exists ek
+  when blocklisted $ throw UserSubsystemChangeBlocklistedEmail
+  available <- keyAvailable ek (Just u)
+  unless available $ throw UserSubsystemEmailExists
+  usr <-
+    getLocalAccountBy WithPendingInvitations lusr
+      >>= note UserSubsystemProfileNotFound
+  case emailIdentity =<< userIdentity usr of
+    -- The user already has an email address and the new one is exactly the same
+    Just current | current == email -> pure ChangeEmailIdempotent
+    _ -> do
+      unless (userManagedBy usr /= ManagedByScim || updateOrigin == UpdateOriginScim) $
+        throw UserSubsystemEmailManagedByScim
+      act <- newActivation ek actTimeout (Just u)
+      pure $ ChangeEmailNeedsActivation (usr, act, email)
 
 ------------------------------------------
 -- FUTUREWORK: Pending functions for a team subsystem

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -160,6 +160,11 @@ data UserSubsystem m a where
   InternalUpdateSearchIndex :: UserId -> UserSubsystem m ()
   InternalFindTeamInvitation :: Maybe EmailKey -> InvitationCode -> UserSubsystem m StoredInvitation
   GetUserExportData :: UserId -> UserSubsystem m (Maybe TeamExportUser)
+  -- | Throws errors in the interpreter.
+  RemoveEmail :: Local UserId -> UserSubsystem m ()
+  -- | Implemented in terms of 'RemoveEmail', but returns as value only a few
+  -- errors of type 'RemoveIdentityError', and re-throws others.
+  RemoveEmailEither :: Local UserId -> UserSubsystem m (Either RemoveIdentityError ())
 
 -- | the return type of 'CheckHandle'
 data CheckHandleResp

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -217,9 +217,9 @@ requestEmailChange ::
   EmailAddress ->
   UpdateOriginType ->
   Sem r ChangeEmailResponse
-changeSelfEmail actTimeout lusr email allowScim = do
+requestEmailChange actTimeout lusr email allowScim = do
   let u = tUnqualified lusr
-  changeEmail actTimeout lusr email allowScim >>= \case
+  createEmailChangeToken actTimeout lusr email allowScim >>= \case
     ChangeEmailIdempotent ->
       pure ChangeEmailResponseIdempotent
     ChangeEmailNeedsActivation (usr, adata, en) -> do
@@ -237,7 +237,7 @@ changeSelfEmail actTimeout lusr email allowScim = do
         (Just (userLocale usr))
 
 -- | Prepare changing the email (checking a number of invariants).
-changeEmail ::
+createEmailChangeToken ::
   ( Member BlockListStore r,
     Member UserKeyStore r,
     Member (Error UserSubsystemError) r,
@@ -249,7 +249,7 @@ changeEmail ::
   EmailAddress ->
   UpdateOriginType ->
   Sem r ChangeEmailResult
-changeEmail actTimeout lusr email updateOrigin = do
+createEmailChangeToken actTimeout lusr email updateOrigin = do
   let ek = mkEmailKey email
       u = tUnqualified lusr
   blocklisted <- BlockListStore.exists ek

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Error.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Error.hs
@@ -14,6 +14,7 @@ data UserSubsystemError
     UserSubsystemDisplayNameManagedByScim
   | UserSubsystemHandleManagedByScim
   | UserSubsystemLocaleManagedByScim
+  | UserSubsystemEmailManagedByScim
   | UserSubsystemNoIdentity
   | UserSubsystemHandleExists
   | UserSubsystemInvalidHandle
@@ -28,6 +29,8 @@ data UserSubsystemError
   | UserSubsystemInvitationNotFound
   | UserSubsystemUserNotAllowedToJoinTeam Wai.Error
   | UserSubsystemMLSServicesNotAllowed
+  | UserSubsystemChangeBlocklistedEmail
+  | UserSubsystemEmailExists
   deriving (Eq, Show)
 
 userSubsystemErrorToHttpError :: UserSubsystemError -> HttpError
@@ -36,6 +39,7 @@ userSubsystemErrorToHttpError =
     UserSubsystemProfileNotFound -> errorToWai @E.UserNotFound
     UserSubsystemDisplayNameManagedByScim -> errorToWai @E.NameManagedByScim
     UserSubsystemLocaleManagedByScim -> errorToWai @E.LocaleManagedByScim
+    UserSubsystemEmailManagedByScim -> errorToWai @E.EmailManagedByScim
     UserSubsystemNoIdentity -> errorToWai @E.NoIdentity
     UserSubsystemHandleExists -> errorToWai @E.HandleExists
     UserSubsystemInvalidHandle -> errorToWai @E.InvalidHandle
@@ -50,5 +54,7 @@ userSubsystemErrorToHttpError =
     UserSubsystemInvitationNotFound -> Wai.mkError status404 "not-found" "Something went wrong, while looking up the invitation"
     UserSubsystemUserNotAllowedToJoinTeam e -> e
     UserSubsystemMLSServicesNotAllowed -> errorToWai @E.MLSServicesNotAllowed
+    UserSubsystemChangeBlocklistedEmail -> errorToWai @E.BlacklistedEmail
+    UserSubsystemEmailExists -> errorToWai @'E.UserKeyExists
 
 instance Exception UserSubsystemError

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Error.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Error.hs
@@ -16,6 +16,7 @@ data UserSubsystemError
   | UserSubsystemLocaleManagedByScim
   | UserSubsystemEmailManagedByScim
   | UserSubsystemNoIdentity
+  | UserSubsystemLastIdentity
   | UserSubsystemHandleExists
   | UserSubsystemInvalidHandle
   | UserSubsystemProfileNotFound
@@ -41,6 +42,7 @@ userSubsystemErrorToHttpError =
     UserSubsystemLocaleManagedByScim -> errorToWai @E.LocaleManagedByScim
     UserSubsystemEmailManagedByScim -> errorToWai @E.EmailManagedByScim
     UserSubsystemNoIdentity -> errorToWai @E.NoIdentity
+    UserSubsystemLastIdentity -> errorToWai @E.LastIdentity
     UserSubsystemHandleExists -> errorToWai @E.HandleExists
     UserSubsystemInvalidHandle -> errorToWai @E.InvalidHandle
     UserSubsystemHandleManagedByScim -> errorToWai @E.HandleManagedByScim

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -32,6 +32,7 @@ import Polysemy.TinyLog qualified as Log
 import SAML2.WebSSO qualified as SAML
 import Servant.Client.Core
 import System.Logger.Message qualified as Log
+import Util.Timeout
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig qualified as FedBrig
 import Wire.API.Federation.Error
@@ -81,7 +82,8 @@ data UserSubsystemConfig = UserSubsystemConfig
   { emailVisibilityConfig :: EmailVisibilityConfig,
     defaultLocale :: Locale,
     searchSameTeamOnly :: Bool,
-    maxTeamSize :: Word32
+    maxTeamSize :: Word32,
+    activationCodeTimeout :: Timeout
   }
   deriving (Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserSubsystemConfig)

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -32,7 +32,6 @@ import Polysemy.TinyLog qualified as Log
 import SAML2.WebSSO qualified as SAML
 import Servant.Client.Core
 import System.Logger.Message qualified as Log
-import Util.Timeout
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig qualified as FedBrig
 import Wire.API.Federation.Error
@@ -49,7 +48,6 @@ import Wire.API.User as User
 import Wire.API.User.RichInfo
 import Wire.API.User.Search
 import Wire.API.UserEvent
-import Wire.Arbitrary
 import Wire.AuthenticationSubsystem
 import Wire.BlockListStore as BlockList
 import Wire.DeleteQueue
@@ -76,17 +74,8 @@ import Wire.UserStore.IndexUser
 import Wire.UserSubsystem
 import Wire.UserSubsystem.Error
 import Wire.UserSubsystem.HandleBlacklist
+import Wire.UserSubsystem.UserSubsystemConfig
 import Witherable (wither)
-
-data UserSubsystemConfig = UserSubsystemConfig
-  { emailVisibilityConfig :: EmailVisibilityConfig,
-    defaultLocale :: Locale,
-    searchSameTeamOnly :: Bool,
-    maxTeamSize :: Word32,
-    activationCodeTimeout :: Timeout
-  }
-  deriving (Show, Generic)
-  deriving (Arbitrary) via (GenericUniform UserSubsystemConfig)
 
 runUserSubsystem ::
   ( Member UserStore r,

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/UserSubsystemConfig.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/UserSubsystemConfig.hs
@@ -1,0 +1,16 @@
+module Wire.UserSubsystem.UserSubsystemConfig where
+
+import Imports
+import Util.Timeout
+import Wire.API.User
+import Wire.Arbitrary
+
+data UserSubsystemConfig = UserSubsystemConfig
+  { emailVisibilityConfig :: EmailVisibilityConfig,
+    defaultLocale :: Locale,
+    searchSameTeamOnly :: Bool,
+    maxTeamSize :: Word32,
+    activationCodeTimeout :: Timeout
+  }
+  deriving (Show, Generic)
+  deriving (Arbitrary) via (GenericUniform UserSubsystemConfig)

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ActivationCodeStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ActivationCodeStore.hs
@@ -19,7 +19,7 @@ inMemoryActivationCodeStoreInterpreter ::
   InterpreterFor ActivationCodeStore r
 inMemoryActivationCodeStoreInterpreter = interpret \case
   LookupActivationCode ek -> gets (!? ek)
-  NewActivation ek _ uid -> do
+  NewActivationCode ek _ uid -> do
     let key =
           ActivationKey
             . Ascii.encodeBase64Url

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ActivationCodeStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ActivationCodeStore.hs
@@ -2,12 +2,36 @@ module Wire.MockInterpreters.ActivationCodeStore where
 
 import Data.Id
 import Data.Map
+import Data.Text (pack)
+import Data.Text.Ascii qualified as Ascii
+import Data.Text.Encoding qualified as T
 import Imports
 import Polysemy
 import Polysemy.State
+import Text.Printf (printf)
 import Wire.API.User.Activation
 import Wire.ActivationCodeStore (ActivationCodeStore (..))
 import Wire.UserKeyStore
 
-inMemoryActivationCodeStoreInterpreter :: (Member (State (Map EmailKey (Maybe UserId, ActivationCode))) r) => InterpreterFor ActivationCodeStore r
-inMemoryActivationCodeStoreInterpreter = interpret \case LookupActivationCode ek -> gets (!? ek)
+inMemoryActivationCodeStoreInterpreter ::
+  ( Member (State (Map EmailKey (Maybe UserId, ActivationCode))) r
+  ) =>
+  InterpreterFor ActivationCodeStore r
+inMemoryActivationCodeStoreInterpreter = interpret \case
+  LookupActivationCode ek -> gets (!? ek)
+  NewActivation ek _ uid -> do
+    let key =
+          ActivationKey
+            . Ascii.encodeBase64Url
+            . T.encodeUtf8
+            . emailKeyUniq
+            $ ek
+        code =
+          ActivationCode
+            . Ascii.unsafeFromText
+            . pack
+            . printf "%06d"
+            . length
+            . show
+            $ ek
+    modify (insert ek (uid, code)) $> Activation key code

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
@@ -81,6 +81,7 @@ inMemoryUserStoreInterpreter = interpret $ \case
   GetActivityTimestamps _ -> pure []
   GetRichInfo _ -> error "rich info not implemented"
   GetUserAuthenticationInfo _uid -> error "Not implemented"
+  DeleteEmail _uid -> error "Not implemented"
 
 storedUserToIndexUser :: StoredUser -> IndexUser
 storedUserToIndexUser storedUser =

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserStore.hs
@@ -37,6 +37,13 @@ inMemoryUserStoreInterpreter = interpret $ \case
               . maybe Imports.id setStoredUserSupportedProtocols update.supportedProtocols
               $ u
           else u
+  UpdateEmailUnvalidated uid email -> modify (map doUpdate)
+    where
+      doUpdate :: StoredUser -> StoredUser
+      doUpdate u =
+        if u.id == uid
+          then u {emailUnvalidated = Just email}
+          else u
   GetIndexUser uid ->
     gets $ fmap storedUserToIndexUser . find (\user -> user.id == uid)
   GetIndexUsersPaginated _pageSize _pagingState ->

--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -57,7 +57,7 @@ spec = describe "UserSubsystem.Interpreter" do
               target1 = mkUserIds remoteDomain1 targetUsers1
               target2 = mkUserIds remoteDomain2 targetUsers2
               localBackend = def {users = [viewer] <> localTargetUsers}
-              config = UserSubsystemConfig visibility miniLocale False 100
+              config = UserSubsystemConfig visibility miniLocale False 100 undefined
               retrievedProfiles =
                 runFederationStack localBackend federation Nothing config $
                   getUserProfiles
@@ -85,7 +85,7 @@ spec = describe "UserSubsystem.Interpreter" do
             mkUserIds domain users = map (flip Qualified domain . (.id)) users
             onlineUsers = mkUserIds onlineDomain onlineTargetUsers
             offlineUsers = mkUserIds offlineDomain offlineTargetUsers
-            config = UserSubsystemConfig visibility miniLocale False 100
+            config = UserSubsystemConfig visibility miniLocale False 100 undefined
             localBackend = def {users = [viewer]}
             result =
               run
@@ -155,7 +155,7 @@ spec = describe "UserSubsystem.Interpreter" do
       \viewer targetUsers visibility domain remoteDomain -> do
         let remoteBackend = def {users = targetUsers}
             federation = [(remoteDomain, remoteBackend)]
-            config = UserSubsystemConfig visibility miniLocale False 100
+            config = UserSubsystemConfig visibility miniLocale False 100 undefined
             localBackend = def {users = [viewer]}
             retrievedProfilesWithErrors :: ([(Qualified UserId, FederationError)], [UserProfile]) =
               runFederationStack localBackend federation Nothing config $
@@ -176,7 +176,7 @@ spec = describe "UserSubsystem.Interpreter" do
     prop "Remote users on offline backend always fail to return" $
       \viewer (targetUsers :: Set StoredUser) visibility domain remoteDomain -> do
         let online = mempty
-            config = UserSubsystemConfig visibility miniLocale False 100
+            config = UserSubsystemConfig visibility miniLocale False 100 undefined
             localBackend = def {users = [viewer]}
             retrievedProfilesWithErrors :: ([(Qualified UserId, FederationError)], [UserProfile]) =
               runFederationStack localBackend online Nothing config $
@@ -196,7 +196,7 @@ spec = describe "UserSubsystem.Interpreter" do
             allDomains = [domain, remoteDomainA, remoteDomainB]
             remoteAUsers = map (flip Qualified remoteDomainA . (.id)) targetUsers
             remoteBUsers = map (flip Qualified remoteDomainB . (.id)) targetUsers
-            config = UserSubsystemConfig visibility miniLocale False 100
+            config = UserSubsystemConfig visibility miniLocale False 100 undefined
             localBackend = def {users = [viewer]}
             retrievedProfilesWithErrors :: ([(Qualified UserId, FederationError)], [UserProfile]) =
               runFederationStack localBackend online Nothing config $
@@ -281,7 +281,7 @@ spec = describe "UserSubsystem.Interpreter" do
     describe "getAccountsBy" do
       prop "GetBy userId when pending fails if not explicitly allowed" $
         \(PendingNotEmptyIdentityStoredUser alice') email teamId invitationInfo localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale False 100
+          let config = UserSubsystemConfig visibility locale False 100 undefined
               alice =
                 alice'
                   { email = Just email,
@@ -316,7 +316,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy userId works for pending if explicitly queried" $
         \(PendingNotEmptyIdentityStoredUser alice') email teamId invitationInfo localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               alice =
                 alice'
                   { email = Just email,
@@ -350,7 +350,7 @@ spec = describe "UserSubsystem.Interpreter" do
            in result === [mkUserFromStored localDomain locale alice]
       prop "GetBy handle when pending fails if not explicitly allowed" $
         \(PendingNotEmptyIdentityStoredUser alice') handl email teamId invitationInfo localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               alice =
                 alice'
                   { email = Just email,
@@ -386,7 +386,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy handle works for pending if explicitly queried" $
         \(PendingNotEmptyIdentityStoredUser alice') handl email teamId invitationInfo localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               alice =
                 alice'
                   { email = Just email,
@@ -422,7 +422,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy email does not filter by pending, missing identity or expired invitations" $
         \(alice' :: StoredUser) email localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               alice = alice' {email = Just email}
               localBackend =
                 def
@@ -436,7 +436,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy userId does not return missing identity users, pending invitation off" $
         \(NotPendingEmptyIdentityStoredUser alice) localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               getBy =
                 toLocalUnsafe localDomain $
                   def
@@ -451,7 +451,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy userId does not return missing identity users, pending invtation on" $
         \(NotPendingEmptyIdentityStoredUser alice) localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               getBy =
                 toLocalUnsafe localDomain $
                   def
@@ -466,7 +466,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy pending user by id works if there is a valid invitation" $
         \(PendingNotEmptyIdentityStoredUser alice') (email :: EmailAddress) teamId (invitationInfo :: StoredInvitation) localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               emailKey = mkEmailKey email
               getBy =
                 toLocalUnsafe localDomain $
@@ -495,7 +495,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy pending user by id fails if there is no valid invitation" $
         \(PendingNotEmptyIdentityStoredUser alice') (email :: EmailAddress) teamId localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               emailKey = mkEmailKey email
               getBy =
                 toLocalUnsafe localDomain $
@@ -516,7 +516,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy pending user handle id works if there is a valid invitation" $
         \(PendingNotEmptyIdentityStoredUser alice') (email :: EmailAddress) handl teamId (invitationInfo :: StoredInvitation) localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               emailKey = mkEmailKey email
               getBy =
                 toLocalUnsafe localDomain $
@@ -550,7 +550,7 @@ spec = describe "UserSubsystem.Interpreter" do
 
       prop "GetBy pending user by handle fails if there is no valid invitation" $
         \(PendingNotEmptyIdentityStoredUser alice') (email :: EmailAddress) handl teamId localDomain visibility locale ->
-          let config = UserSubsystemConfig visibility locale True 100
+          let config = UserSubsystemConfig visibility locale True 100 undefined
               emailKey = mkEmailKey email
               getBy =
                 toLocalUnsafe localDomain $

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -135,6 +135,7 @@ library
     Wire.UserSubsystem.Error
     Wire.UserSubsystem.HandleBlacklist
     Wire.UserSubsystem.Interpreter
+    Wire.UserSubsystem.UserSubsystemConfig
     Wire.VerificationCode
     Wire.VerificationCodeGen
     Wire.VerificationCodeStore

--- a/services/brig/src/Brig/API/Auth.hs
+++ b/services/brig/src/Brig/API/Auth.hs
@@ -60,6 +60,7 @@ import Wire.UserStore
 import Wire.UserSubsystem (UpdateOriginType (..), UserSubsystem)
 import Wire.UserSubsystem qualified as User
 import Wire.UserSubsystem.Error
+import Wire.UserSubsystem.UserSubsystemConfig
 import Wire.VerificationCodeSubsystem (VerificationCodeSubsystem)
 
 accessH ::
@@ -137,7 +138,8 @@ changeSelfEmail ::
     Member UserSubsystem r,
     Member UserStore r,
     Member ActivationCodeStore r,
-    Member (Error UserSubsystemError) r
+    Member (Error UserSubsystemError) r,
+    Member (Input UserSubsystemConfig) r
   ) =>
   [Either Text SomeUserToken] ->
   Maybe (Either Text SomeAccessToken) ->
@@ -150,9 +152,8 @@ changeSelfEmail uts' mat' up = do
   usr <- either (uncurry validateCredentials) (uncurry validateCredentials) toks
   lusr <- qualifyLocal usr
   let email = euEmail up
-  timeout <- asks (.settings.activationTimeout)
   lift . liftSem $
-    User.requestEmailChange timeout lusr email UpdateOriginWireClient
+    User.requestEmailChange lusr email UpdateOriginWireClient
 
 validateCredentials ::
   (TokenPair u a) =>

--- a/services/brig/src/Brig/API/Auth.hs
+++ b/services/brig/src/Brig/API/Auth.hs
@@ -148,7 +148,7 @@ changeSelfEmail uts' mat' up = do
   lusr <- qualifyLocal usr
   let email = euEmail up
   timeout <- asks (.settings.activationTimeout)
-  liftUserSubsystemError $ User.changeSelfEmail timeout lusr email UpdateOriginWireClient
+  liftUserSubsystemError $ User.requestEmailChange timeout lusr email UpdateOriginWireClient
 
 validateCredentials ::
   (TokenPair u a) =>

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -76,12 +76,6 @@ sendActCodeError (InvalidRecipient _) = StdError $ errorToWai @'E.InvalidEmail
 sendActCodeError (UserKeyInUse _) = StdError (errorToWai @'E.UserKeyExists)
 sendActCodeError (ActivationBlacklistedUserKey _) = StdError blacklistedEmail
 
-changeEmailError :: ChangeEmailError -> HttpError
-changeEmailError (InvalidNewEmail _ _) = StdError (errorToWai @'E.InvalidEmail)
-changeEmailError (EmailExists _) = StdError (errorToWai @'E.UserKeyExists)
-changeEmailError (ChangeBlacklistedEmail _) = StdError blacklistedEmail
-changeEmailError EmailManagedByScim = StdError $ propertyManagedByScim "email"
-
 legalHoldLoginError :: LegalHoldLoginError -> HttpError
 legalHoldLoginError LegalHoldLoginNoBindingTeam = StdError noBindingTeam
 legalHoldLoginError LegalHoldLoginLegalHoldNotEnabled = StdError legalHoldNotEnabled

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -21,7 +21,6 @@ module Brig.API.Handler
     toServantHandler,
 
     -- * Utilities
-    liftUserSubsystemError,
     checkAllowlist,
     checkAllowlistWithError,
     isAllowlisted,
@@ -48,8 +47,6 @@ import Imports
 import Network.HTTP.Types (Status (statusCode, statusMessage))
 import Network.Wai.Utilities.Error qualified as WaiError
 import Network.Wai.Utilities.Server qualified as Server
-import Polysemy (Sem)
-import Polysemy.Error qualified as P
 import Servant qualified
 import System.Logger qualified as Log
 import System.Logger.Class (Logger)
@@ -58,7 +55,6 @@ import Wire.API.Error
 import Wire.API.Error.Brig
 import Wire.API.User
 import Wire.Error
-import Wire.UserSubsystem.Error
 
 -------------------------------------------------------------------------------
 -- HTTP Handler Monad
@@ -120,13 +116,6 @@ brigErrorHandlers logger reqId =
 
 -------------------------------------------------------------------------------
 -- Utilities
-
--- | Run a 'UserSubsystemError' error and lift to the handler type.
-liftUserSubsystemError ::
-  Sem ((P.Error UserSubsystemError) : r) a ->
-  Handler r a
-liftUserSubsystemError =
-  withExceptT userSubsystemErrorToHttpError . ExceptT . liftSem . P.runError
 
 -- | If an Allowlist is configured, consult it, otherwise a no-op. {#RefActivationAllowlist}
 checkAllowlist :: EmailAddress -> Handler r ()

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -570,11 +570,11 @@ changeSelfEmailMaybeSend u ActuallySendEmail email allowScim = do
   lusr <- qualifyLocal u
   timeout <- asks (.settings.activationTimeout)
   liftUserSubsystemError $
-    UserSubsystem.changeSelfEmail timeout lusr email allowScim
+    UserSubsystem.requestEmailChange timeout lusr email allowScim
 changeSelfEmailMaybeSend u DoNotSendEmail email allowScim = do
   lusr <- qualifyLocal u
   timeout <- asks (.settings.activationTimeout)
-  liftUserSubsystemError (UserSubsystem.changeEmail timeout lusr email allowScim) >>= \case
+  liftUserSubsystemError (UserSubsystem.createEmailChangeToken timeout lusr email allowScim) >>= \case
     ChangeEmailIdempotent -> pure ChangeEmailResponseIdempotent
     ChangeEmailNeedsActivation _ -> pure ChangeEmailResponseNeedsActivation
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1343,7 +1343,8 @@ updateUserEmail ::
     Member EmailSubsystem r,
     Member UserSubsystem r,
     Member UserStore r,
-    Member ActivationCodeStore r
+    Member ActivationCodeStore r,
+    Member (Error UserSubsystemError) r
   ) =>
   UserId ->
   UserId ->
@@ -1356,7 +1357,7 @@ updateUserEmail zuserId emailOwnerId (Public.EmailUpdate email) = do
   checkSameTeam maybeZuserTeamId maybeEmailOwnerTeamId
   acTimeout <- asks (.settings.activationTimeout)
   lEmailOwnerId <- qualifyLocal emailOwnerId
-  void . liftUserSubsystemError $
+  void . lift . liftSem $
     User.requestEmailChange acTimeout lEmailOwnerId email UpdateOriginWireClient
   where
     checkSameTeam :: Maybe TeamId -> Maybe TeamId -> (Handler r) ()

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -173,7 +173,7 @@ import Wire.UserKeyStore
 import Wire.UserSearch.Types
 import Wire.UserStore (UserStore)
 import Wire.UserStore qualified as UserStore
-import Wire.UserSubsystem hiding (changeSelfEmail, checkHandle, checkHandles, removeEmail)
+import Wire.UserSubsystem hiding (checkHandle, checkHandles, removeEmail, requestEmailChange)
 import Wire.UserSubsystem qualified as User
 import Wire.UserSubsystem.Error
 import Wire.VerificationCode
@@ -1357,7 +1357,7 @@ updateUserEmail zuserId emailOwnerId (Public.EmailUpdate email) = do
   acTimeout <- asks (.settings.activationTimeout)
   lEmailOwnerId <- qualifyLocal emailOwnerId
   void . liftUserSubsystemError $
-    User.changeSelfEmail acTimeout lEmailOwnerId email UpdateOriginWireClient
+    User.requestEmailChange acTimeout lEmailOwnerId email UpdateOriginWireClient
   where
     checkSameTeam :: Maybe TeamId -> Maybe TeamId -> (Handler r) ()
     checkSameTeam (Just zuserTeamId) maybeEmailOwnerTeamId =

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1029,7 +1029,7 @@ removeEmail ::
     Member UserSubsystem r,
     Member Events r
   ) =>
-  UserId ->
+  Local UserId ->
   Handler r (Maybe Public.RemoveIdentityError)
 removeEmail self = lift . exceptTToMaybe $ API.removeEmail self
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1102,7 +1102,12 @@ getHandleInfoUnqualifiedH self handle = do
   Public.UserHandleInfo . Public.profileQualifiedId
     <$$> Handle.getHandleInfo self (Qualified handle domain)
 
-changeHandle :: (Member UserSubsystem r) => Local UserId -> ConnId -> Public.HandleUpdate -> Handler r ()
+changeHandle ::
+  (Member UserSubsystem r) =>
+  Local UserId ->
+  ConnId ->
+  Public.HandleUpdate ->
+  Handler r ()
 changeHandle u conn (Public.HandleUpdate h) = lift $ liftSem do
   User.updateHandle u (Just conn) UpdateOriginWireClient h
 

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -30,7 +30,7 @@ module Brig.API.Types
   )
 where
 
-import Brig.Data.Activation (Activation (..), ActivationError (..))
+import Brig.Data.Activation (ActivationError (..))
 import Brig.Data.Client (ClientDataError (..))
 import Brig.Types.Intra
 import Data.Code
@@ -42,6 +42,7 @@ import Imports
 import Network.Wai.Utilities.Error qualified as Wai
 import Wire.API.Federation.Error
 import Wire.API.User
+import Wire.API.User.Activation
 import Wire.AuthenticationSubsystem.Error
 import Wire.UserKeyStore
 
@@ -63,14 +64,6 @@ data ActivationResult
     ActivationSuccess !(Maybe UserIdentity) !Bool
   | -- | The key/code was valid but already recently activated.
     ActivationPass
-  deriving (Show)
-
--- | Outcome of the invariants check in 'Brig.API.User.changeEmail'.
-data ChangeEmailResult
-  = -- | The request was successful, user needs to verify the new email address
-    ChangeEmailNeedsActivation !(User, Activation, EmailAddress)
-  | -- | The user asked to change the email address to the one already owned
-    ChangeEmailIdempotent
   deriving (Show)
 
 -------------------------------------------------------------------------------
@@ -152,12 +145,6 @@ data VerificationCodeError
   = VerificationCodeRequired
   | VerificationCodeNoPendingCode
   | VerificationCodeNoEmail
-
-data ChangeEmailError
-  = InvalidNewEmail !EmailAddress !String
-  | EmailExists !EmailAddress
-  | ChangeBlacklistedEmail !EmailAddress
-  | EmailManagedByScim
 
 data SendActivationCodeError
   = InvalidRecipient EmailKey

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -487,7 +487,7 @@ createUser new = do
         Nothing -> do
           timeout <- asks (.settings.activationTimeout)
           lift . liftSem $ do
-            edata <- newActivation ek timeout (Just uid)
+            edata <- newActivationCode ek timeout (Just uid)
             Log.info $
               field "user" (toByteString uid)
                 . field "activation.key" (toByteString $ activationKey edata)
@@ -739,7 +739,7 @@ sendActivationCode email loc = do
       case c of
         Just c' -> liftIO $ (,c') <$> Data.mkActivationKey k
         Nothing -> lift . liftSem $ do
-          dat <- newActivation k timeout u
+          dat <- newActivationCode k timeout u
           pure (activationKey dat, activationCode dat)
     sendVerificationEmail ek uc = do
       (key, code) <- mkPair ek uc Nothing

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -25,8 +25,6 @@ module Brig.API.User
     createUserSpar,
     createUserInviteViaScim,
     checkRestrictedUserCreation,
-    changeSelfEmail,
-    changeEmail,
     CheckHandleResp (..),
     checkHandle,
     lookupHandle,
@@ -67,7 +65,6 @@ module Brig.API.User
   )
 where
 
-import Brig.API.Error qualified as Error
 import Brig.API.Types
 import Brig.API.Util
 import Brig.App as App
@@ -128,7 +125,7 @@ import Wire.API.User.Activation
 import Wire.API.User.Client
 import Wire.API.User.RichInfo
 import Wire.API.UserEvent
-import Wire.ActivationCodeStore (ActivationCodeStore)
+import Wire.ActivationCodeStore
 import Wire.ActivationCodeStore qualified as ActivationCode
 import Wire.AuthenticationSubsystem (AuthenticationSubsystem, internalLookupPasswordResetCode)
 import Wire.BlockListStore as BlockListStore
@@ -319,7 +316,8 @@ createUser ::
     Member (Input (Local ())) r,
     Member PasswordResetCodeStore r,
     Member HashPassword r,
-    Member InvitationStore r
+    Member InvitationStore r,
+    Member ActivationCodeStore r
   ) =>
   NewUser ->
   ExceptT RegisterError (AppT r) CreateUserResult
@@ -479,17 +477,22 @@ createUser new = do
       pure $ CreateUserTeam tid nm
 
     -- Handle e-mail activation (deprecated, see #RefRegistrationNoPreverification in /docs/reference/user/registration.md)
-    handleEmailActivation :: Maybe EmailAddress -> UserId -> Maybe BindingNewTeamUser -> ExceptT RegisterError (AppT r) (Maybe Activation)
+    handleEmailActivation ::
+      Maybe EmailAddress ->
+      UserId ->
+      Maybe BindingNewTeamUser ->
+      ExceptT RegisterError (AppT r) (Maybe Activation)
     handleEmailActivation email uid newTeam = do
       fmap join . for (mkEmailKey <$> email) $ \ek -> case newUserEmailCode new of
         Nothing -> do
           timeout <- asks (.settings.activationTimeout)
-          edata <- lift . wrapClient $ Data.newActivation ek timeout (Just uid)
-          lift . liftSem . Log.info $
-            field "user" (toByteString uid)
-              . field "activation.key" (toByteString $ activationKey edata)
-              . msg (val "Created email activation key/code pair")
-          pure $ Just edata
+          lift . liftSem $ do
+            edata <- newActivation ek timeout (Just uid)
+            Log.info $
+              field "user" (toByteString uid)
+                . field "activation.key" (toByteString $ activationKey edata)
+                . msg (val "Created email activation key/code pair")
+            pure $ Just edata
         Just c -> do
           ak <- liftIO $ Data.mkActivationKey ek
           void $
@@ -545,61 +548,6 @@ checkRestrictedUserCreation new = do
         && not (isNewUserEphemeral new)
     )
     $ throwE RegisterErrorUserCreationRestricted
-
--------------------------------------------------------------------------------
--- Change Email
-
--- | Call 'changeEmail' and process result: if email changes to itself, succeed, if not, send
--- validation email.
-changeSelfEmail ::
-  ( Member BlockListStore r,
-    Member UserKeyStore r,
-    Member EmailSubsystem r,
-    Member UserSubsystem r
-  ) =>
-  UserId ->
-  EmailAddress ->
-  UpdateOriginType ->
-  ExceptT HttpError (AppT r) ChangeEmailResponse
-changeSelfEmail u email allowScim = do
-  changeEmail u email allowScim !>> Error.changeEmailError >>= \case
-    ChangeEmailIdempotent ->
-      pure ChangeEmailResponseIdempotent
-    ChangeEmailNeedsActivation (usr, adata, en) -> lift $ do
-      liftSem $ sendOutEmail usr adata en
-      wrapClient $ Data.updateEmailUnvalidated u email
-      liftSem $ User.internalUpdateSearchIndex u
-      pure ChangeEmailResponseNeedsActivation
-  where
-    sendOutEmail usr adata en = do
-      (maybe sendActivationMail (const sendEmailAddressUpdateMail) usr.userIdentity)
-        en
-        (userDisplayName usr)
-        (activationKey adata)
-        (activationCode adata)
-        (Just (userLocale usr))
-
--- | Prepare changing the email (checking a number of invariants).
-changeEmail :: (Member BlockListStore r, Member UserKeyStore r) => UserId -> EmailAddress -> UpdateOriginType -> ExceptT ChangeEmailError (AppT r) ChangeEmailResult
-changeEmail u email updateOrigin = do
-  let ek = mkEmailKey email
-  blacklisted <- lift . liftSem $ BlockListStore.exists ek
-  when blacklisted $
-    throwE (ChangeBlacklistedEmail email)
-  available <- lift $ liftSem $ keyAvailable ek (Just u)
-  unless available $
-    throwE $
-      EmailExists email
-  usr <- maybe (throwM $ UserProfileNotFound u) pure =<< lift (wrapClient $ Data.lookupUser WithPendingInvitations u)
-  case emailIdentity =<< userIdentity usr of
-    -- The user already has an email address and the new one is exactly the same
-    Just current | current == email -> pure ChangeEmailIdempotent
-    _ -> do
-      unless (userManagedBy usr /= ManagedByScim || updateOrigin == UpdateOriginScim) $
-        throwE EmailManagedByScim
-      timeout <- asks (.settings.activationTimeout)
-      act <- lift . wrapClient $ Data.newActivation ek timeout (Just u)
-      pure $ ChangeEmailNeedsActivation (usr, act, email)
 
 -------------------------------------------------------------------------------
 -- Remove Email
@@ -776,6 +724,7 @@ onActivated (EmailActivated uid email) = do
 
 -- docs/reference/user/activation.md {#RefActivationRequest}
 sendActivationCode ::
+  forall r.
   ( Member BlockListStore r,
     Member EmailSubsystem r,
     Member GalleyAPIAccess r,
@@ -801,22 +750,27 @@ sendActivationCode email loc = do
     Just (Just uid, c) -> sendActivationEmail ek c uid -- User re-requesting activation
   where
     notFound = throwM . UserDisplayNameNotFound
+    mkPair ::
+      EmailKey ->
+      Maybe ActivationCode ->
+      Maybe UserId ->
+      ExceptT SendActivationCodeError (AppT r) (ActivationKey, ActivationCode)
     mkPair k c u = do
       timeout <- asks (.settings.activationTimeout)
       case c of
         Just c' -> liftIO $ (,c') <$> Data.mkActivationKey k
-        Nothing -> lift $ do
-          dat <- Data.newActivation k timeout u
+        Nothing -> lift . liftSem $ do
+          dat <- newActivation k timeout u
           pure (activationKey dat, activationCode dat)
     sendVerificationEmail ek uc = do
-      (key, code) <- wrapClientE $ mkPair ek uc Nothing
+      (key, code) <- mkPair ek uc Nothing
       let em = emailKeyOrig ek
       lift $ liftSem $ sendVerificationMail em key code loc
     sendActivationEmail ek uc uid = do
       -- FUTUREWORK(fisx): we allow for 'PendingInvitations' here, but I'm not sure this
       -- top-level function isn't another piece of a deprecated onboarding flow?
       u <- maybe (notFound uid) pure =<< lift (wrapClient $ Data.lookupUser WithPendingInvitations uid)
-      (aKey, aCode) <- wrapClientE $ mkPair ek (Just uc) (Just uid)
+      (aKey, aCode) <- mkPair ek (Just uc) (Just uid)
       let ident = userIdentity u
           name = userDisplayName u
           loc' = loc <|> Just (userLocale u)

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -214,6 +214,9 @@ runBrigToIO e (AppT ma) = do
           }
 
       -- These interpreters depend on each other, we use let recursion to solve that.
+      --
+      -- This terminates if and only if we do not create an action sequence at
+      -- runtime such that interpretation of actions results in a call cycle.
       userSubsystemInterpreter :: (Members BrigLowerLevelEffects r) => InterpreterFor UserSubsystem r
       userSubsystemInterpreter = runUserSubsystem authSubsystemInterpreter
 

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -176,7 +176,8 @@ runBrigToIO e (AppT ma) = do
           { emailVisibilityConfig = e.settings.emailVisibility,
             defaultLocale = Opt.defaultUserLocale e.settings,
             searchSameTeamOnly = fromMaybe False e.settings.searchSameTeamOnly,
-            maxTeamSize = e.settings.maxTeamSize
+            maxTeamSize = e.settings.maxTeamSize,
+            activationCodeTimeout = e.settings.activationTimeout
           }
       teamInvitationSubsystemConfig =
         TeamInvitationSubsystemConfig

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -45,7 +45,6 @@ module Brig.Data.User
     updateFeatureConferenceCalling,
 
     -- * Deletions
-    deleteEmail,
     deleteEmailUnvalidated,
     deleteServiceUser,
   )
@@ -229,9 +228,6 @@ updateFeatureConferenceCalling uid mStatus =
   where
     update :: PrepQuery W (Maybe FeatureStatus, UserId) ()
     update = fromString "update user set feature_conference_calling = ? where id = ?"
-
-deleteEmail :: (MonadClient m) => UserId -> m ()
-deleteEmail u = retry x5 $ write userEmailDelete (params LocalQuorum (Identity u))
 
 deleteEmailUnvalidated :: (MonadClient m) => UserId -> m ()
 deleteEmailUnvalidated u = retry x5 $ write userEmailUnvalidatedDelete (params LocalQuorum (Identity u))
@@ -448,9 +444,6 @@ userDeactivatedUpdate = {- `IF EXISTS`, but that requires benchmarking -} "UPDAT
 
 userActivatedUpdate :: PrepQuery W (Maybe EmailAddress, UserId) ()
 userActivatedUpdate = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE user SET activated = true, email = ? WHERE id = ?"
-
-userEmailDelete :: PrepQuery W (Identity UserId) ()
-userEmailDelete = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE user SET email = null, write_time_bumper = 0 WHERE id = ?"
 
 userRichInfoUpdate :: PrepQuery W (RichInfoAssocList, UserId) ()
 userRichInfoUpdate = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE rich_info SET json = ? WHERE user = ?"

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -36,7 +36,6 @@ module Brig.Data.User
 
     -- * Updates
     updateEmail,
-    updateEmailUnvalidated,
     updateSSOId,
     updateManagedBy,
     activateUser,
@@ -208,9 +207,6 @@ insertAccount u mbConv password activated = retry x5 . batch $ do
 
 updateEmail :: (MonadClient m) => UserId -> EmailAddress -> m ()
 updateEmail u e = retry x5 $ write userEmailUpdate (params LocalQuorum (e, u))
-
-updateEmailUnvalidated :: (MonadClient m) => UserId -> EmailAddress -> m ()
-updateEmailUnvalidated u e = retry x5 $ write userEmailUnvalidatedUpdate (params LocalQuorum (e, u))
 
 updateSSOId :: (MonadClient m) => UserId -> Maybe UserSSOId -> m Bool
 updateSSOId u ssoid = do
@@ -434,9 +430,6 @@ userInsert =
 
 userEmailUpdate :: PrepQuery W (EmailAddress, UserId) ()
 userEmailUpdate = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE user SET email = ? WHERE id = ?"
-
-userEmailUnvalidatedUpdate :: PrepQuery W (EmailAddress, UserId) ()
-userEmailUnvalidatedUpdate = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE user SET email_unvalidated = ? WHERE id = ?"
 
 userEmailUnvalidatedDelete :: PrepQuery W (Identity UserId) ()
 userEmailUnvalidatedDelete = {- `IF EXISTS`, but that requires benchmarking -} "UPDATE user SET email_unvalidated = null WHERE id = ?"

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -29,7 +29,7 @@ import Control.Concurrent.Async
 import Control.Lens hiding (from, to, uncons, (#), (.=))
 import Control.Monad.Catch (MonadCatch, MonadMask)
 import Control.Monad.Codensity (lowerCodensity)
-import Control.Retry (constantDelay, exponentialBackoff, limitRetries, retrying)
+import Control.Retry (constantDelay, exponentialBackoff, limitRetries, recoverAll, retrying)
 import Data.Aeson hiding (json)
 import Data.Aeson qualified as A
 import Data.Aeson.Lens (key, _String)
@@ -429,7 +429,8 @@ addUserToTeamWithRole' role inviter tid = do
   let invite = InvitationRequest Nothing role Nothing inviteeEmail
   invResponse <- postInvitation tid inviter invite
   inv <- responseJsonError invResponse
-  inviteeCode <- getInvitationCode tid inv.invitationId
+  inviteeCode <- recoverAll (exponentialBackoff 1000 <> limitRetries 11) $
+    \_ -> getInvitationCode tid inv.invitationId
   r <-
     post
       ( brig


### PR DESCRIPTION
This is a refactoring PR about user email update and remove operations.

Tracked by https://wearezeta.atlassian.net/browse/WPB-8881.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
