### PR TITLE
WPB-14856 fix: Personal user to team owner not listed in team search

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-14856
+++ b/changelog.d/3-bug-fixes/WPB-14856
@@ -1,0 +1,1 @@
+Fixed search index after personal user creates team

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -265,6 +265,12 @@ searchTeam user q = do
   req <- baseRequest user Brig Versioned $ joinHttpPath ["teams", tid, "search"]
   submit "GET" (req & addQueryParams [("q", q)])
 
+searchTeamAll :: (HasCallStack, MakesValue user) => user -> App Response
+searchTeamAll user = do
+  tid <- user %. "team" & asString
+  req <- baseRequest user Brig Versioned $ joinHttpPath ["teams", tid, "search"]
+  submit "GET" (req & addQueryParams [("q", ""), ("size", "100"), ("sortby", "created_at"), ("sortorder", "desc")])
+
 getAPIVersion :: (HasCallStack, MakesValue domain) => domain -> App Response
 getAPIVersion domain = do
   req <- baseRequest domain Brig Unversioned $ "/api-version"

--- a/integration/test/Test/Teams.hs
+++ b/integration/test/Test/Teams.hs
@@ -296,6 +296,16 @@ testUpgradePersonalToTeam = do
     shouldBeNull $ owner %. "created_at"
     shouldBeNull $ owner %. "created_by"
 
+  mem <- createTeamMember alice' def
+  I.refreshIndex OwnDomain
+
+  bindResponse (searchTeamAll alice') $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    docs <- resp.json %. "documents" >>= asList
+    actualIds <- for docs ((%. "id") >=> asString)
+    expectedIds <- for [alice', mem] ((%. "id") >=> asString)
+    actualIds `shouldMatchSet` expectedIds
+
 testUpgradePersonalToTeamAlreadyInATeam :: (HasCallStack) => App ()
 testUpgradePersonalToTeamAlreadyInATeam = do
   (alice, _, _) <- createTeam OwnDomain 0

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -291,6 +291,7 @@ upgradePersonalToTeam luid bNewTeam = do
       pure $ CreateUserTeam tid (fromRange newTeam.newTeamName)
 
     liftSem $ updateUserTeam uid tid
+    liftSem $ User.internalUpdateSearchIndex uid
     liftSem $ Intra.sendUserEvent uid Nothing (teamUpdated uid tid)
     initAccountFeatureConfig uid
 


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
