### PR TITLE
charts: Use bitnami helm repo from github 

### DIFF
--- a/charts/rabbitmq/requirements.yaml
+++ b/charts/rabbitmq/requirements.yaml
@@ -1,4 +1,6 @@
 dependencies:
 - name: rabbitmq
   version: 14.6.9
-  repository: https://charts.bitnami.com/bitnami
+  # Use helm repo from the git repo because bitnami's repo is failing
+  # intermittently
+  repository: https://raw.githubusercontent.com/bitnami/charts/234a73987975ffeb0674dc60287012052ce0ddfc/bitnami

--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,6 @@
 dependencies:
 - name: redis-cluster
   version: 7.6.4
-  repository: https://charts.bitnami.com/bitnami
+  # Use helm repo from the git repo because bitnami's repo is failing
+  # intermittently
+  repository: https://raw.githubusercontent.com/bitnami/charts/234a73987975ffeb0674dc60287012052ce0ddfc/bitnami

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -49,9 +49,6 @@ repositories:
   - name: stable
     url: 'https://charts.helm.sh/stable'
 
-  - name: bitnami
-    url: 'https://charts.bitnami.com/bitnami'
-
   - name: ingress
     url: 'https://kubernetes.github.io/ingress-nginx'
 


### PR DESCRIPTION
The main repo seems to have some intermittent issues

https://github.com/bitnami/charts/issues/31257

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
