### PR TITLE
/i/index/refresh : Refresh additional index on same ElasticSearch

### DIFF
--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -132,8 +132,14 @@ refreshIndexes = liftIndexIO $ do
   mbAddElasticEnv <- asks idxAdditionalElastic
   case (mbAddIdx, mbAddElasticEnv) of
     (Just addIdx, Just addElasticEnv) ->
+      -- Refresh additional index on a separate ElasticSearch instance.
       ES.runBH addElasticEnv ((void . ES.refreshIndex) addIdx)
-    (_, _) -> pure ()
+    (Just addIdx, Nothing) ->
+      -- Refresh additional index on the same ElasticSearch instance.
+      void $ ES.refreshIndex addIdx
+    (Nothing, _) ->
+      -- No additional index
+      pure ()
 
 createIndexIfNotPresent ::
   (MonadIndexIO m) =>


### PR DESCRIPTION
This case was missing: The additional index can reside on the same ElasticSearch instance as the normal/default one.

Ticket: https://wearezeta.atlassian.net/browse/WPB-15437

## Checklist

 - ~[ ] Add a new entry in an appropriate subdirectory of `changelog.d`~ (This is a fixup of https://github.com/wireapp/wire-server/pull/4413/)
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
