### PR TITLE
WPB-3530 fix old SCIM users no longer found through SCIM API after IdP update

### DIFF
--- a/integration/test/API/Spar.hs
+++ b/integration/test/API/Spar.hs
@@ -99,6 +99,14 @@ createIdp user metadata = do
     & addXML (fromLT $ SAML.encode metadata)
     & addHeader "Content-Type" "application/xml"
 
+-- | https://staging-nginz-https.zinfra.io/v7/api/swagger-ui/#/default/idp-update
+updateIdp :: (HasCallStack, MakesValue user) => user -> String -> SAML.IdPMetadata -> App Response
+updateIdp user idpId metadata = do
+  req <- baseRequest user Spar Versioned $ joinHttpPath ["identity-providers", idpId]
+  submit "PUT" $ req
+    & addXML (fromLT $ SAML.encode metadata)
+    & addHeader "Content-Type" "application/xml"
+
 -- | https://staging-nginz-https.zinfra.io/v7/api/swagger-ui/#/default/idp-get-all
 getIdps :: (HasCallStack, MakesValue user) => user -> App Response
 getIdps user = do

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -436,6 +436,11 @@ registerTestIdPWithMetaWithPrivateCreds owner = do
   SampleIdP idpmeta pCreds _ _ <- makeSampleIdPMetadata
   (,(idpmeta, pCreds)) <$> createIdp owner idpmeta
 
+updateTestIdpWithMetaWithPrivateCreds :: (HasCallStack, MakesValue owner) => owner -> String -> App (Response, (SAML.IdPMetadata, SAML.SignPrivCreds))
+updateTestIdpWithMetaWithPrivateCreds owner idpId = do
+  SampleIdP idpmeta pCreds _ _ <- makeSampleIdPMetadata
+  (,(idpmeta, pCreds)) <$> updateIdp owner idpId idpmeta
+
 -- | Given a team configured with saml sso, attempt a login with valid credentials.  This
 -- function simulates client *and* IdP (instead of talking to an IdP).  It can be used to test
 -- scim-provisioned users as well as saml auto-provisioning without scim.


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
