### PR TITLE
WPB-16875 Team admin creates a channel without joining - follow up

### DIFF
--- a/changelog.d/2-features/WBP-16875
+++ b/changelog.d/2-features/WBP-16875
@@ -1,1 +1,1 @@
-Team admins can create a channel without joining
+Team admins can create a channel without joining (#4527, #4553)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -69,26 +69,6 @@ instance
   fromUnion (S (Z (I x))) = GroupConversationCreatedV8 x
   fromUnion (S (S x)) = case x of {}
 
--- | A type similar to 'ResponseForExistedCreated' introduced to allow for a failure
--- to add remote members while creating a conversation or due to involved
--- backends forming an incomplete graph.
-data CreateGroupConversationResponse
-  = GroupConversationExisted Conversation
-  | GroupConversationCreated CreateGroupConversation
-
-instance
-  ( ResponseType r1 ~ Conversation,
-    ResponseType r2 ~ CreateGroupConversation
-  ) =>
-  AsUnion '[r1, r2] CreateGroupConversationResponse
-  where
-  toUnion (GroupConversationExisted x) = Z (I x)
-  toUnion (GroupConversationCreated x) = S (Z (I x))
-
-  fromUnion (Z (I x)) = GroupConversationExisted x
-  fromUnion (S (Z (I x))) = GroupConversationCreated x
-  fromUnion (S (S x)) = case x of {}
-
 type ConversationHeaders = '[DescHeader "Location" "Conversation ID" ConvId]
 
 type family ConversationResponse r
@@ -504,14 +484,10 @@ type ConversationAPI =
                     '[JSON]
                     '[ WithHeaders
                          ConversationHeaders
-                         Conversation
-                         (Respond 200 "Conversation existed" Conversation),
-                       WithHeaders
-                         ConversationHeaders
                          CreateGroupConversation
                          (Respond 201 "Conversation created" CreateGroupConversation)
                      ]
-                    CreateGroupConversationResponse
+                    CreateGroupConversation
            )
     :<|> Named
            "create-self-conversation@v2"

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -213,13 +213,13 @@ createGroupConversation ::
   Local UserId ->
   Maybe ConnId ->
   NewConv ->
-  Sem r CreateGroupConversationResponse
+  Sem r CreateGroupConversation
 createGroupConversation lusr conn newConv = do
   createGroupConvAndMkResponse
     lusr
     conn
     newConv
-    (\dbConv -> pure $ GroupConversationCreated $ CreateGroupConversation (conversationView lusr dbConv) mempty)
+    (\dbConv -> pure $ CreateGroupConversation (conversationView lusr dbConv) mempty)
 
 createGroupConvAndMkResponse ::
   ( Member (Input Opts) r,


### PR DESCRIPTION
Follow up/ clean up of #4527

The `ConversationExisted` constructor was never used and therefore removed.

https://wearezeta.atlassian.net/browse/WPB-16875

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
