### PR TITLE
WPB-15933 Special case of getDomainRegistrationPublic

### DIFF
--- a/changelog.d/1-api-changes/WPB-15933
+++ b/changelog.d/1-api-changes/WPB-15933
@@ -1,0 +1,5 @@
+Add a flag to the response body of `POST /get-domain-registration` to indicate
+whether `domain_redirect` is set to `none` due to the existence of a registered
+account. This makes it possible for clients to let a user log in with an
+existing cloud account even if a redirection to an on-prem backend is set up
+for their domain.

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig/DomainVerification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig/DomainVerification.hs
@@ -151,6 +151,22 @@ instance ToSchema RegisteredDomains where
       RegisteredDomains
         <$> unRegisteredDomains .= field "registered_domains" (array schema)
 
+data DomainRedirectResponse = DomainRedirectResponse
+  { userExists :: Bool,
+    redirect :: DomainRedirect
+  }
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema DomainRedirectResponse)
+
+instance ToSchema DomainRedirectResponse where
+  schema =
+    object "DomainRedirectResponse" $
+      DomainRedirectResponse
+        <$> (\r -> True <$ guard r.userExists)
+          .= maybe_
+            ( fromMaybe False <$> optField "due_to_existing_account" schema
+            )
+        <*> (.redirect) .= domainRedirectSchema
+
 type DomainVerificationChallengeAPI =
   Named
     "domain-verification-challenge"
@@ -241,5 +257,5 @@ type DomainVerificationAPI =
                :> CanThrow DomainVerificationInvalidDomain
                :> "get-domain-registration"
                :> ReqBody '[JSON] GetDomainRegistrationRequest
-               :> Post '[JSON] DomainRedirect
+               :> Post '[JSON] DomainRedirectResponse
            )

--- a/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/EnterpriseLoginSubsystem.hs
@@ -30,7 +30,7 @@ data EnterpriseLoginSubsystem m a where
     EnterpriseLoginSubsystem m ()
   GetDomainRegistrationPublic ::
     GetDomainRegistrationRequest ->
-    EnterpriseLoginSubsystem m DomainRedirect
+    EnterpriseLoginSubsystem m DomainRedirectResponse
   CreateDomainVerificationChallenge ::
     Domain ->
     EnterpriseLoginSubsystem m DomainVerificationChallenge

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1557,7 +1557,7 @@ deleteRegisteredDomain lusr tid domain = lift . liftSem $ EnterpriseLogin.delete
 getDomainRegistration ::
   (_) =>
   GetDomainRegistrationRequest ->
-  Handler r DomainRedirect
+  Handler r DomainRedirectResponse
 getDomainRegistration req =
   lift . liftSem $
     EnterpriseLogin.getDomainRegistrationPublic req


### PR DESCRIPTION
Add a flag to the response body of `POST /get-domain-registration` to indicate
whether `domain_redirect` is set to `none` due to the existence of a registered
account.

This makes it possible for clients to let a user log in with an existing cloud
account even if a redirection to an on-prem backend is set up for their domain.

https://wearezeta.atlassian.net/browse/WPB-15933

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
