### PR TITLE
Stabilize index migration tests

### DIFF
--- a/changelog.d/5-internal/refreshIndex-correct-url
+++ b/changelog.d/5-internal/refreshIndex-correct-url
@@ -1,0 +1,3 @@
+/i/index/refresh now uses the correct URL for additional indices. Thus, the
+refreshed indices can reside on different ElasticSearch instances. This
+endpoint is exclusively called from tests.

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -129,7 +129,11 @@ refreshIndexes = liftIndexIO $ do
   idx <- asks idxName
   void $ ES.refreshIndex idx
   mbAddIdx <- asks idxAdditionalName
-  mapM_ ES.refreshIndex mbAddIdx
+  mbAddElasticEnv <- asks idxAdditionalElastic
+  case (mbAddIdx, mbAddElasticEnv) of
+    (Just addIdx, Just addElasticEnv) ->
+      ES.runBH addElasticEnv ((void . ES.refreshIndex) addIdx)
+    (_, _) -> pure ()
 
 createIndexIfNotPresent ::
   (MonadIndexIO m) =>

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -812,7 +812,11 @@ indexProxyServer idxs opts mgr =
       proxyToHost = URI.hostBS . URI.authorityHost . fromMaybe (error "No Host") . URI.uriAuthority $ proxyURI
       proxyToPort = URI.portNumber . fromMaybe (URI.Port 9200) . URI.authorityPort . fromMaybe (error "No Host") . URI.uriAuthority $ proxyURI
       forwardRequest = Wai.WPRProxyDestSecure (Wai.ProxyDest proxyToHost proxyToPort)
-      denyRequest req = Wai.WPRResponse (Wai.responseLBS HTTP.status400 [] $ "Refusing to proxy to path=" <> cs (Wai.rawPathInfo req))
+      denyRequest req =
+        Wai.WPRResponse
+          ( Wai.responseLBS HTTP.status400 [] $
+              "Refusing to proxy to path=" <> cs (Wai.rawPathInfo req) <> ". Proxy configured for indices: " <> cs (show idxs)
+          )
       proxyApp req
         | (headMay (Wai.pathInfo req)) `elem` [Just "_reindex", Just "_tasks"] =
             forwardRequest


### PR DESCRIPTION
Additional indices were not correctly refreshed in [testMigrationToNewIndex](https://github.com/wireapp/wire-server/blob/b9959a626deb256bd9d49f5eb34330b51f75d0a8/services/brig/test/integration/API/Search.hs#L623) due to a proxy masking them (forbidding to write access to the additional index with the default one's proxy URL.) Thus, it was a bit of luck if all index writes could be read, which led to flaky tests.

This PR lets `/i/index/refresh` sync default and additional indices with their dedicated URL.

Tickets:
- https://wearezeta.atlassian.net/browse/WPB-15437
- https://wearezeta.atlassian.net/browse/WPB-15433

N.B. yes, it is a bit weird to request merging with a failing pipeline. But, index migration tests seem to be stable now.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
