### PR TITLE
WPB-16210 Allow transitioning from `no-registration` to `backend` configuration for email domain registration

### DIFF
--- a/changelog.d/3-bug-fixes/W-16210
+++ b/changelog.d/3-bug-fixes/W-16210
@@ -1,0 +1,1 @@
+Allow transition of the domain redirect value to and from `no-registration` and `backend`.


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
