### PR TITLE
Use patched version of servant 0.20.2

### DIFF
--- a/changelog.d/3-bug-fixes/fix-servant-streaming
+++ b/changelog.d/3-bug-fixes/fix-servant-streaming
@@ -1,0 +1,4 @@
+Lazy streams were broken due to
+https://github.com/haskell-servant/servant/pull/1781 . So, in specific cases,
+the playload of a streamed response was realised in the application's memory
+instead of streaming it piecewise.

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -207,6 +207,19 @@ let
       };
     };
 
+    # Replace this with upstream once > 0.20.2 has been released.
+    servant = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/servant";
+        rev = "fa8271564ebd9dff22de84aa77a687c89398a612";
+        hash = "sha256-9g3tEfHCtGyA+w4HAy6H36IyIUnDPmfJHAxCswJEVSQ=";
+      };
+      packages = {
+        servant = "servant";
+        servant-server = "servant-server";
+      };
+    };
+
     # we need HEAD, the latest release is too old
     postie = {
       src = fetchgit {


### PR DESCRIPTION
Streams were broken upstream due to https://github.com/haskell-servant/servant/pull/1781

Ticket: https://wearezeta.atlassian.net/browse/WPB-17171

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
