### PR TITLE
Fix 503 on registration with disabled enterprise service

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-14307-quickfix-503
+++ b/changelog.d/3-bug-fixes/WPB-14307-quickfix-503
@@ -1,0 +1,1 @@
+Fix 503 on user registration when the enterprise service is disabled

--- a/integration/test/Test/Teams.hs
+++ b/integration/test/Test/Teams.hs
@@ -247,12 +247,12 @@ testInvitePersonalUserToTeamLegacy = withAPIVersion 6 $ do
       resp.json %. "email" `shouldMatch` email
       resp.json %. "team" `shouldMatch` tid
 
-testInvitationTypesAreDistinct :: (HasCallStack) => App ()
-testInvitationTypesAreDistinct = do
+testInvitationTypesAreDistinct :: (HasCallStack) => Domain -> App ()
+testInvitationTypesAreDistinct domain = do
   -- We are only testing one direction because the other is not possible
   -- because the non-existing user cannot have a valid session
-  (owner, _, _) <- createTeam OwnDomain 0
-  user <- I.createUser OwnDomain def >>= getJSON 201
+  (owner, _, _) <- createTeam domain 0
+  user <- I.createUser domain def >>= getJSON 201
   email <- user %. "email" >>= asString
   inv <- postInvitation owner (PostInvitation (Just email) Nothing) >>= getJSON 201
   code <- I.getInvitationCode owner inv >>= getJSON 200 >>= (%. "code") & asString
@@ -263,7 +263,7 @@ testInvitationTypesAreDistinct = do
             password = Just defPassword,
             teamCode = Just code
           }
-  addUser OwnDomain body >>= assertStatus 409
+  addUser domain body >>= assertStatus 409
 
 testTeamUserCannotBeInvited :: (HasCallStack) => App ()
 testTeamUserCannotBeInvited = do

--- a/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem/Null.hs
+++ b/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem/Null.hs
@@ -9,5 +9,7 @@ import Wire.EnterpriseLoginSubsystem.Error
 runEnterpriseLoginSubsystemNoConfig ::
   (Member (Error EnterpriseLoginSubsystemError) r) =>
   InterpreterFor EnterpriseLoginSubsystem r
-runEnterpriseLoginSubsystemNoConfig = interpret $ \_ ->
-  throw EnterpriseLoginSubsystemNotEnabled
+runEnterpriseLoginSubsystemNoConfig = interpret $ \case
+  GuardEmailDomainRegistrationTeamInvitation {} -> pure ()
+  GuardEmailDomainRegistrationRegister {} -> pure ()
+  _ -> throw EnterpriseLoginSubsystemNotEnabled


### PR DESCRIPTION
Fix 503 on user registration when the enterprise service is disabled.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
