### PR TITLE
integration/testChannelKilled: Wait for connection to disappear before asserting that WS should be closed

### DIFF
--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -45,6 +45,11 @@ assertOne xs = case toList xs of
   [x] -> pure x
   other -> assertFailure ("Expected one, but got " <> show (length other))
 
+assertAtLeastOne :: (HasCallStack, Foldable t) => t a -> App ()
+assertAtLeastOne xs = case toList xs of
+  [] -> assertFailure ("Expected at least one, but got nothing")
+  _ -> pure ()
+
 expectFailure :: (HasCallStack) => (AssertionFailure -> App ()) -> App a -> App ()
 expectFailure checkFailure action = do
   env <- ask


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-15208

Also ensure that lingering connections from previous uses of the dynamic backend are not causing flakiness.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
