### PR TITLE
chore: Remove hie.yaml Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,15 +375,6 @@ db-migrate: c
 libzauth:
 	$(MAKE) -C libs/libzauth install
 
-#################################
-# Useful when using Haskell IDE Engine
-# https://github.com/haskell/haskell-ide-engine
-#
-# Run this again after changes to libraries or dependencies.
-.PHONY: hie.yaml
-hie.yaml:
-	echo -e 'cradle:\n  cabal: {}' > hie.yaml
-
 #####################################
 # Today we pretend to be CI and run integration tests on kubernetes
 # (see also docs/developer/processes.md)


### PR DESCRIPTION
The generated file already exists in our repo and won't change.

Current `hie.yaml`:

```yaml
cradle:
  cabal: {}
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
