### PR TITLE
RabbitMQ temporary clients

### DIFF
--- a/changelog.d/1-api-changes/rabbitmq-temp
+++ b/changelog.d/1-api-changes/rabbitmq-temp
@@ -1,0 +1,1 @@
+The `client_id` query parameter of the `GET /events` endpoint is now optional. When not provided, events are returned from a temporary queue that's not bound to any specific client. The queue is deleted when the websocket disconnects.

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -36,7 +36,7 @@ testConsumeEventsOneWebSocket = do
   client <- addClient alice def {acapabilities = Just ["consumable-notifications"]} >>= getJSON 201
   clientId <- objId client
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     deliveryTag <- assertEvent ws $ \e -> do
       e %. "type" `shouldMatch` "event"
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
@@ -61,6 +61,34 @@ testConsumeEventsOneWebSocket = do
     resp.status `shouldMatchInt` 200
     shouldBeEmpty $ resp.json %. "notifications"
 
+testConsumeTempEvents :: (HasCallStack) => App ()
+testConsumeTempEvents = do
+  alice <- randomUser OwnDomain def
+
+  client0 <- addClient alice def {acapabilities = Just ["consumable-notifications"]} >>= getJSON 201
+  runCodensity (createEventsWebSocket alice Nothing) $ \ws -> do
+    clientId <- objId client0
+
+    void $ assertEvent ws $ \e -> do
+      e %. "type" `shouldMatch` "event"
+      e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
+      e %. "data.event.payload.0.client.id" `shouldMatch` clientId
+
+      ackEvent ws e
+
+  runCodensity (createEventsWebSocket alice Nothing) $ \ws -> do
+    client <- addClient alice def {acapabilities = Just ["consumable-notifications"]} >>= getJSON 201
+    clientId <- objId client
+
+    void $ assertEvent ws $ \e -> do
+      e %. "type" `shouldMatch` "event"
+      e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
+      e %. "data.event.payload.0.client.id" `shouldMatch` clientId
+
+      ackEvent ws e
+
+    assertNoEvent_ ws
+
 testConsumeEventsForDifferentUsers :: (HasCallStack) => App ()
 testConsumeEventsForDifferentUsers = do
   alice <- randomUser OwnDomain def
@@ -73,8 +101,8 @@ testConsumeEventsForDifferentUsers = do
   bobClientId <- objId bobClient
 
   lowerCodensity $ do
-    aliceWS <- createEventsWebSocket alice aliceClientId
-    bobWS <- createEventsWebSocket bob bobClientId
+    aliceWS <- createEventsWebSocket alice (Just aliceClientId)
+    bobWS <- createEventsWebSocket bob (Just bobClientId)
     lift $ assertClientAdd aliceClientId aliceWS
     lift $ assertClientAdd bobClientId bobWS
   where
@@ -110,7 +138,7 @@ testConsumeEventsWhileHavingLegacyClients = do
     oldNotif <- awaitMatch isUserClientAddNotif oldWS
     oldNotif %. "payload.0.client.id" `shouldMatch` newClientId
 
-    runCodensity (createEventsWebSocket alice newClientId) $ \ws ->
+    runCodensity (createEventsWebSocket alice (Just newClientId)) $ \ws ->
       assertEvent ws $ \e -> do
         e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
         e %. "data.event.payload.0.client.id" `shouldMatch` newClientId
@@ -127,20 +155,20 @@ testConsumeEventsAcks = do
   client <- addClient alice def {acapabilities = Just ["consumable-notifications"]} >>= getJSON 201
   clientId <- objId client
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
       e %. "data.event.payload.0.client.id" `shouldMatch` clientId
 
   -- without ack, we receive the same event again
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     deliveryTag <- assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
       e %. "data.event.payload.0.client.id" `shouldMatch` clientId
       e %. "data.delivery_tag"
     sendAck ws deliveryTag False
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertNoEvent_ ws
 
 testConsumeEventsMultipleAcks :: (HasCallStack) => App ()
@@ -152,7 +180,7 @@ testConsumeEventsMultipleAcks = do
   handle <- randomHandle
   putHandle alice handle >>= assertSuccess
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
       e %. "data.event.payload.0.client.id" `shouldMatch` clientId
@@ -164,7 +192,7 @@ testConsumeEventsMultipleAcks = do
 
     sendAck ws deliveryTag True
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertNoEvent_ ws
 
 testConsumeEventsAckNewEventWithoutAckingOldOne :: (HasCallStack) => App ()
@@ -176,7 +204,7 @@ testConsumeEventsAckNewEventWithoutAckingOldOne = do
   handle <- randomHandle
   putHandle alice handle >>= assertSuccess
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
       e %. "data.event.payload.0.client.id" `shouldMatch` clientId
@@ -190,7 +218,7 @@ testConsumeEventsAckNewEventWithoutAckingOldOne = do
     sendAck ws deliveryTagHandleAdd False
 
   -- Expect client-add event to be delivered again.
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     deliveryTagClientAdd <- assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
       e %. "data.event.payload.0.client.id" `shouldMatch` clientId
@@ -198,7 +226,7 @@ testConsumeEventsAckNewEventWithoutAckingOldOne = do
 
     sendAck ws deliveryTagClientAdd False
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     assertNoEvent_ ws
 
 testEventsDeadLettered :: (HasCallStack) => App ()
@@ -218,7 +246,7 @@ testEventsDeadLettered = do
     handle1 <- randomHandle
     putHandle alice handle1 >>= assertSuccess
 
-    runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+    runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
       assertEvent ws $ \e -> do
         e %. "type" `shouldMatch` "notifications.missed"
 
@@ -245,7 +273,7 @@ testTransientEventsDoNotTriggerDeadLetters = do
     clientId <- objId client
 
     -- consume it
-    runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+    runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
       assertEvent ws $ \e -> do
         e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
         e %. "type" `shouldMatch` "event"
@@ -260,7 +288,7 @@ testTransientEventsDoNotTriggerDeadLetters = do
     -- Typing status is transient, currently no one is listening.
     sendTypingStatus alice selfConvId "started" >>= assertSuccess
 
-    runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+    runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
       assertNoEvent_ ws
 
 testTransientEvents :: (HasCallStack) => App ()
@@ -273,7 +301,7 @@ testTransientEvents = do
   -- indicators, so we don't have to create another conv.
   selfConvId <- objQidObject alice
 
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     consumeAllEvents ws
     sendTypingStatus alice selfConvId "started" >>= assertSuccess
     assertEvent ws $ \e -> do
@@ -293,7 +321,7 @@ testTransientEvents = do
   -- We shouldn't see the stopped typing status because we were not connected to
   -- the websocket when it was sent. The other events should still show up in
   -- order.
-  runCodensity (createEventsWebSocket alice clientId) $ \ws -> do
+  runCodensity (createEventsWebSocket alice (Just clientId)) $ \ws -> do
     for_ [handle1, handle2] $ \handle ->
       assertEvent ws $ \e -> do
         e %. "data.event.payload.0.type" `shouldMatch` "user.update"
@@ -321,20 +349,21 @@ testChannelLimit = withModifiedBackend
 
     lowerCodensity $ do
       for_ clients $ \c -> do
-        ws <- createEventsWebSocket alice c
+        ws <- createEventsWebSocket alice (Just c)
         lift $ assertEvent ws $ \e -> do
           e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
           e %. "data.event.payload.0.client.id" `shouldMatch` c
 
       -- the first client fails to connect because the server runs out of channels
       do
-        ws <- createEventsWebSocket alice client0
+        ws <- createEventsWebSocket alice (Just client0)
         lift $ assertNoEvent_ ws
 
 testChannelKilled :: (HasCallStack) => App ()
 testChannelKilled = lowerCodensity $ do
   pool <- lift $ asks (.resourcePool)
   [backend] <- acquireResources 1 pool
+
   domain <- startDynamicBackend backend mempty
   alice <- lift $ randomUser domain def
   [c1, c2] <-
@@ -345,7 +374,7 @@ testChannelKilled = lowerCodensity $ do
       >>= (%. "id")
       >>= asString
 
-  ws <- createEventsWebSocket alice c1
+  ws <- createEventsWebSocket alice (Just c1)
   lift $ do
     assertEvent ws $ \e -> do
       e %. "data.event.payload.0.type" `shouldMatch` "user.client-add"
@@ -374,7 +403,7 @@ data EventWebSocket = EventWebSocket
 createEventsWebSocket ::
   (HasCallStack, MakesValue uid) =>
   uid ->
-  String ->
+  Maybe String ->
   Codensity App EventWebSocket
 createEventsWebSocket user cid = do
   eventsChan <- liftIO newChan
@@ -388,7 +417,7 @@ createEventsWebSocket user cid = do
 
   uid <- lift $ objId =<< objQidObject user
   let HostPort caHost caPort = serviceHostPort serviceMap Cannon
-      path = "/v" <> show apiVersion <> "/events?client=" <> cid
+      path = "/v" <> show apiVersion <> "/events" <> maybe "" ("?client=" <>) cid
       caHdrs = [(fromString "Z-User", toByteString' uid)]
       app conn =
         race_

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
@@ -51,8 +51,7 @@ type CannonAPI =
                :> "events"
                :> ZUser
                :> QueryParam'
-                    [ -- Make this optional in https://wearezeta.atlassian.net/browse/WPB-11173
-                      Required,
+                    [ Optional,
                       Strict,
                       Description "Client ID"
                     ]

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -105,6 +105,7 @@ library
     , lens                                  >=4.4
     , lens-family-core                      >=1.1
     , metrics-wai                           >=0.4
+    , MonadRandom
     , mwc-random                            >=0.13
     , prometheus-client
     , retry                                 >=0.7

--- a/services/cannon/default.nix
+++ b/services/cannon/default.nix
@@ -31,6 +31,7 @@
 , lens-family-core
 , lib
 , metrics-wai
+, MonadRandom
 , mwc-random
 , prometheus-client
 , QuickCheck
@@ -91,6 +92,7 @@ mkDerivation {
     lens
     lens-family-core
     metrics-wai
+    MonadRandom
     mwc-random
     prometheus-client
     retry

--- a/services/cannon/src/Cannon/API/Public.hs
+++ b/services/cannon/src/Cannon/API/Public.hs
@@ -42,7 +42,7 @@ streamData userId connId clientId con = do
   e <- wsenv
   liftIO $ wsapp (mkKey userId connId) clientId e con
 
-consumeEvents :: UserId -> ClientId -> PendingConnection -> Cannon ()
-consumeEvents userId clientId con = do
+consumeEvents :: UserId -> Maybe ClientId -> PendingConnection -> Cannon ()
+consumeEvents userId mClientId con = do
   e <- wsenv
-  liftIO $ rabbitMQWebSocketApp userId clientId e con
+  liftIO $ rabbitMQWebSocketApp userId mClientId e con

--- a/services/cannon/src/Cannon/RabbitMq.hs
+++ b/services/cannon/src/Cannon/RabbitMq.hs
@@ -227,8 +227,13 @@ ackMessage chan deliveryTag multiple = do
   inner <- readMVar chan.inner
   Q.ackMsg inner deliveryTag multiple
 
-createChannel :: (Ord key) => RabbitMqPool key -> Text -> key -> Codensity IO RabbitMqChannel
-createChannel pool queue key = do
+type QueueName = Text
+
+-- TODO: can the action simply be run after creating the consumer?
+type CreateQueue = Q.Channel -> Codensity IO ()
+
+createChannel :: (Ord key) => RabbitMqPool key -> QueueName -> CreateQueue -> key -> Codensity IO RabbitMqChannel
+createChannel pool queueName createQueue key = do
   closedVar <- lift newEmptyMVar
   inner <- lift newEmptyMVar
   msgVar <- lift newEmptyMVar
@@ -263,9 +268,11 @@ createChannel pool queue key = do
           if connSize > pool.opts.maxChannels
             then pure True
             else do
+              createQueue chan
+
               liftIO $ Q.addChannelExceptionHandler chan handleException
               putMVar inner chan
-              void $ liftIO $ Q.consumeMsgs chan queue Q.Ack $ \(message, envelope) -> do
+              void $ liftIO $ Q.consumeMsgs chan queueName Q.Ack $ \(message, envelope) -> do
                 putMVar msgVar (Just (message, envelope))
               retry <- takeMVar closedVar
               void $ takeMVar inner

--- a/services/cannon/src/Cannon/RabbitMq.hs
+++ b/services/cannon/src/Cannon/RabbitMq.hs
@@ -229,7 +229,6 @@ ackMessage chan deliveryTag multiple = do
 
 type QueueName = Text
 
--- TODO: can the action simply be run after creating the consumer?
 type CreateQueue = Q.Channel -> Codensity IO ()
 
 createChannel :: (Ord key) => RabbitMqPool key -> QueueName -> CreateQueue -> key -> Codensity IO RabbitMqChannel

--- a/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
+++ b/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
@@ -7,11 +7,13 @@ import Cannon.RabbitMq
 import Cannon.WS hiding (env)
 import Cassandra as C hiding (batch)
 import Control.Concurrent.Async
-import Control.Exception (Handler (..), bracket, catch, catches, throwIO, try)
+import Control.Exception (Handler (..), bracket, catch, catches, finally, throwIO, try)
 import Control.Lens hiding ((#))
 import Control.Monad.Codensity
+import Control.Monad.Random.Class
 import Data.Aeson hiding (Key)
 import Data.Id
+import Data.Text qualified as T
 import Imports hiding (min, threadDelay)
 import Network.AMQP qualified as Q
 import Network.WebSockets
@@ -20,11 +22,11 @@ import System.Logger qualified as Log
 import Wire.API.Event.WebSocketProtocol
 import Wire.API.Notification
 
-rabbitMQWebSocketApp :: UserId -> ClientId -> Env -> ServerApp
-rabbitMQWebSocketApp uid cid e pendingConn = do
+rabbitMQWebSocketApp :: UserId -> Maybe ClientId -> Env -> ServerApp
+rabbitMQWebSocketApp uid mcid e pendingConn = do
   bracket openWebSocket closeWebSocket $ \wsConn ->
     ( do
-        sendFullSyncMessageIfNeeded wsConn uid cid e
+        traverse_ (sendFullSyncMessageIfNeeded wsConn uid e) mcid
         sendNotifications wsConn
     )
       `catches` [ handleClientMisbehaving wsConn,
@@ -34,7 +36,7 @@ rabbitMQWebSocketApp uid cid e pendingConn = do
   where
     logClient =
       Log.field "user" (idToText uid)
-        . Log.field "client" (clientToText cid)
+        . Log.field "client" (maybe "<temporary>" clientToText mcid)
 
     openWebSocket =
       acceptRequest pendingConn
@@ -108,8 +110,21 @@ rabbitMQWebSocketApp uid cid e pendingConn = do
 
     sendNotifications :: WS.Connection -> IO ()
     sendNotifications wsConn = lowerCodensity $ do
+      cid <- lift $ mkRabbitMqClientId mcid
       let key = mkKeyRabbit uid cid
-      chan <- createChannel e.pool (clientNotificationQueueName uid cid) key
+      let queueName = clientNotificationQueueName uid cid
+
+      let createQueue chan = case mcid of
+            Nothing -> Codensity $ \k ->
+              ( do
+                  for_ [userRoutingKey uid, temporaryRoutingKey uid] $
+                    Q.bindQueue chan queueName userNotificationExchangeName
+                  k ()
+              )
+                `finally` Q.deleteQueue chan queueName
+            Just _ -> pure ()
+
+      chan <- createChannel e.pool queueName createQueue key
 
       let consumeRabbitMq = forever $ do
             eventData <- getEventData chan
@@ -171,10 +186,10 @@ rabbitMQWebSocketApp uid cid e pendingConn = do
 sendFullSyncMessageIfNeeded ::
   WS.Connection ->
   UserId ->
-  ClientId ->
   Env ->
+  ClientId ->
   IO ()
-sendFullSyncMessageIfNeeded wsConn uid cid env = do
+sendFullSyncMessageIfNeeded wsConn uid env cid = do
   row <- C.runClient env.cassandra do
     retry x5 $ query1 q (params LocalQuorum (uid, cid))
   for_ row $ \_ -> sendFullSyncMessage uid cid wsConn env
@@ -220,3 +235,8 @@ data WebSocketServerError
   deriving (Show)
 
 instance Exception WebSocketServerError
+
+mkRabbitMqClientId :: Maybe ClientId -> IO RabbitMqClientId
+mkRabbitMqClientId (Just cid) = pure (RabbitMqClientId cid)
+mkRabbitMqClientId Nothing =
+  RabbitMqTempId . T.pack <$> replicateM 8 (getRandomR ('a', 'z'))

--- a/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
+++ b/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
@@ -15,6 +15,7 @@ import Data.Aeson hiding (Key)
 import Data.Id
 import Data.Text qualified as T
 import Imports hiding (min, threadDelay)
+import Network.AMQP (newQueue)
 import Network.AMQP qualified as Q
 import Network.WebSockets
 import Network.WebSockets qualified as WS
@@ -117,6 +118,7 @@ rabbitMQWebSocketApp uid mcid e pendingConn = do
       let createQueue chan = case mcid of
             Nothing -> Codensity $ \k ->
               ( do
+                  void $ Q.declareQueue chan newQueue {Q.queueName = queueName}
                   for_ [userRoutingKey uid, temporaryRoutingKey uid] $
                     Q.bindQueue chan queueName userNotificationExchangeName
                   k ()

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -80,6 +80,7 @@ import System.Logger qualified as Logger
 import System.Logger.Class hiding (Error, Settings, close, (.=))
 import System.Random.MWC (GenIO, uniform)
 import UnliftIO.Async (async, cancel, pooledMapConcurrentlyN_)
+import Wire.API.Notification
 import Wire.API.Presence
 
 -----------------------------------------------------------------------------
@@ -93,7 +94,7 @@ newtype Key = Key
 mkKey :: UserId -> ConnId -> Key
 mkKey u c = Key (toByteString' u, fromConnId c)
 
-mkKeyRabbit :: UserId -> ClientId -> Key
+mkKeyRabbit :: UserId -> RabbitMqClientId -> Key
 mkKeyRabbit u c = Key (toByteString' u, toByteString' c)
 
 instance ToByteString Key where

--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -50,7 +50,7 @@ setupConsumableNotifications ::
   ClientId ->
   IO Text
 setupConsumableNotifications chan uid cid = do
-  let qName = clientNotificationQueueName uid cid
+  let qName = clientNotificationQueueName uid (RabbitMqClientId cid)
   void $
     declareQueue
       chan

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -313,7 +313,9 @@ pushViaRabbitMq p = do
               RecipientClientsAll ->
                 Set.singleton $ userRoutingKey r._recipientId
               RecipientClientsSome (toList -> cs) ->
-                Set.fromList $ map (clientRoutingKey r._recipientId) cs
+                Set.fromList $
+                  temporaryRoutingKey r._recipientId
+                    : map (clientRoutingKey r._recipientId) cs
   for_ routingKeys $ \routingKey ->
     mpaPublishToRabbitMq routingKey qMsg
 


### PR DESCRIPTION
This PR implements "temporary" queues for listening to events not bound to a specific client, meant to be used by team management or similar services.

When `GET /events` is called without a `client_id` parameter, we create a new temporary queue and bind it to the `user-notifications` exchange with routing keys `<user-id>` and `<user-id>.temporary`.

When a notification is published to RabbitMQ to all clients of a user, nothing changes, and `<user-id>` is used as its routing key. When it is published to a list of clients, it is now also published with routing key `<user-id>.temporary`. Each notifications is only published once with the `<user-id>.temporary` routing key even if the user has multiple capable clients.

When the websocket is closed, the temporary queue is deleted.

https://wearezeta.atlassian.net/browse/WPB-11173

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)