### PR TITLE
integration: Bring back port checking for dynamic backends

### DIFF
--- a/integration/default.nix
+++ b/integration/default.nix
@@ -70,6 +70,7 @@
 , stm
 , streaming-commons
 , string-conversions
+, system-linux-proc
 , tagged
 , temporary
 , text
@@ -169,6 +170,7 @@ mkDerivation {
     stm
     streaming-commons
     string-conversions
+    system-linux-proc
     tagged
     temporary
     text

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -265,6 +265,7 @@ library
     , stm
     , streaming-commons
     , string-conversions
+    , system-linux-proc
     , tagged
     , temporary
     , text

--- a/integration/test/Testlib/Ports.hs
+++ b/integration/test/Testlib/Ports.hs
@@ -8,6 +8,7 @@ data PortNamespace
   | NginzHttp2
   | FederatorExternal
   | ServiceInternal Service
+  deriving (Show, Eq)
 
 port :: (Num a) => PortNamespace -> BackendName -> a
 port NginzSSL bn = mkPort 8443 bn

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -59,6 +59,7 @@ hself: hsuper: {
   # (we can unfortunately not do anything here but update nixpkgs)
   # ------------------------------------
   template = hlib.markUnbroken hsuper.template;
+  system-linux-proc = hlib.markUnbroken hsuper.system-linux-proc;
 
   # -----------------
   # version overrides


### PR DESCRIPTION
Instead of killing processes, wait for the port to be freed.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
