### PR TITLE
Upgrade Redis to latest

### DIFF
--- a/changelog.d/5-internal/redis-upgrade
+++ b/changelog.d/5-internal/redis-upgrade
@@ -1,0 +1,1 @@
+Upgrade redis chart, make use of redis 7.x

--- a/charts/redis-ephemeral/requirements.yaml
+++ b/charts/redis-ephemeral/requirements.yaml
@@ -1,5 +1,6 @@
 dependencies:
 - name: redis
-  version: 16.11.3 # redis 6.2.7
+  version: 20.11.3 # redis 7.4.2
   repository: https://charts.bitnami.com/bitnami
   alias: redis-ephemeral
+


### PR DESCRIPTION
Upgrade redis to latest helm chart (and to redis 7)

https://wearezeta.atlassian.net/browse/WPB-16438

From the trivy report of the image, this decreases the CVE count:

```diff
-bitnami/redis:6.2.7-debian-11-r0 (debian 11.3)
+bitnami/redis:7.4.2-debian-12-r4 (debian 12.10)
 
-Total: 325 (UNKNOWN: 1, LOW: 112, MEDIUM: 118, HIGH: 72, CRITICAL: 22)
+Total: 92 (UNKNOWN: 0, LOW: 68, MEDIUM: 19, HIGH: 4, CRITICAL: 1)
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
