### PR TITLE
fix(redis-ephemeral): bump to 6.2.16

### DIFF
--- a/changelog.d/5-internal/redis-6.2.16
+++ b/changelog.d/5-internal/redis-6.2.16
@@ -1,0 +1,1 @@
+Bump redis version used by redis-ephemeral to 6.2.16

--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -1,4 +1,6 @@
 redis-ephemeral:
+  image:
+    tag: 6.2.16
   # We use a single node redis for now.
   architecture: standalone
   auth:


### PR DESCRIPTION
related to WPB-15658 - we did bump the Helm chart, but it didn't contain the latest available image.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
