### PR TITLE
Log uncaught IO exceptions in cargohold

### DIFF
--- a/changelog.d/5-internal/cargohold-errors
+++ b/changelog.d/5-internal/cargohold-errors
@@ -1,0 +1,1 @@
+Log uncaught IO exceptions in cargohold


### PR DESCRIPTION
Uncaught IO exceptions in cargohold simply become "Server Error" responses with no extra information. This PR ensures that such exceptions are logged before being handled by the middleware, just like it happens in galley.

https://wearezeta.atlassian.net/browse/WPB-14410

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
