### PR TITLE
brig: make rabbitmq field optional again

### DIFF
--- a/changelog.d/3-bug-fixes/brig-rabbitmq
+++ b/changelog.d/3-bug-fixes/brig-rabbitmq
@@ -1,0 +1,1 @@
+brig now only requires rabbitmq if federation is enabled

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -80,7 +80,6 @@ data:
     federatorInternal:
       host: federator
       port: 8080
-    {{- end }}
 
     {{- with .rabbitmq }}
     rabbitmq:
@@ -92,6 +91,7 @@ data:
       {{- if .tlsCaSecretRef }}
       caCert: /etc/wire/brig/rabbitmq-ca/{{ .tlsCaSecretRef.key }}
       {{- end }}
+    {{- end }}
     {{- end }}
 
     {{- with .aws }}

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -22,7 +22,6 @@ import Control.Monad.Catch (throwM)
 import Data.Qualified (Local, toLocalUnsafe)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Imports
-import Network.AMQP
 import Polysemy
 import Polysemy.Async
 import Polysemy.Conc
@@ -116,7 +115,6 @@ type BrigLowerLevelEffects =
      DeleteQueue,
      Wire.Events.Events,
      NotificationSubsystem,
-     Input Channel,
      Error UserSubsystemError,
      Error TeamInvitationSubsystemError,
      Error AuthenticationSubsystemError,
@@ -278,7 +276,6 @@ runBrigToIO e (AppT ma) = do
               . mapError authenticationSubsystemErrorToHttpError
               . mapError teamInvitationErrorToHttpError
               . mapError userSubsystemErrorToHttpError
-              . runInputSem (readChannel e.rabbitmqChannel)
               . runNotificationSubsystemGundeck (defaultNotificationSubsystemConfig e.requestId)
               . runEvents
               . runDeleteQueue e.internalEvents

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -141,9 +141,17 @@ notifyUserDeleted self remotes = do
   let remoteConnections = tUnqualified remotes
   let notif = UserDeletedConnectionsNotification (tUnqualified self) remoteConnections
       remoteDomain = tDomain remotes
-  chanVar <- asks (.rabbitmqChannel)
-  enqueueNotification (tDomain self) remoteDomain Q.Persistent chanVar $
-    fedQueueClient @'OnUserDeletedConnectionsTag notif
+
+  asks (.rabbitmqChannel) >>= \case
+    Just chanVar -> do
+      enqueueNotification (tDomain self) remoteDomain Q.Persistent chanVar $
+        fedQueueClient @'OnUserDeletedConnectionsTag notif
+    Nothing ->
+      Log.err $
+        Log.msg ("Federation error while notifying remote backends of a user deletion." :: ByteString)
+          . Log.field "user_id" (show self)
+          . Log.field "domain" (domainText remoteDomain)
+          . Log.field "error" (show FederationNotConfigured)
 
 -- | Enqueues notifications in RabbitMQ. Retries 3 times with a delay of 1s.
 enqueueNotification :: (MonadIO m, MonadMask m, Log.MonadLogger m, MonadReader Env m) => Domain -> Domain -> Q.DeliveryMode -> MVar Q.Channel -> FedQueueClient c () -> m ()

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -389,7 +389,7 @@ data Opts = Opts
     -- | SFT Federation
     multiSFT :: !(Maybe Bool),
     -- | RabbitMQ settings, required when federation is enabled.
-    rabbitmq :: !AmqpEndpoint,
+    rabbitmq :: !(Maybe AmqpEndpoint),
     -- | AWS settings
     aws :: !AWSOpts,
     -- | Enable Random Prekey Strategy

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -316,7 +316,7 @@ testGetUserByQualifiedHandleFailure brig = do
 
 testGetUserByQualifiedHandleNoFederation :: Opt.Opts -> Brig -> Http ()
 testGetUserByQualifiedHandleNoFederation opt brig = do
-  let newOpts = opt {Opt.federatorInternal = Nothing}
+  let newOpts = opt {Opt.federatorInternal = Nothing, Opt.rabbitmq = Nothing}
   someUser <- randomUser brig
   withSettingsOverrides newOpts $
     get


### PR DESCRIPTION
It seems the rabbitmq configuration field in brig was made mandatory by mistake in #4272. This reverts it to an optional field and removes the corresponding `Input` effect, which was unused.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
