### PR TITLE
Make minio-ingress multi-ingress ready

### DIFF
--- a/changelog.d/3-bug-fixes/multi-ingress_minio-ingress
+++ b/changelog.d/3-bug-fixes/multi-ingress_minio-ingress
@@ -1,0 +1,3 @@
+When `fakeS3` is enabled, `nginx-ingress-services` creates an ingress for
+Minio. This ingress' name is now configurable to allow multiple of them
+("multi-ingress".)

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -109,6 +109,21 @@ nginx-ingress-{{ .Values.ingressName }}
 {{- end -}}
 
 {{/*
+Name of the minio ingress. Extracted as helper to reduce the complexity in the template
+itself. The default name is 'minio-ingress' for backwards compatibility (it has
+been this name in previous versions.)
+Why do we need to be able to change this name? For multi-ingress setups, we'll
+have multiple of these ingresses (which need unique names).
+*/}}
+{{- define "nginx-ingress-services.getMinioIngressName" -}}
+{{- if (eq .Values.ingressName "") -}}
+minio-ingress
+{{- else -}}
+minio-ingress-{{ .Values.ingressName }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Name of the certificate 'Issuer'. Especially, used in 'issuerRef's.
 In multi-domain backends (multi-ingress), the 'ingressName' is used as postfix
 of the name to ensure that certificates aren't accidentally all issued by the

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -111,7 +111,7 @@ nginx-ingress-{{ .Values.ingressName }}
 {{/*
 Name of the minio ingress. Extracted as helper to reduce the complexity in the template
 itself. The default name is 'minio-ingress' for backwards compatibility (it has
-been this name in previous versions.)
+been this name since version 5.7.0.)
 Why do we need to be able to change this name? For multi-ingress setups, we'll
 have multiple of these ingresses (which need unique names).
 */}}

--- a/charts/nginx-ingress-services/templates/ingress_minio.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_minio.yaml
@@ -7,7 +7,7 @@
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: minio-ingress
+  name: {{ include "nginx-ingress-services.getMinioIngressName" . | quote }}
   annotations:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"


### PR DESCRIPTION
When `fakeS3` is enabled, `nginx-ingress-services` creates an ingress for Minio. This ingress' name is now configurable to allow multiple of them("multi-ingress".)

Ticket: https://wearezeta.atlassian.net/browse/WPB-16855

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
