### PR TITLE
Upgrade ingress-nginx chart

### DIFF
--- a/charts/ingress-nginx-controller/Chart.yaml
+++ b/charts/ingress-nginx-controller/Chart.yaml
@@ -4,5 +4,5 @@ name: ingress-nginx-controller
 version: 0.0.42
 dependencies:
 - name: ingress-nginx
-  version: 4.5.2 # k8s compatibility [1.23 - 1.26]
+  version: 4.11.5 # k8s compatibility [1.26 - 1.30]
   repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/ingress-nginx-controller/values.yaml
+++ b/charts/ingress-nginx-controller/values.yaml
@@ -56,3 +56,4 @@ ingress-nginx:
       # Also add ssl/tls protocol/cipher to gain some observability here (can we turn off TLS 1.2?)
       log-format-escape-json: true
       log-format-upstream: '{"bytes_sent": "$bytes_sent", "duration": "$request_time", "http_referrer": "$http_referer", "http_user_agent": "$http_user_agent", "method": "$request_method", "path": "$uri", "remote_addr": "$proxy_protocol_addr", "remote_user": "$remote_user", "request_id": "$req_id", "request_length": "$request_length", "request_proto": "$server_protocol", "request_time": "$request_time", "status": "$status", "time": "$time_iso8601", "tls_cipher": "$ssl_cipher", "tls_protocol": "$ssl_protocol", "vhost": "$host", "x_forwarded_for": "$proxy_add_x_forwarded_for"}'
+    allowSnippetAnnotations: true


### PR DESCRIPTION
Upgrade ingress-nginx chart to the same version used in kube-ci.

## Checklist

 - [x] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
