### PR TITLE
Remove sub-second precision from UTCTime

### DIFF
--- a/changelog.d/3-bug-fixes/utctime-subseconds
+++ b/changelog.d/3-bug-fixes/utctime-subseconds
@@ -1,0 +1,1 @@
+The precision below the level of seconds has been removed from UTCTime.

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -130,7 +130,7 @@ showUTCTimeMillis :: UTCTimeMillis -> Text
 showUTCTimeMillis = Text.pack . formatTime defaultTimeLocale "%FT%T.%03qZ" . fromUTCTimeMillis
 
 showUTCTime :: UTCTime -> Text
-showUTCTime = Text.pack . formatTime defaultTimeLocale "%FT%T%QZ"
+showUTCTime = Text.pack . formatTime defaultTimeLocale "%FT%TZ"
 
 readUTCTimeMillis :: String -> Maybe UTCTimeMillis
 readUTCTimeMillis = fmap toUTCTimeMillis . parseTimeM True defaultTimeLocale formatUTCTimeMillis


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
