### PR TITLE
charts/reaper: fix unwanted cannon restart bug

### DIFF
--- a/changelog.d/3-bug-fixes/reaper-error-handling
+++ b/changelog.d/3-bug-fixes/reaper-error-handling
@@ -1,0 +1,1 @@
+Fix issue with the (redis/cannon) reaper chart, which was sometimes killing cannon pods for no good reasons during transient networking errors.

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -1,5 +1,16 @@
-reaper
+Reaper
 ------
 
-Due to the nature of pods and their ephemerality, there might be situations where a redis pod is restarted.
-In such cases, clients will have stale connections and will not receive any messages; this reaper will check that the `redis-ephemeral` pod is older than any other `cannon`; if that is not the case, it kills the `cannon`s forcing clients to reconnect.
+This pod is useful in the following scenario: You run wire-server alongside a single
+redis-ephemeral (part of databases-ephemeral). If you have a different setup for redis,
+do not use this chart.
+
+Due to the nature of pods and their ephemerality, there might be situations where a
+redis-ephemeral pod is restarted. In such cases, wire clients will have stale
+connections (they will have an active websocket connection, but gundeck (responsible for
+sending messages) will be unaware of this (as the record of who is connected where is
+gone with a redis-ephemeral restart). So these stale clients will not receive any
+messages. Here, this reaper will check that the `redis-ephemeral` pod is older than any
+other `cannon`; if that is not the case, it kills the `cannon`s forcing clients to
+reconnect.
+

--- a/charts/reaper/scripts/reaper.sh
+++ b/charts/reaper/scripts/reaper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# See the readme of the reaper chart.
+
+# we loop forever, and on transient errors sleep and try again.
+# setting -e would crash the pod on transient e.g. network errors, which isn't useful.
+set -uo pipefail
+
+USAGE="$0 <NAMESPACE>"
+NAMESPACE="${1:?$USAGE}"
+
+echo "Using namespace: $NAMESPACE"
+
+kill_all_cannons() {
+  echo "Killing all cannons"
+  CANNON_PODS=$(kubectl -n "$NAMESPACE" get pods 2>/dev/null \
+    | grep -e "cannon" \
+    | awk '{ print $1 }') || {
+    echo "Failed to list cannon pods. Skipping this iteration..."
+    return
+  }
+
+  while IFS= read -r cannon; do
+    if [ -n "$cannon" ]; then
+      echo "Deleting $cannon"
+      # If a single delete fails, we skip it but keep going.
+      kubectl -n "$NAMESPACE" delete pod "$cannon" || {
+        echo "Failed to delete pod $cannon, crash reaper and try again"
+        exit 1
+      }
+    fi
+  done <<< "$CANNON_PODS"
+}
+
+while true; do
+  # Gather all pods that contain "cannon" or "redis-ephemeral", sorted by creation time
+  ALL_PODS=$(kubectl -n "$NAMESPACE" get pods --sort-by=.metadata.creationTimestamp 2>/dev/null \
+    | grep -e "cannon" -e "redis-ephemeral") || {
+      echo "Failed to list pods. Skipping this iteration..."
+      sleep 60
+      continue
+  }
+
+  # Check if we have any cannon pods at all
+  if ! echo "$ALL_PODS" | grep -q "cannon"; then
+    echo "No cannon pods found. Doing nothing..."
+    sleep 60
+    continue
+  fi
+
+  # Check if we have any redis-ephemeral pods at all
+  if ! echo "$ALL_PODS" | grep -q "redis-ephemeral"; then
+    echo "No redis-ephemeral pod found. Doing nothing..."
+    sleep 60
+    continue
+  fi
+
+  # At this point, we have both cannon and redis-ephemeral pods in ALL_PODS
+  # Check which is oldest
+  FIRST_POD=$(echo "$ALL_PODS" | head -n 1 | awk '{ print $1 }')
+
+  if [ -z "$FIRST_POD" ]; then
+    echo "Could not determine the oldest pod from the list. Doing nothing..."
+    sleep 60
+    continue
+  fi
+
+  if [[ "$FIRST_POD" =~ "redis-ephemeral" ]]; then
+    echo "redis-ephemeral is the oldest pod, all good."
+  else
+    kill_all_cannons
+  fi
+
+  echo "Sleep 1"
+  sleep 1
+done
+

--- a/charts/reaper/templates/configmap.yaml
+++ b/charts/reaper/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reaper-script
+  labels:
+    app: reaper
+data:
+  reaper.sh: |-
+    {{- .Files.Get "scripts/reaper.sh" | nindent 4 }}
+

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -28,29 +28,19 @@ spec:
             matchLabels:
               app: reaper
       containers:
-      - name: reaper
-        image: bitnami/kubectl:1.32.2
-        command: ["bash"]
-        args:
-        - -c
-        - |
-          NAMESPACE={{ .Release.Namespace }}
-          kill_all_cannons() {
-              echo "Killing all cannons"
-              while IFS= read -r cannon
-              do
-                  echo "Killing $cannon"
-                  kubectl -n "$NAMESPACE" delete pod "$cannon"
-              done < <(kubectl -n "$NAMESPACE" get pods | grep -e "cannon" | awk '{ print $1 }')
-          }
+        - name: reaper
+          image: bitnami/kubectl:1.32.2
+          command: ["/app/reaper.sh", "{{ .Release.Namespace }}"]
+          volumeMounts:
+            - name: reaper-script
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: reaper-script
+          configMap:
+            name: reaper-script
+            defaultMode: 0755
+            items:
+              - key: reaper.sh
+                path: reaper.sh
 
-          while true
-          do
-              FIRST_POD=$(kubectl -n "$NAMESPACE" get pods --sort-by=.metadata.creationTimestamp | grep -e "cannon" -e "redis-ephemeral" | head -n 1 | awk '{ print $1 }')
-              if [[ "$FIRST_POD" =~ "redis-ephemeral" ]];
-                  then echo "redis-ephemeral is the oldest pod, all good"
-                  else kill_all_cannons
-              fi
-              echo 'Sleeping 1 seconds'
-              sleep 1
-          done


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-16521

Fix issue with the (redis/cannon) reaper chart, which was sometimes killing cannon pods for no good reasons during transient networking errors.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
