### PR TITLE
WPB-15072 team activated is not sent to ibis when a personal user creates a new team

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-15072
+++ b/changelog.d/3-bug-fixes/WPB-15072
@@ -1,0 +1,1 @@
+Send team active event in personal user to team flow

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -119,3 +119,8 @@ patchTeamFeature domain team featureName payload = do
   tid <- asString team
   req <- baseRequest domain Galley Unversioned $ joinHttpPath ["i", "teams", tid, "features", featureName]
   submit "PATCH" $ req & addJSON payload
+
+getTeam :: (HasCallStack, MakesValue domain) => domain -> String -> App Response
+getTeam domain tid = do
+  req <- baseRequest domain Galley Unversioned $ joinHttpPath ["i", "teams", tid]
+  submit "GET" $ req

--- a/integration/test/Test/Teams.hs
+++ b/integration/test/Test/Teams.hs
@@ -22,7 +22,7 @@ import API.Brig
 import qualified API.BrigInternal as I
 import API.Common
 import API.Galley (getTeam, getTeamMembers, getTeamMembersCsv, getTeamNotifications)
-import API.GalleyInternal (setTeamFeatureStatus)
+import qualified API.GalleyInternal as I
 import API.Gundeck
 import qualified API.Nginz as Nginz
 import Control.Monad.Codensity (Codensity (runCodensity))
@@ -58,7 +58,7 @@ testInvitePersonalUserToTeam = do
           resp.json %. "invitations" `shouldMatch` ([] :: [()])
 
         ownerId <- owner %. "id" & asString
-        setTeamFeatureStatus domain tid "exposeInvitationURLsToTeamAdmin" "enabled" >>= assertSuccess
+        I.setTeamFeatureStatus domain tid "exposeInvitationURLsToTeamAdmin" "enabled" >>= assertSuccess
         user <- I.createUser domain def >>= getJSON 201
         uid <- user %. "id" >>= asString
         email <- user %. "email" >>= asString
@@ -288,6 +288,10 @@ testUpgradePersonalToTeam = do
 
   team <- getTeam alice tid >>= getJSON 200
   team %. "name" `shouldMatch` teamName
+
+  iTeam <- asString tid >>= I.getTeam alice >>= getJSON 200
+  iTeam %. "team.name" `shouldMatch` teamName
+  iTeam %. "status" `shouldMatch` "active"
 
   bindResponse (getTeamMembers alice tid) $ \resp -> do
     resp.status `shouldMatchInt` 200

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -289,6 +289,7 @@ upgradePersonalToTeam luid bNewTeam = do
       liftSem $ GalleyAPIAccess.createTeam uid (bnuTeam bNewTeam) tid
       let newTeam = bNewTeam.bnuTeam
       pure $ CreateUserTeam tid (fromRange newTeam.newTeamName)
+    liftSem $ GalleyAPIAccess.changeTeamStatus tid Team.Active bNewTeam.bnuCurrency
 
     liftSem $ updateUserTeam uid tid
     liftSem $ User.internalUpdateSearchIndex uid


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
