### PR TITLE
Fix the description of `TeamStatus`

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley/TeamsIntra.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley/TeamsIntra.hs
@@ -52,7 +52,7 @@ data TeamStatus
 
 instance S.ToSchema TeamStatus where
   schema =
-    S.enum @Text "Access" $
+    S.enum @Text "TeamStatus" $
       mconcat
         [ S.element "active" Active,
           S.element "pending_delete" PendingDelete,


### PR DESCRIPTION
Just a tiny fix for the Swagger description of `TeamStatus`.

## Checklist

 - ~~[ ] Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
