### PR TITLE
WPB-16026 secure hold does not activate on prod with protheus only client

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-16026
+++ b/changelog.d/3-bug-fixes/WPB-16026
@@ -1,0 +1,1 @@
+Ignore MLS self conversation while requesting LH device

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -67,7 +67,7 @@ import Polysemy.Error
 import Polysemy.Input
 import Polysemy.TinyLog qualified as P
 import System.Logger.Class qualified as Log
-import Wire.API.Conversation (ConvType (..))
+import Wire.API.Conversation (ConvType (..), ConversationMetadata (..))
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Error
@@ -401,7 +401,7 @@ requestDevice lzusr tid uid = do
     disallowIfMLSUser :: Local UserId -> Sem r ()
     disallowIfMLSUser luid = do
       void $ iterateConversations luid (toRange (Proxy @500)) $ \convs -> do
-        when (any (\c -> c.convProtocol /= ProtocolProteus) convs) $ do
+        when (any (\c -> c.convMetadata.cnvmType /= SelfConv && c.convProtocol /= ProtocolProteus) convs) $ do
           throwS @'MLSLegalholdIncompatible
 
     -- Wire's LH service that galley is usually calling here is idempotent in device creation,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-16026

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
