### PR TITLE
feat: Alpine version bump to v3.21.3 for cassandra-migrations and cannon helm charts

### DIFF
--- a/changelog.d/5-internal/alpine-version
+++ b/changelog.d/5-internal/alpine-version
@@ -1,0 +1,1 @@
+Alpine version bump to v3.21.3 for cassandra-migrations and cannon helm charts

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       initContainers:
       - name: cannon-configurator
-        image: alpine:3.18.2
+        image: alpine:3.21.3
         {{- if eq (include "includeSecurityContext" .) "true" }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}

--- a/charts/cassandra-migrations/templates/migrate-schema.yaml
+++ b/charts/cassandra-migrations/templates/migrate-schema.yaml
@@ -166,7 +166,7 @@ spec:
 
       containers:
         - name: job-done
-          image: alpine:3.18.2
+          image: alpine:3.21.3
         {{- if eq (include "includeSecurityContext" .) "true" }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}


### PR DESCRIPTION
### Version 3.18.2:

**Security Fixes:**
- Addressed OpenSSL vulnerabilities:
- CVE-2023-1255: Potential denial of service due to excessive resource consumption.
- CVE-2023-2650: Possible buffer overrun during X.509 certificate verification.

**Source:** [Alpine 3.15.9, 3.16.6, 3.17.4, and 3.18.2 released](https://www.alpinelinux.org/posts/Alpine-3.15.9-3.16.6-3.17.4-3.18.2-released.html)

### Version 3.19.0:

**Breaking Changes:**
- OpenRC Update: Removal of the deprecated /sbin/rc binary. Ensure /etc/inittab references /sbin/openrc to maintain system initialization processes.
- iptables Backend Change: Default transition to iptables-nft. Users relying on traditional iptables should adjust configurations accordingly.
- Kernel Consolidation: Unification of linux-rpi4 and linux-rpi2 kernels into a single linux-rpi package. Raspberry Pi users should update kernel references.
- Yggdrasil Networking Update: Upgrade to version 0.5 introduces a new routing scheme incompatible with previous versions. Adjust Yggdrasil configurations as needed.
- Python Package Management: Python package directory marked as externally managed, preventing pip from installing packages into system directories managed by apk. Use pipx for installing Python packages to avoid conflicts.

**Source:** [Release Notes for Alpine 3.19.0](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.19.0)

### Version 3.20.0:

**Breaking Changes:**
- GRUB Bootloader Update: For systems using GRUB on UEFI, update the installed bootloader before rebooting to prevent boot failures due to new configurations.
- Package Renaming: The yq package has been renamed to yq-go. Transition to the new package name to ensure continued functionality.
- Redis License Change: Due to a license change to a non-free model, Redis has been replaced by Valkey in the main package repository. Migrate to Valkey to comply with licensing and maintain support.

**Security Fixes:**
Addressed OpenSSL vulnerability:
- CVE-2024-6119: Potential application crashes due to invalid memory access during certificate name checks.

**Source:** [Alpine 3.17.10, 3.18.9, 3.19.4, 3.20.3 released](https://www.alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html)



### Version 3.21.0:

**Breaking Changes:**
- OpenSSH Service Restart: Post-upgrade, the OpenSSH service will automatically restart to accept new connections. Be aware of this behavior to prevent potential disruptions.
- Firmware Compression Change: The linux-firmware package is now compressed with Zstandard (ZSTD). Ensure CONFIG_FW_LOADER_COMPRESS_ZSTD=y is enabled in custom-built kernels to support the new compression format.
- Filesystem Structure Preparation: Preparations for merging / and /usr directories have begun. Systems with these directories on separate filesystems may encounter issues. Consult the Alpine Linux wiki for detailed guidance.

**Security Fixes:**
- Addressed XZ Utils backdoor vulnerability:
- CVE-2024-3094: A backdoor in XZ Utils source code for versions 5.6.0 and 5.6.1 affected Alpine's xz package in the edge repository. The xz package was rebuilt to remove the malicious code. Users on the edge branch should upgrade to xz-5.6.1-r2 or newer.

**Source:** [Backdoor found in xz package source](https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html)


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
