### PR TITLE
background-worker: Use regex to list queues for backend-notifications

### DIFF
--- a/changelog.d/5-internal/efficient-queue-listing
+++ b/changelog.d/5-internal/efficient-queue-listing
@@ -1,0 +1,1 @@
+List queues for backend notifications more efficiently.

--- a/integration/test/Testlib/ResourcePool.hs
+++ b/integration/test/Testlib/ResourcePool.hs
@@ -89,7 +89,7 @@ deleteAllRabbitMQQueues rc resource = do
             tls = Just $ RabbitMqTlsOpts Nothing True
           }
   client <- mkRabbitMqAdminClientEnv opts
-  queues <- listQueuesByVHost client (T.pack resource.berVHost)
+  queues <- listQueuesByVHost client (T.pack resource.berVHost) Nothing Nothing
   for_ queues $ \queue ->
     deleteQueue client (T.pack resource.berVHost) queue.name
 

--- a/libs/extended/src/Network/RabbitMqAdmin.hs
+++ b/libs/extended/src/Network/RabbitMqAdmin.hs
@@ -24,6 +24,8 @@ data AdminAPI route = AdminAPI
         :- "api"
           :> "queues"
           :> Capture "vhost" VHost
+          :> QueryParam "name" Text
+          :> QueryParam "use_regex" Bool
           :> Get '[JSON] [Queue],
     deleteQueue ::
       route

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -282,7 +282,7 @@ getRemoteDomains adminClient = do
     go :: AppT IO [Domain]
     go = do
       vhost <- asks rabbitmqVHost
-      queues <- liftIO $ listQueuesByVHost adminClient vhost
+      queues <- liftIO $ listQueuesByVHost adminClient vhost (Just "backend-notifications\\..*") (Just True)
       let notifQueuesSuffixes = mapMaybe (\q -> Text.stripPrefix "backend-notifications." q.name) queues
       catMaybes <$> traverse (\d -> either (\e -> logInvalidDomain d e >> pure Nothing) (pure . Just) $ mkDomain d) notifQueuesSuffixes
     logInvalidDomain d e =

--- a/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
+++ b/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
@@ -351,8 +351,8 @@ mockApi mockAdmin =
       deleteQueue = mockListDeleteQueue mockAdmin
     }
 
-mockListQueuesByVHost :: MockRabbitMqAdmin -> Text -> Servant.Handler [Queue]
-mockListQueuesByVHost MockRabbitMqAdmin {..} vhost = do
+mockListQueuesByVHost :: MockRabbitMqAdmin -> Text -> Maybe Text -> Maybe Bool -> Servant.Handler [Queue]
+mockListQueuesByVHost MockRabbitMqAdmin {..} vhost _ _ = do
   atomically $ modifyTVar listQueuesVHostCalls (<> [vhost])
   readTVarIO broken >>= \case
     True -> throwError $ Servant.err500


### PR DESCRIPTION
With consumable-notifications we expect a lot of queues to exist in RabbitMQ. Using regex to filter here would ensure this loop doesn't keep going over all of those queues over and over again.

https://wearezeta.atlassian.net/browse/WPB-11811

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
