### PR TITLE
[WPB-16535] emulate saml idp-initiated login

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-16535-emulate-saml-idp-initiated-login
+++ b/changelog.d/3-bug-fixes/WPB-16535-emulate-saml-idp-initiated-login
@@ -1,0 +1,1 @@
+Emulate IdP-initiated login with a redirect.

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -473,7 +473,7 @@ loginWithSamlWithZHost mbZHost domain expectSuccess tid email (iid, (meta, privc
   let nameId = fromRight (error "could not create name id") $ SAML.emailNameID (cs email)
       spMetaData = toSPMetaData spmeta.body
       parsedAuthnReq = parseAuthnReqResp authnreq.body
-  authnReqResp <- makeAuthnResponse nameId privcreds idpConfig spMetaData parsedAuthnReq
+  authnReqResp <- makeAuthnResponse nameId privcreds idpConfig spMetaData (Just parsedAuthnReq)
   mUid <- finalizeSamlLoginWithZHost domain mbZHost tid authnReqResp `bindResponse` validateLoginResp
   pure (mUid, authnReqResp)
   where

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/SP.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/SP.hs
@@ -303,7 +303,7 @@ foldJudge (toList -> assertions) = do
 
 judge1 :: (HasCallStack, MonadJudge m, SP m, SPStore m) => Assertion -> m AccessVerdict
 judge1 assertion = do
-  inRespTo <- either (giveup . DeniedBadInResponseTos) pure $ assertionToInResponseTo assertion
+  inRespTo <- either (const . giveup . DeniedNoInResponseTo $ assertion ^. assIssuer) pure $ assertionToInResponseTo assertion
   checkInResponseTo "response" (assertion ^. assIssuer) inRespTo
   verdict <- checkAssertion assertion
   unStoreRequest inRespTo

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/SP.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/SP.hs
@@ -303,7 +303,7 @@ foldJudge (toList -> assertions) = do
 
 judge1 :: (HasCallStack, MonadJudge m, SP m, SPStore m) => Assertion -> m AccessVerdict
 judge1 assertion = do
-  inRespTo <- either (const . giveup . DeniedNoInResponseTo $ assertion ^. assIssuer) pure $ assertionToInResponseTo assertion
+  inRespTo <- either (const $ giveup DeniedNoInResponseTo) pure $ assertionToInResponseTo assertion
   checkInResponseTo "response" (assertion ^. assIssuer) inRespTo
   verdict <- checkAssertion assertion
   unStoreRequest inRespTo

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/Types.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/Types.hs
@@ -228,6 +228,7 @@ data DeniedReason
   = DeniedStatusFailure
   | DeniedBadUserRefs {deniedDetails :: String}
   | DeniedBadInResponseTos {deniedDetails :: String}
+  | DeniedNoInResponseTo {idpIssuer :: Issuer}
   | DeniedAssertionIssueInstantNotInPast {deniedTimestamp :: Time, deniedNow :: Time}
   | DeniedAuthnStatementIssueInstantNotInPast {deniedTimestamp :: Time, deniedNow :: Time}
   | DeniedBadRecipient {deniedWeExpected :: String, deniedTheyExpected :: String}

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/Types.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/Types.hs
@@ -228,7 +228,7 @@ data DeniedReason
   = DeniedStatusFailure
   | DeniedBadUserRefs {deniedDetails :: String}
   | DeniedBadInResponseTos {deniedDetails :: String}
-  | DeniedNoInResponseTo {idpIssuer :: Issuer}
+  | DeniedNoInResponseTo
   | DeniedAssertionIssueInstantNotInPast {deniedTimestamp :: Time, deniedNow :: Time}
   | DeniedAuthnStatementIssueInstantNotInPast {deniedTimestamp :: Time, deniedNow :: Time}
   | DeniedBadRecipient {deniedWeExpected :: String, deniedTheyExpected :: String}

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/XML.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/XML.hs
@@ -196,6 +196,9 @@ explainDeniedReason = \case
   DeniedStatusFailure -> "status: failure"
   DeniedBadUserRefs msg -> "bad user refs: " <> cs msg
   DeniedBadInResponseTos msg -> "bad InResponseTo attribute(s): " <> cs msg
+  DeniedNoInResponseTo _issuer ->
+    -- this can be turned into a redirect to simulate idp-initiated login.
+    "authentication response without authentication request ID"
   DeniedAssertionIssueInstantNotInPast ts now ->
     "IssueInstant in Assertion must be older than "
       <> renderTime now

--- a/libs/saml2-web-sso/src/SAML2/WebSSO/XML.hs
+++ b/libs/saml2-web-sso/src/SAML2/WebSSO/XML.hs
@@ -196,7 +196,7 @@ explainDeniedReason = \case
   DeniedStatusFailure -> "status: failure"
   DeniedBadUserRefs msg -> "bad user refs: " <> cs msg
   DeniedBadInResponseTos msg -> "bad InResponseTo attribute(s): " <> cs msg
-  DeniedNoInResponseTo _issuer ->
+  DeniedNoInResponseTo ->
     -- this can be turned into a redirect to simulate idp-initiated login.
     "authentication response without authentication request ID"
   DeniedAssertionIssueInstantNotInPast ts now ->

--- a/libs/saml2-web-sso/test/Test/SAML2/WebSSO/APISpec.hs
+++ b/libs/saml2-web-sso/test/Test/SAML2/WebSSO/APISpec.hs
@@ -195,7 +195,7 @@ spec = describe "API" $ do
             spiss <- defSPIssuer
             authnreq :: AuthnRequest <- createAuthnRequest 3600 spiss (testIdPConfig ^. idpMetadata . edIssuer)
             fromSignedAuthnResponse
-              <$> (if badTimeStamp then timeTravel 1800 else id) (mkAuthnResponse privkey testIdPConfig spmeta authnreq True)
+              <$> (if badTimeStamp then timeTravel 1800 else id) (mkAuthnResponse privkey testIdPConfig spmeta (Just authnreq) True)
           postHtmlForm "/authresp" [("SAMLResponse", cs . EL.encode . renderLBS def $ aresp)]
 
     let testAuthRespApp :: IO CtxV -> SpecWith (CtxV, Application) -> Spec
@@ -217,7 +217,7 @@ spec = describe "API" $ do
               spmeta :: SPMetadata <- mkTestSPMetadata
               spiss <- defSPIssuer
               authnreq :: AuthnRequest <- createAuthnRequest 3600 spiss (testIdPConfig ^. idpMetadata . edIssuer)
-              aresp <- fromSignedAuthnResponse <$> mkAuthnResponse privkey testIdPConfig spmeta authnreq True
+              aresp <- fromSignedAuthnResponse <$> mkAuthnResponse privkey testIdPConfig spmeta (Just authnreq) True
               timestamp <- getNow
               pure (aresp, authnreq, idpEntry, timestamp)
 
@@ -268,7 +268,7 @@ spec = describe "API" $ do
           spiss <- defSPIssuer
           createAuthnRequest 3600 spiss idpiss
       SignedAuthnResponse authnrespDoc <-
-        ioFromTestSP ctx $ mkAuthnResponse privcert testIdPConfig spmeta authnreq True
+        ioFromTestSP ctx $ mkAuthnResponse privcert testIdPConfig spmeta (Just authnreq) True
       parseFromDocument @AuthnResponse authnrespDoc `shouldSatisfy` isRight
     let check :: (HasCallStack) => Bool -> (Either SomeException () -> Bool) -> IO ()
         check certIsGood expectation = do
@@ -284,7 +284,7 @@ spec = describe "API" $ do
             spissuer :: Issuer <- defSPIssuer
             authnreq <- createAuthnRequest 3600 spissuer idpissuer
             SignedAuthnResponse authnrespDoc <-
-              liftIO . ioFromTestSP ctx $ mkAuthnResponse privkey (idpcfg ^. _1) spmeta authnreq True
+              liftIO . ioFromTestSP ctx $ mkAuthnResponse privkey (idpcfg ^. _1) spmeta (Just authnreq) True
             let authnrespLBS = renderLBS def authnrespDoc
             creds <- issuerToCreds (Just idpissuer) Nothing
             void $ simpleVerifyAuthnResponse creds authnrespLBS

--- a/libs/saml2-web-sso/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
+++ b/libs/saml2-web-sso/test/Test/SAML2/WebSSO/XML/ExamplesSpec.hs
@@ -86,7 +86,7 @@ spec = describe "XML serialization" $ do
             createAuthnRequest 3600 spiss idpiss
           SignedAuthnResponse doc <-
             ioFromTestSP ctx $
-              mkAuthnResponseWithRawSubj nameId sampleIdPPrivkey testIdPConfig spmeta authnreq True
+              mkAuthnResponseWithRawSubj nameId sampleIdPPrivkey testIdPConfig spmeta (Just authnreq) True
           let parsed :: Either String AuthnResponse = parseFromDocument @AuthnResponse doc
           case expectedsubj of
             Nothing -> do

--- a/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
@@ -120,7 +120,7 @@ type APIAuthResp =
     ( "finalize-login"
         :> Capture "team" TeamId
         -- (SAML.APIAuthResp from here on, except for response)
-        :> MultipartForm Mem SAML.AuthnResponseBody
+        :> MultipartForm Mem SAML.AuthnResponseBody -- this is the *http request* body containing the *saml response*.
         :> ZHostOpt
         :> Post '[PlainText] Void
     )

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -377,14 +377,58 @@ authresp mbtid arbody mbHost = do
   logErrors $ SAML2.authResp mbtid iss rsp go arbody
   where
     go :: NonEmpty SAML.Assertion -> IdP -> SAML.AccessVerdict -> Sem r Void
+    go _assertions idp (SAML.AccessDenied (shouldRedirectToInit -> True)) = do
+      -- redirect back to idp for idp-initiated login.
+      redirectToInit idp
     go assertions verdict idp = do
+      -- handle the verdict
       SAML.ResponseVerdict result <- verdictHandler assertions idp verdict
       throw @SparError $ SAML.CustomServant result
 
+    -- Whenever at least one of the denied reasons is `DeniedNoInResponseTo`, try again.
+    -- there may be other reasons that will make the redirect less likely to result in a
+    -- positive authentication, but better be lenient wrt what the IdP sends us here, it is
+    -- about to get thrown away anyway.
+    shouldRedirectToInit :: [SAML.DeniedReason] -> Bool
+    shouldRedirectToInit = any (\case SAML.DeniedNoInResponseTo _ -> True; _ -> False)
+
+    redirectToInit :: IdP -> Sem r Void
+    redirectToInit idp = do
+      throw (SAML.CustomError (SparRequestMissingTryIdpInitiatedLogin initiateLoginEndPointText))
+      where
+        -- FUTUREWORK: success_url and error_url (used to distinguish between mobile and web)
+        -- are missing in this flow.  maybe the mobile browser can start app.wire.com, and
+        -- app.wire.com finds the app for us?  server-side solutions probably exist, but are
+        -- likely to make everything more complicated, both now and in the long run.  see
+        -- `APIAuthReq` route.
+        success_url = Nothing
+        error_url = Nothing
+
+        initiateLoginEndPoint :: URI
+        initiateLoginEndPoint =
+          ( safeLink'
+              linkURI
+              (Proxy @SparAPI)
+              (Proxy @("sso" :> "initiate-login" :> APIAuthReq))
+          )
+            success_url
+            error_url
+            (idp ^. SAML.idpId)
+
+        initiateLoginEndPointText :: T.Text
+        initiateLoginEndPointText =
+          T.pack ("/" <> uriPath initiateLoginEndPoint <> uriQuery initiateLoginEndPoint)
+
     logErrors :: Sem r Void -> Sem r Void
     logErrors action = catch @SparError action $ \case
-      e@(SAML.CustomServant _) -> throw e
+      e@(SAML.CustomServant _) ->
+        -- this is where the "you're ok, please come in" redirect response is coming from
+        throw e
+      e@(SAML.CustomError (SparRequestMissingTryIdpInitiatedLogin _)) -> do
+        -- redirect to /sso/initiate-login
+        throw e
       e -> do
+        -- something went wrong, log and fail
         throw @SparError
           . SAML.CustomServant
           $ errorPage

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -390,7 +390,7 @@ authresp mbtid arbody mbHost = do
     -- positive authentication, but better be lenient wrt what the IdP sends us here, it is
     -- about to get thrown away anyway.
     shouldRedirectToInit :: [SAML.DeniedReason] -> Bool
-    shouldRedirectToInit = any (\case SAML.DeniedNoInResponseTo _ -> True; _ -> False)
+    shouldRedirectToInit = any (\case SAML.DeniedNoInResponseTo -> True; _ -> False)
 
     redirectToInit :: IdP -> Sem r Void
     redirectToInit idp = do

--- a/services/spar/test-integration/Test/Spar/AppSpec.hs
+++ b/services/spar/test-integration/Test/Spar/AppSpec.hs
@@ -168,7 +168,7 @@ requestAccessVerdict idp isGranted mkAuthnReq = do
       (SAML.FormRedirect _ req) -> do
         SAML.SignedAuthnResponse (XML.Document _ el _) <-
           runSimpleSP $
-            SAML.mkAuthnResponseWithSubj subject privKey idp spmeta req True
+            SAML.mkAuthnResponseWithSubj subject privKey idp spmeta (Just req) True
         either (error . show) pure $ SAML.parse [XML.NodeElement el]
   let verdict =
         if isGranted

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1076,7 +1076,7 @@ createViaSamlResp idp privCreds (SAML.UserRef _ subj) = do
   spmeta <- getTestSPMetadata tid
   authnResp <-
     runSimpleSP $
-      SAML.mkAuthnResponseWithSubj subj privCreds idp spmeta authnReq True
+      SAML.mkAuthnResponseWithSubj subj privCreds idp spmeta (Just authnReq) True
   submitAuthnResponse tid authnResp <!! const 200 === statusCode
 
 createViaSamlFails :: (HasCallStack) => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar ()

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -823,7 +823,7 @@ tryLogin privkey idp userSubject = do
   let tid = idp ^. idpExtraInfo . team
   spmeta <- getTestSPMetadata tid
   (_, authnreq) <- call $ callAuthnReq (env ^. teSpar) (idp ^. SAML.idpId)
-  idpresp <- runSimpleSP $ mkAuthnResponseWithSubj userSubject privkey idp spmeta authnreq True
+  idpresp <- runSimpleSP $ mkAuthnResponseWithSubj userSubject privkey idp spmeta (Just authnreq) True
   sparresp <- submitAuthnResponse tid idpresp
   liftIO $ do
     statusCode sparresp `shouldBe` 200
@@ -838,7 +838,7 @@ tryLoginFail privkey idp userSubject bodyShouldContain = do
   let tid = idp ^. idpExtraInfo . team
   spmeta <- getTestSPMetadata tid
   (_, authnreq) <- call $ callAuthnReq (env ^. teSpar) (idp ^. SAML.idpId)
-  idpresp <- runSimpleSP $ mkAuthnResponseWithSubj userSubject privkey idp spmeta authnreq True
+  idpresp <- runSimpleSP $ mkAuthnResponseWithSubj userSubject privkey idp spmeta (Just authnreq) True
   sparresp <- submitAuthnResponse tid idpresp
   liftIO $ do
     let bdy = maybe "" (cs @LByteString @String) (responseBody sparresp)
@@ -919,7 +919,7 @@ loginCreatedSsoUser nameid idp privCreds = do
   let tid = idp ^. idpExtraInfo . team
   authnReq <- negotiateAuthnRequest idp
   spmeta <- getTestSPMetadata tid
-  authnResp <- runSimpleSP $ mkAuthnResponseWithSubj nameid privCreds idp spmeta authnReq True
+  authnResp <- runSimpleSP $ mkAuthnResponseWithSubj nameid privCreds idp spmeta (Just authnReq) True
   sparAuthnResp <- submitAuthnResponse tid authnResp
 
   let wireCookie = fromMaybe (error (show sparAuthnResp)) . lookup "Set-Cookie" $ responseHeaders sparAuthnResp


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-16535

before:

```
$ make ci-safe package=integration TEST_INCLUDE=testSparIdPInitiatedLogin
[...]
----- Spar.testSparIdPInitiatedLogin FAIL (0.74 s) -----
assertion failure:
Actual:
400
Expected:
303

call stack:
1. assertFailure at test/Testlib/Assertions.hs:102
     assertFailure $ (maybe "" (<> "\n") msg) <> "Actual:\n" <> pa <> "\nExpected:\n" <> pb <> diff

2. shouldMatchWithMsg at test/Testlib/Assertions.hs:71
     shouldMatch = shouldMatchWithMsg Nothing

3. shouldMatch at test/Testlib/Assertions.hs:198
     shouldMatchInt = shouldMatch

4. shouldMatchInt at test/Test/Spar.hs:382
     resp.status `shouldMatchInt` 303



request:
POST http://127.0.0.1:8088/v9/sso/finalize-login/07e50c4f-c1db-4ccc-9e63-32b9da884c14
request headers:
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryoa60QRvjlfQ4BYje
Z-Connection: conn
Z-User: example.com
response status: 400
response headers:
Transfer-Encoding: chunked
Date: Wed, 02 Apr 2025 14:21:23 GMT
Server: Warp/3.4.2
Cache-Control: no-cache, no-store
Pragma: no-cache
Content-Type: text/html
response body:
<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
  <title>wire:sso:error:server-error-unsupported-saml</title>
</head>
</body>
  sorry, something went wrong :(<br>
  please copy the following debug information to your clipboard and provide it when opening an issue in our customer support.<br><br>
  <pre>KEN1c3RvbUVycm9yIChTcGF[..]</pre>
</body></html>
[...]

1 failed test:
 - Spar.testSparIdPInitiatedLogin
```

after:

```
$ make ci-safe package=integration TEST_INCLUDE=testSparIdPInitiatedLogin
[...]

Spar.testSparIdPInitiatedLogin OK (0.70 s)
```


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
