### PR TITLE
Disallow duplicate clients in MLS groups

### DIFF
--- a/changelog.d/3-bug-fixes/mls-duplicate-client
+++ b/changelog.d/3-bug-fixes/mls-duplicate-client
@@ -1,0 +1,1 @@
+Prevent duplicate clients from being added to a conversation

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -875,15 +875,14 @@ testInternalCommitDuplicateClient = do
   replicateM_ 2 $ uploadNewKeyPackage def alice2
   void $ createAddCommit alice1 convId [alice] >>= sendAndConsumeCommitBundle
 
-  void $ do
-    -- wipe key store
-    setClientGroupState alice2 def
-    (kp, _) <- generateKeyPackage alice2 def
+  -- wipe key store
+  setClientGroupState alice2 def
+  (kp, _) <- generateKeyPackage alice2 def
 
-    -- We cannot upload the new key package at this point, because the
-    -- signature key won't match. However, alice1 can still use it to craft an
-    -- add proposal.
-    mp <- createAddCommitWithKeyPackages alice1 convId [(alice2, kp)]
-    bindResponse (postMLSCommitBundle alice1 (mkBundle mp)) $ \resp -> do
-      resp.status `shouldMatchInt` 400
-      resp.json %. "label" `shouldMatch` "mls-protocol-error"
+  -- We cannot upload the new key package at this point, because the
+  -- signature key won't match. However, alice1 can still use it to craft an
+  -- add proposal.
+  mp <- createAddCommitWithKeyPackages alice1 convId [(alice2, kp)]
+  bindResponse (postMLSCommitBundle alice1 (mkBundle mp)) $ \resp -> do
+    resp.status `shouldMatchInt` 400
+    resp.json %. "label" `shouldMatch` "mls-protocol-error"

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -108,7 +108,11 @@ getExternalCommitData senderIdentity lConvOrSub epoch commit = do
         | cid /= senderIdentity ->
             throw $ mlsProtocolError "Only the self client can be removed by an external commit"
         | otherwise -> pure (Just idx)
-      [] -> pure Nothing
+      [] -> do
+        -- no remove proposal, make sure the client is not already part of the conversation
+        when (isJust (cmLookupIndex senderIdentity convOrSub.members)) $
+          throw (mlsProtocolError "External commits for existing members must contain a Remove proposal")
+        pure Nothing
       _ -> throw (mlsProtocolError "External commits must contain at most one Remove proposal")
 
     -- add sender client

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -155,8 +155,15 @@ processInternalCommit senderIdentity con lConvOrSub ciphersuite ciphersuiteUpdat
               fmap catMaybes . forM newUserClients $
                 \(qtarget, newclients) -> case Map.lookup qtarget cm of
                   -- user is already present, skip check in this case
-                  Just _ -> do
-                    -- new user
+                  Just existingClients -> do
+                    -- make sure none of the new clients already exist in the group
+                    when
+                      ( any
+                          (`Map.member` existingClients)
+                          (Map.keys newclients)
+                      )
+                      $ throw
+                        (mlsProtocolError "Cannot add a client that is already part of the group")
                     pure Nothing
                   Nothing -> do
                     -- final set of clients in the conversation


### PR DESCRIPTION
This is a first step to safeguard against broken clients that sometimes operate with new credentials without registering a new client to the backend. We simply check that duplicate clients are never introduced in group, either with internal or external commits.

Checking that the signature key of new leaf nodes always matches the one registered with the backend will be in a followup PR.

https://wearezeta.atlassian.net/browse/WPB-16786

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
