### PR TITLE
fix bug: consent request not correctly forwarded to galeb

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-14613
+++ b/changelog.d/3-bug-fixes/WPB-14613
@@ -1,0 +1,1 @@
+Fix bug in nginz: `/consent/<foo>` requests not correctly forwarded to `galeb`.

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -708,7 +708,7 @@ nginx_conf:
       versioned: false
       strip_version: true
     galeb:
-    - path: /consent
+    - path: /consent(.*)
       envs:
       - all
       disable_zauth: true


### PR DESCRIPTION
This PR fixes the following bug: requests to nginz of form `/v./consent/.*` are not forwaded forwarded to `galeb` with path `/consent/.*` but with path `/consent`

I also considered changing the rewrite rule from

```
rewrite ^/v[0-9]+({{ $location.path }}) $1;
```

to

```
rewrite ^/v[0-9]+({{ $location.path }}.*) $1;
```

to fix the bug, but opted against it, because it would make the paths configured in `values.yaml` less explicit.
I think it's better to be explicit in the config about the fact that requests may be of form `/consent/<foo>/<bar>/<baz>`.
This is also consistent with other parts in the configuration where we are explicit about the whole path instead of relying on the fact for a `~*` you may omit the tail.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

Tracked by https://wearezeta.atlassian.net/browse/WPB-14613
