### PR TITLE
Fix assertion in unit test

### DIFF
--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -803,8 +803,8 @@ spec = describe "UserSubsystem.Interpreter" do
               BaseProtocolMLSTag `member` (fromMaybe mempty storedUser.supportedProtocols)
                 && BaseProtocolMLSTag `notMember` newSupportedProtocols
             expected
-              | S.null newSupportedProtocols = Right defSupportedProtocols
               | mlsRemoval = Left UserSubsystemMlsRemovalNotAllowed
+              | S.null newSupportedProtocols = Right defSupportedProtocols
               | otherwise = Right newSupportedProtocols
          in actual === expected
 


### PR DESCRIPTION
This fixes a rare unit test failure introduced by #4478.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
