### PR TITLE
 Release 2025-01-28 - (expected chart version 5.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [2025-01-28] (Chart Release 5.10.0)
+
+## Release notes
+
+
+This is a hotfix release to re-enable adding and removing bots to conversations. (#4424, #4425, #4426)
+
+
 # [2024-12-30] (Chart Release 5.9.0)
 
 ## Release notes

--- a/charts/nginz/static/conf/zauth.acl
+++ b/charts/nginz/static/conf/zauth.acl
@@ -1,8 +1,18 @@
 a (blacklist (regex "(/v[0-9]+)?/provider(/.*)?")
-             (regex "(/v[0-9]+)?/bot(/.*)?")
+             (regex "(/v[0-9]+)?/bot/self")
+             (regex "(/v[0-9]+)?/bot/client(/.*)?")
+             (regex "(/v[0-9]+)?/bot/users(/.*)?")
+             (regex "(/v[0-9]+)?/bot/assets(/.*)?")
+             (regex "(/v[0-9]+)?/bot/conversation$")
+             (regex "(/v[0-9]+)?/bot/messages")
              (regex "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
+b (whitelist (regex "(/v[0-9]+)?/bot/self")
+             (regex "(/v[0-9]+)?/bot/client(/.*)?")
+             (regex "(/v[0-9]+)?/bot/users(/.*)?")
+             (regex "(/v[0-9]+)?/bot/assets(/.*)?")
+             (regex "(/v[0-9]+)?/bot/conversation$")
+             (regex "(/v[0-9]+)?/bot/messages"))
 
 p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -471,6 +471,9 @@ nginx_conf:
     - path: /upgrade-personal-to-team$
       envs:
       - all
+    - path: /bot/conversations/(.+)
+      envs:
+      - all
     galley:
     - path: /conversations/code-check
       disable_zauth: true
@@ -503,7 +506,7 @@ nginx_conf:
       - all
       max_body_size: 40m
       body_buffer_size: 256k
-    - path: /bot/conversation
+    - path: /bot/conversation$
       envs:
       - all
     - path: /bot/messages


### PR DESCRIPTION
# [2025-01-28] (Chart Release 5.10.0)

## Release notes

This is a hotfix release to re-enable adding and removing bots to conversations. (#4424, #4425, #4426)
