### PR TITLE
integration: Close FDs of dynamic backend processes after they stop

### DIFF
--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -360,3 +360,5 @@ spec:
       value: "1"
     - name: ENABLE_FEDERATION_V1
       value: "1"
+    - name: TEST_INCLUDE
+      value: "testMigratingPasswordHashingAlgorithm"

--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -360,5 +360,3 @@ spec:
       value: "1"
     - name: ENABLE_FEDERATION_V1
       value: "1"
-    - name: TEST_INCLUDE
-      value: "testMigratingPasswordHashingAlgorithm"

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -62,8 +62,9 @@ kubectl -n wire-federation-v1 get secrets rabbitmq -ojson | jq 'del(.metadata.na
 # - run all tests. Perhaps multiple flaky tests in multiple services exist, if so, we wish to see all problems
 mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 printf '%s\n' "${tests[@]}" | parallel echo "Running helm tests for {}..."
+# TODO: Revert timeout to 15 mins
 printf '%s\n' "${tests[@]}" | parallel -P "${HELM_PARALLELISM}" \
-    helm test -n "${NAMESPACE}" "${CHART}" --timeout 900s --filter name="${CHART}-{}-integration" '> logs-{};' \
+    helm test -n "${NAMESPACE}" "${CHART}" --timeout 1800s --filter name="${CHART}-{}-integration" '> logs-{};' \
     echo '$? > stat-{};' \
     echo "==== Done testing {}. ====" '};' \
     kubectl -n "${NAMESPACE}" logs "${CHART}-{}-integration" '>> logs-{};'

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -11,7 +11,7 @@ UPLOAD_LOGS=${UPLOAD_LOGS:-0}
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 
 CHART=wire-server
-tests=(integration stern galley cargohold gundeck federator spar brig)
+tests=(integration)
 
 cleanup() {
     if ((CLEANUP_LOCAL_FILES > 0)); then

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -190,12 +190,16 @@ testMigratingPasswordHashingAlgorithm = do
           ]
       cfgArgon2id =
         def
-          { brigCfg = setField "settings.setPasswordHashingOptions" argon2idOpts,
+          { brigCfg =
+              setField "settings.setPasswordHashingOptions" argon2idOpts
+                >=> removeField "optSettings.setSuspendInactiveUsers",
             galleyCfg = setField "settings.passwordHashingOptions" argon2idOpts
           }
       cfgScrypt =
         def
-          { brigCfg = setField "settings.setPasswordHashingOptions.algorithm" "scrypt",
+          { brigCfg =
+              setField "settings.setPasswordHashingOptions.algorithm" "scrypt"
+                >=> removeField "optSettings.setSuspendInactiveUsers",
             galleyCfg = setField "settings.passwordHashingOptions.algorithm" "scrypt"
           }
   resourcePool <- asks (.resourcePool)

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -179,8 +179,15 @@ testActivateAccountWithPhoneV5 = do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "bad-request"
 
-testMigratingPasswordHashingAlgorithm :: (HasCallStack) => App ()
-testMigratingPasswordHashingAlgorithm = do
+data Deflake = Deflake
+
+instance TestCases Deflake where
+  mkTestCases =
+    pure . flip map [(0 :: Int) .. 20] $ \n ->
+      MkTestCase {testCaseName = "Deflake" <> show n, testCase = Deflake}
+
+testMigratingPasswordHashingAlgorithm :: (HasCallStack) => Deflake -> App ()
+testMigratingPasswordHashingAlgorithm _ = do
   let argon2idOpts =
         object
           [ "algorithm" .= "argon2id",

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -179,15 +179,8 @@ testActivateAccountWithPhoneV5 = do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "bad-request"
 
-data Deflake = Deflake
-
-instance TestCases Deflake where
-  mkTestCases =
-    pure . flip map [(0 :: Int) .. 20] $ \n ->
-      MkTestCase {testCaseName = "Deflake" <> show n, testCase = Deflake}
-
-testMigratingPasswordHashingAlgorithm :: (HasCallStack) => Deflake -> App ()
-testMigratingPasswordHashingAlgorithm _ = do
+testMigratingPasswordHashingAlgorithm :: (HasCallStack) => App ()
+testMigratingPasswordHashingAlgorithm = do
   let argon2idOpts =
         object
           [ "algorithm" .= "argon2id",

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -123,11 +123,11 @@ traverseConcurrentlyCodensity f args = do
 
     pure result
 
-startDynamicBackends :: [ServiceOverrides] -> ([String] -> App a) -> App a
+startDynamicBackends :: (HasCallStack) => [ServiceOverrides] -> ([String] -> App a) -> App a
 startDynamicBackends beOverrides k = do
   startDynamicBackendsReturnResources beOverrides (\resources -> k $ map (.berDomain) resources)
 
-startDynamicBackendsReturnResources :: [ServiceOverrides] -> ([BackendResource] -> App a) -> App a
+startDynamicBackendsReturnResources :: (HasCallStack) => [ServiceOverrides] -> ([BackendResource] -> App a) -> App a
 startDynamicBackendsReturnResources beOverrides k = do
   let startDynamicBackendsCodensity = do
         when (Prelude.length beOverrides > 3) $ lift $ failApp "Too many backends. Currently only 3 are supported."

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -276,7 +276,7 @@ startBackend resource overrides = do
   lift $ ensureBackendReachable resource.berDomain
 
 -- | Using ss because it is most convenient. Checking if a port is free in Haskell involves binding to it which is not what we want.
-ensureFederatorPortIsFree :: BackendResource -> App ()
+ensureFederatorPortIsFree :: (HasCallStack) => BackendResource -> App ()
 ensureFederatorPortIsFree resource = do
   serviceMap <- getServiceMap resource.berDomain
   let federatorExternalPort :: Word16 = serviceMap.federatorExternal.port

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -282,7 +282,7 @@ ensureFederatorPortIsFree resource = do
   let federatorExternalPort :: Word16 = serviceMap.federatorExternal.port
   env <- ask
   UnliftIO.timeout (env.timeOutSeconds * 1_000_000) (check federatorExternalPort) >>= \case
-    Nothing -> assertFailure $ "timeout waiting for federator port to be free: " <> show federatorExternalPort
+    Nothing -> assertFailure $ "timeout waiting for federator port to be free, domain=" <> resource.berDomain <> ", port=" <> show federatorExternalPort
     Just _ -> pure ()
   where
     check :: Word16 -> App ()

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -431,7 +431,7 @@ withProcess resource overrides service = do
         _ -> do
           config <- getConfig
           tempFile <- writeTempFile "/tmp" (execName <> "-" <> domain <> "-" <> ".yaml") (cs $ Yaml.encode config)
-          (_, Just stdoutHdl, Just stderrHdl, ph) <- createProcess (proc exe ["-c", tempFile]) {cwd = cwd, std_out = CreatePipe, std_err = CreatePipe}
+          (_, Just stdoutHdl, Just stderrHdl, ph) <- createProcess (proc exe ["-c", tempFile]) {cwd = cwd, std_out = CreatePipe, std_err = CreatePipe, close_fds = True}
           let prefix = "[" <> execName <> "@" <> domain <> maybe "" (":" <>) env.currentTestName <> "] "
           let colorize = fromMaybe id (lookup execName processColors)
           void $ forkIO $ logToConsole colorize prefix stdoutHdl

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -431,7 +431,7 @@ withProcess resource overrides service = do
         _ -> do
           config <- getConfig
           tempFile <- writeTempFile "/tmp" (execName <> "-" <> domain <> "-" <> ".yaml") (cs $ Yaml.encode config)
-          (_, Just stdoutHdl, Just stderrHdl, ph) <- createProcess (proc exe ["-c", tempFile]) {cwd = cwd, std_out = CreatePipe, std_err = CreatePipe, close_fds = True}
+          (_, Just stdoutHdl, Just stderrHdl, ph) <- createProcess (proc exe ["-c", tempFile]) {cwd = cwd, std_out = CreatePipe, std_err = CreatePipe}
           let prefix = "[" <> execName <> "@" <> domain <> maybe "" (":" <>) env.currentTestName <> "] "
           let colorize = fromMaybe id (lookup execName processColors)
           void $ forkIO $ logToConsole colorize prefix stdoutHdl


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-15156

Most of the services get a SIGKILL because we don't wait long enough for them to close gracefully. This is mostly fine in tests because we don't want to wait ~30s for each service. So making sure that the FDs don't leak should fix the problem with federator not being able to come up due to previous federator's FDs not being closed.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
