### PR TITLE
feat(reaper) bump bitnami/kubectl docker image from 1.24.12 to 1.32.2

### DIFF
--- a/changelog.d/5-internal/update-kubectl-image-reaper-helm-chart
+++ b/changelog.d/5-internal/update-kubectl-image-reaper-helm-chart
@@ -1,0 +1,1 @@
+reaper helm chart: bump bitnami/kubectl docker image from 1.24.12 to 1.32.2

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               app: reaper
       containers:
       - name: reaper
-        image: bitnami/kubectl:1.24.12
+        image: bitnami/kubectl:1.32.2
         command: ["bash"]
         args:
         - -c


### PR DESCRIPTION
Ticket: https://wearezeta.atlassian.net/browse/WPB-15648

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
