### PR TITLE
Fix 503 on team invitation with wire-server-enterprise disabled

### DIFF
--- a/integration/test/Test/Teams.hs
+++ b/integration/test/Test/Teams.hs
@@ -247,9 +247,11 @@ testInvitePersonalUserToTeamLegacy = withAPIVersion 6 $ do
       resp.json %. "email" `shouldMatch` email
       resp.json %. "team" `shouldMatch` tid
 
-testInvitationTypesAreDistinct :: (HasCallStack) => App ()
-testInvitationTypesAreDistinct = do
-  let domain = OwnDomain -- enterprise is not enabled for OtherDomain / dynamic backends.
+testInvitationTypesAreDistinct :: (HasCallStack) => Domain -> App ()
+testInvitationTypesAreDistinct domain = do
+  -- Test all domains here to make sure that enterprise login being disabled
+  -- does not prevent user registration.
+
   -- We are only testing one direction because the other is not possible
   -- because the non-existing user cannot have a valid session
   (owner, _, _) <- createTeam domain 0

--- a/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem/Null.hs
+++ b/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem/Null.hs
@@ -10,4 +10,5 @@ runEnterpriseLoginSubsystemNoConfig ::
   (Member (Error EnterpriseLoginSubsystemError) r) =>
   InterpreterFor EnterpriseLoginSubsystem r
 runEnterpriseLoginSubsystemNoConfig = interpret $ \case
+  GetDomainRegistration _domain -> pure Nothing
   _ -> throw EnterpriseLoginSubsystemNotEnabled


### PR DESCRIPTION
Followup to #4418.

The test that user registration and team invitation works with enterprise login disabled was accidentally deleted. This re-enables the test and fixes the 503 in that case by making `GetDomainRegistration` return `Nothing` in the `Null` interpreter.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
