### PR TITLE
WPB-14284 personal user invitation URL configmap fixed

### DIFF
--- a/changelog.d/0-release-notes/WPB-14284
+++ b/changelog.d/0-release-notes/WPB-14284
@@ -1,0 +1,1 @@
+If brig's server values config has the field `emailSMS.team`, the correct value for the personal user to team invitation URL must be set under `emailSMS.team.tExistingUserInvitationUrl`. Otherwise the URL will point to a path under the account pages and therefore a value for `externalUrls.accountPages` is required.

--- a/changelog.d/3-bug-fixes/WPB-14284
+++ b/changelog.d/3-bug-fixes/WPB-14284
@@ -1,0 +1,1 @@
+Fixed config for personal user to team invitation URL template.

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -186,14 +186,13 @@ data:
       {{- else }}
       {{- if .externalUrls.teamSettings }}
         tInvitationUrl: {{ .externalUrls.teamSettings }}/join/?team-code=${code}
-        tExistingUserInvitationUrl: {{ .externalUrls.teamSettings }}/accept-invitation/?team-code=${code}
       {{- else }}
         tInvitationUrl: {{ .externalUrls.nginz }}/register?team=${team}&team_code=${code}
-        tExistingUserInvitationUrl: {{ .externalUrls.nginz }}/accept-invitation/?team-code=${code}
       {{- end }}
         tActivationUrl: {{ .externalUrls.nginz }}/register?team=${team}&team_code=${code}
         tCreatorWelcomeUrl: {{ .externalUrls.teamCreatorWelcome }}
         tMemberWelcomeUrl: {{ .externalUrls.teamMemberWelcome }}
+        tExistingUserInvitationUrl: {{ .externalUrls.accountPages }}/accept-invitation/?team-code=${code}
       {{- end }}
 
     zauth:

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -801,6 +801,27 @@ This setting is required to be present for all the services (brig, cannon, cargo
 
 The default value (provided under `charts/<service>/values.yaml`) is `[ development ]` and disables the development versions. To enable all versions including the development versions set the value to be empty: `[]`.
 
+### Team invitation URL for personal users
+
+To configure the team invitation URL for personal users that is sent vai email, `emailSMS.team.tExistingUserInvitationUrl` should be set to the desired URL, e.g.:
+
+```yaml
+brig:
+  config
+    emailSMS:
+      team:
+        tExistingUserInvitationUrl: '{{ .Values.accountUrl }}/accept-invitation/?team-code=${code}'
+```
+
+In some environments the `team` config section does not exist. In this case brig's configmap constructs the URL from the account pages URL which then must be set under `externalUrls.accountPages` e.g. as follows:
+
+```yaml
+brig:
+  config:
+    externalUrls:
+      accountPages: https://account.wire.com
+```
+
 ## Settings in cargohold
 
 AWS S3 (or an alternative provider / service) is used to upload and download

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -57,6 +57,7 @@ brig:
       nginz: https://kube-staging-nginz-https.zinfra.io
       teamCreatorWelcome: https://teams.wire.com/login
       teamMemberWelcome: https://wire.com/download
+      accountPages: https://account.wire.com
     cassandra:
       host: {{ .Values.cassandraHost }}
       replicaCount: 1
@@ -134,7 +135,7 @@ brig:
       setOAuthEnabled: true
       setOAuthRefreshTokenExpirationTimeSecs: 14515200 # 24 weeks
       setOAuthMaxActiveRefreshTokens: 10
-      # These values are insecure, against anyone getting hold of the hash, 
+      # These values are insecure, against anyone getting hold of the hash,
       # but its not a concern for the integration tests.
       setPasswordHashingOptions:
         algorithm: argon2id
@@ -281,7 +282,7 @@ galley:
       federationDomain: integration.example.com
       disabledAPIVersions: []
 
-      # These values are insecure, against anyone getting hold of the hash, 
+      # These values are insecure, against anyone getting hold of the hash,
       # but its not a concern for the integration tests.
       passwordHashingOptions:
         algorithm: argon2id


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-14284

This in combination with the caillaich PR https://github.com/zinfra/cailleach/pull/2380 should fix the setting for the team invitation URL for personal users.

The brig server configs in some environments have the field `emailSMS.team` set, in which case the invitation URL set there as `tExistingUserInvitationUrl`. If `emailSMS.team` does not exist, the URL is constructed from `externalUrls.accountPages`.

So depending on the environment, a correct config must contain either a value for `emailSMS.team.tExistingUserInvitationUrl` or for `externalUrls.accountPages`.

## Checklist

 - [x] Merge the cailleach PR first
 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
