### PR TITLE
integration: Use lsof instead of ss to find processes listening on a port

### DIFF
--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -297,6 +297,7 @@ let
       pkgs.awscli2
       pkgs.vacuum-go
       pkgs.iproute2
+      pkgs.lsof
       integration-dynamic-backends-db-schemas
       integration-dynamic-backends-brig-index
       integration-dynamic-backends-ses
@@ -547,6 +548,7 @@ in
       pkgs.cabal-install
       pkgs.nix-prefetch-git
       pkgs.haskellPackages.cabal-plan
+      pkgs.lsof
       profileEnv
     ]
     ++ ghcWithPackages


### PR DESCRIPTION
Also don't ignore exceptions when stopping dynamic backends.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
