### PR TITLE
fix add bots to conversations

### DIFF
--- a/charts/nginz/static/conf/zauth.acl
+++ b/charts/nginz/static/conf/zauth.acl
@@ -1,8 +1,8 @@
 a (blacklist (regex "(/v[0-9]+)?/provider(/.*)?")
-             (regex "(/v[0-9]+)?/bot(/(?!conversation/.+).*)?")
+             (regex "(/v[0-9]+)?/bot(/(?!conversations/.+).*)?")
              (regex "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (regex "(/v[0-9]+)?/bot(/(?!conversation/.+).*)?"))
+b (whitelist (regex "(/v[0-9]+)?/bot(/(?!conversations/.+).*)?"))
 
 p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 

--- a/charts/nginz/static/conf/zauth.acl
+++ b/charts/nginz/static/conf/zauth.acl
@@ -1,8 +1,8 @@
 a (blacklist (regex "(/v[0-9]+)?/provider(/.*)?")
-             (regex "(/v[0-9]+)?/bot(/.*)?")
+             (regex "(/v[0-9]+)?/bot(/(?!conversation/.+).*)?")
              (regex "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
+b (whitelist (regex "(/v[0-9]+)?/bot(/(?!conversation/.+).*)?"))
 
 p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -471,6 +471,9 @@ nginx_conf:
     - path: /upgrade-personal-to-team$
       envs:
       - all
+    - path: /bot/conversation/(.+)
+      envs:
+      - all
     galley:
     - path: /conversations/code-check
       disable_zauth: true
@@ -503,7 +506,7 @@ nginx_conf:
       - all
       max_body_size: 40m
       body_buffer_size: 256k
-    - path: /bot/conversation
+    - path: /bot/conversation$
       envs:
       - all
     - path: /bot/messages

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -471,7 +471,7 @@ nginx_conf:
     - path: /upgrade-personal-to-team$
       envs:
       - all
-    - path: /bot/conversation/(.+)
+    - path: /bot/conversations/(.+)
       envs:
       - all
     galley:


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-15723

Seperate the handling of
- /bot/conversation and
- /bot/conversations/.+ .

For /bot/conversations/.+
- redirect to and authenticate with user token for brig.

For /bot/conversation
- leave redirected to and authenticate with bot token for galley.

## Checklist

 - [ ] ~Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
