### PR TITLE
Fix DNS hostname in federation-v1 config

### DIFF
--- a/deploy/dockerephemeral/federation-v1/federator.yaml
+++ b/deploy/dockerephemeral/federation-v1/federator.yaml
@@ -25,5 +25,5 @@ optSettings:
   clientCertificate: "/etc/wire/federator/conf/integration-leaf.pem"
   clientPrivateKey: "/etc/wire/federator/conf/integration-leaf-key.pem"
   tcpConnectionTimeout: 5000000
-  dnsHost: 172.20.1.3
+  dnsHost: 172.20.1.4
   dnsPort: 53


### PR DESCRIPTION
Fix copy-paste mistake in the configuration of federator-v1 for the local test environment. This prevented federation v1 from being able to run without federation-v0 being present as well.

## Checklist

 - [x] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
