### PR TITLE
Cleanup ingress classes after integration tests.

### DIFF
--- a/changelog.d/5-internal/ingress-classes
+++ b/changelog.d/5-internal/ingress-classes
@@ -1,0 +1,1 @@
+For internal CI: Cleanup nginx ingress class objects after running integration tests.

--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Script to delete any helm releases prefixed with `test-` older than 20 minutes deemed inactive
+# Script to delete any helm releases prefixed with `test-` older than 2 hours deemed inactive
+# Also deletes leftover nginx ingress classes.
 #
 # Motivation: cleanup of old test clusters that were not deleted (e.g. by the CI system, because it broke)
 
@@ -21,3 +22,5 @@ if [ -n "$releases" ]; then
 else
     echo "Nothing to clean up."
 fi
+
+"${DIR}"/integration-teardown-ingress-classes.sh

--- a/hack/bin/integration-spring-cleaning.sh
+++ b/hack/bin/integration-spring-cleaning.sh
@@ -2,6 +2,9 @@
 
 set -x
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${DIR}"/integration-teardown-ingress-classes.sh
+
 IFS=$'\n'
 for NAMESPACE in $(kubectl get namespaces | grep "^test-" | awk '{print $1}'); do
     echo "$NAMESPACE"

--- a/hack/bin/integration-teardown-federation.sh
+++ b/hack/bin/integration-teardown-federation.sh
@@ -28,4 +28,7 @@ fi
 . "$DIR/helm_overrides.sh"
 helmfile --environment "$HELMFILE_ENV" --file "${TOP_LEVEL}/hack/helmfile.yaml" destroy --skip-deps --skip-charts --concurrency 0 || echo "Failed to delete helm deployments, ignoring this failure as next steps will the destroy namespaces anyway."
 
+kubectl delete ingressclass "nginx-$NAMESPACE_1" || true
+kubectl delete ingressclass "nginx-$NAMESPACE_2" || true
+
 kubectl delete namespace "$NAMESPACE_1" "$NAMESPACE_2"

--- a/hack/bin/integration-teardown-ingress-classes.sh
+++ b/hack/bin/integration-teardown-ingress-classes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Script to delete any leftover ingress classes named `nginx-test-` older than 2 hours, which are deemed inactive
+#
+set -euo pipefail
+
+# Get the current time in seconds since the epoch
+now=$(date +%s)
+
+# Create a temporary file to store names of IngressClasses to delete
+tmpfile=$(mktemp)
+
+# List all IngressClasses, filter for names starting with "nginx-test-" and that are older than 24 hours.
+# This uses jq’s `fromdateiso8601` to convert the creationTimestamp to epoch seconds.
+kubectl get ingressclasses -o json | jq -r --argjson now "$now" '
+  .items[]
+  | select(.metadata.name | startswith("nginx-test-"))
+  | .metadata as $meta
+  | ($meta.creationTimestamp | fromdateiso8601) as $created
+  | if ($now - $created > 86400) then $meta.name else empty end
+' > "$tmpfile"
+
+if [ ! -s "$tmpfile" ]; then
+  echo "No IngressClasses older than 24 hours found for deletion."
+  rm "$tmpfile"
+  exit 0
+fi
+
+echo "Found the following IngressClasses to delete:"
+cat "$tmpfile"
+echo
+
+# Use GNU Parallel to delete the IngressClasses in batches of 20.
+parallel -j20 --line-buffer '
+  echo "Deleting IngressClass: {}"
+  kubectl delete ingressclass {}
+' < "$tmpfile"
+
+# Clean up
+rm "$tmpfile"


### PR DESCRIPTION
These objects used to linger forever, eventually exhausting etcd after many months of development.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
