### PR TITLE
Fix regex escaping in cassandra dump script

### DIFF
--- a/hack/bin/cassandra_dump_schema
+++ b/hack/bin/cassandra_dump_schema
@@ -18,7 +18,7 @@ def main():
 
     ks = []
     for line in s.splitlines():
-        ks.append(re.split('\s+', line))
+        ks.append(re.split(r'\s+', line))
 
     keyspaces = transpose(ks)
     print("-- automatically generated with `make git-add-cassandra-schema`\n")


### PR DESCRIPTION
Fix regex escaping in cassandra dump script.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
