### PR TITLE
WPB-16953 Only one conversation-creation notification should be forwarded to pydio

### DIFF
--- a/integration/test/Test/Cells.hs
+++ b/integration/test/Test/Cells.hs
@@ -75,6 +75,24 @@ testCellsCreationEvent = do
   event %. "conversation" `shouldMatch` (conv %. "id")
   event %. "qualified_from" `shouldMatch` (alice %. "qualified_id")
 
+  assertNoMessage q
+
+testCellsCreationEventIsSentOnlyOnce :: (HasCallStack) => App ()
+testCellsCreationEventIsSentOnlyOnce = do
+  -- start watcher before creating conversation
+  q0 <- watchCellsEvents def
+  (alice, tid, members) <- createTeam OwnDomain 2
+  conv <- postConversation alice defProteus {team = Just tid, cells = True, qualifiedUsers = members} >>= getJSON 201
+
+  let q = q0 {filter = isNotifConv conv} :: QueueConsumer
+
+  event <- getMessage q %. "payload.0"
+  event %. "type" `shouldMatch` "conversation.create"
+  event %. "conversation" `shouldMatch` (conv %. "id")
+  event %. "qualified_from" `shouldMatch` (alice %. "qualified_id")
+
+  assertNoMessage q
+
 testCellsFeatureCheck :: (HasCallStack) => App ()
 testCellsFeatureCheck = do
   (alice, tid, _) <- createTeam OwnDomain 1


### PR DESCRIPTION
git checkout -b WPB-16953-only-one-conversation-creation-notification-should-be-forwarded-to-pydio

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
