### PR TITLE
[WPB-14912] Limit the consume events endpoint to v8

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
@@ -22,6 +22,7 @@ import Servant
 import Wire.API.Routes.API
 import Wire.API.Routes.Named
 import Wire.API.Routes.Public (ZConn, ZUser)
+import Wire.API.Routes.Version
 import Wire.API.Routes.WebSocket
 
 type CannonAPI =
@@ -46,7 +47,7 @@ type CannonAPI =
            "consume-events"
            ( Summary "Consume events over a websocket connection"
                :> Description "This is the rabbitMQ-based variant of \"await-notifications\""
-               -- :> From 'V8 -- cannon is not versioned yet
+               :> From 'V8
                :> "events"
                :> ZUser
                :> QueryParam'


### PR DESCRIPTION
Tracked by https://wearezeta.atlassian.net/browse/WPB-14912.

## Checklist

 - [x] No changelog ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
