### PR TITLE
[WPB-15151] eliminate legahold test redundancy

### DIFF
--- a/changelog.d/5-internal/wpb-15151-revive-and-translate-tests
+++ b/changelog.d/5-internal/wpb-15151-revive-and-translate-tests
@@ -1,0 +1,1 @@
+Revive and translate old integration test.

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -717,10 +717,23 @@ getTeamFeature user tid featureName = do
   req <- baseRequest user Galley Versioned (joinHttpPath ["teams", tidStr, "features", featureName])
   submit "GET" req
 
-setTeamFeatureConfig :: (HasCallStack, MakesValue user, MakesValue team, MakesValue featureName, MakesValue payload) => user -> team -> featureName -> payload -> App Response
+setTeamFeatureConfig ::
+  (HasCallStack, MakesValue user, MakesValue team, MakesValue featureName, MakesValue payload) =>
+  user ->
+  team ->
+  featureName ->
+  payload ->
+  App Response
 setTeamFeatureConfig = setTeamFeatureConfigVersioned Versioned
 
-setTeamFeatureConfigVersioned :: (HasCallStack, MakesValue user, MakesValue team, MakesValue featureName, MakesValue payload) => Versioned -> user -> team -> featureName -> payload -> App Response
+setTeamFeatureConfigVersioned ::
+  (HasCallStack, MakesValue user, MakesValue team, MakesValue featureName, MakesValue payload) =>
+  Versioned ->
+  user ->
+  team ->
+  featureName ->
+  payload ->
+  App Response
 setTeamFeatureConfigVersioned versioned user team featureName payload = do
   tid <- asString team
   fn <- asString featureName

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -98,7 +98,13 @@ generateVerificationCode' domain email = do
   emailStr <- asString email
   submit "POST" $ req & addJSONObject ["email" .= emailStr, "action" .= "login"]
 
-setTeamFeatureConfig :: (HasCallStack, MakesValue domain, MakesValue team, MakesValue featureName, MakesValue payload) => domain -> team -> featureName -> payload -> App Response
+setTeamFeatureConfig ::
+  (HasCallStack, MakesValue domain, MakesValue team, MakesValue featureName, MakesValue payload) =>
+  domain ->
+  team ->
+  featureName ->
+  payload ->
+  App Response
 setTeamFeatureConfig domain team featureName payload = do
   tid <- asString team
   fn <- asString featureName
@@ -106,7 +112,13 @@ setTeamFeatureConfig domain team featureName payload = do
   req <- baseRequest domain Galley Unversioned $ joinHttpPath ["i", "teams", tid, "features", fn]
   submit "PUT" $ req & addJSON p
 
-patchTeamFeatureConfig :: (HasCallStack, MakesValue domain, MakesValue team, MakesValue featureName, MakesValue payload) => domain -> team -> featureName -> payload -> App Response
+patchTeamFeatureConfig ::
+  (HasCallStack, MakesValue domain, MakesValue team, MakesValue featureName, MakesValue payload) =>
+  domain ->
+  team ->
+  featureName ->
+  payload ->
+  App Response
 patchTeamFeatureConfig domain team featureName payload = do
   tid <- asString team
   fn <- asString featureName

--- a/integration/test/Test/LegalHold.hs
+++ b/integration/test/Test/LegalHold.hs
@@ -1108,7 +1108,7 @@ testNoCommonVersion = do
       resp.status `shouldMatchInt` 500
       resp.json %. "label" `shouldMatch` "server-error"
 
--- | LH can be configured i a way that does not require users to give preliminary consent to
+-- | LH can be configured in a way that does not require users to give preliminary consent to
 -- LH when being added to a team.  The user still has to approve the LH device before the
 -- recording starts.  This is called "implicit consent", was introduced to accomodate specific
 -- work flows, and there is some hope that it'll be removed in the future.

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -56,7 +56,7 @@ import Prelude
 
 withModifiedBackend :: (HasCallStack) => ServiceOverrides -> ((HasCallStack) => String -> App a) -> App a
 withModifiedBackend overrides k =
-  startDynamicBackends [overrides] (\domains -> k (head domains))
+  startDynamicBackends [overrides] (\[domains] -> k domains)
 
 copyDirectoryRecursively :: FilePath -> FilePath -> IO ()
 copyDirectoryRecursively from to = do


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
