### PR TITLE
galley: Use bulk query when getting all feature configs for a team user

### DIFF
--- a/changelog.d/3-bug-fixes/optimize-get-all-features
+++ b/changelog.d/3-bug-fixes/optimize-get-all-features
@@ -1,0 +1,1 @@
+galley: Use bulk query when getting all feature configs for a team user

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -246,7 +246,9 @@ getAllTeamFeaturesForUser ::
   Sem r AllTeamFeatures
 getAllTeamFeaturesForUser uid = do
   mTid <- getTeamAndCheckMembership uid
-  hsequence' $ hcpure (Proxy @(GetAllTeamFeaturesForUserConstraints r)) $ Comp $ getFeatureForTeamUser uid mTid
+  case mTid of
+    Nothing -> hsequence' $ hcpure (Proxy @(GetAllTeamFeaturesForUserConstraints r)) $ Comp $ getFeatureForUser uid
+    Just tid -> getAllTeamFeatures tid
 
 getSingleFeatureForUser ::
   forall cfg r.


### PR DESCRIPTION
This used to be specialized, but mistakenly got converted to multiple DB calls here:
https://github.com/wireapp/wire-server/pull/4178/files#diff-9daaabfa64d3ada89e121d9f68351f16a0237abf97d8fdc672acde7f9f2fd2ffL197-L207https://github.com/wireapp/wire-server/pull/4178/files#diff-9daaabfa64d3ada89e121d9f68351f16a0237abf97d8fdc672acde7f9f2fd2ffL197-L207

https://wearezeta.atlassian.net/browse/WPB-12044

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
