### PR TITLE
charts/background-worker: Explicitly remove serviceAccount

### DIFF
--- a/charts/background-worker/templates/deployment.yaml
+++ b/charts/background-worker/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         checksum/cassandra-secret: {{ include (print .Template.BasePath "/cassandra-secret.yaml") . | sha256sum }}
         fluentbit.io/parser: json
     spec:
+      serviceAccount: null
+      serviceAccountName: null
       automountServiceAccountToken: false
       volumes:
         - name: "background-worker-config"


### PR DESCRIPTION
Fixup for https://github.com/wireapp/wire-server/pull/4410

The service account needs to be unset expliclty otherwise the previous value remains. https://github.com/kubernetes/kubernetes/issues/72519

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
