### PR TITLE
CI: Pin technitium-dnsserver chart version

### DIFF
--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -323,5 +323,6 @@ releases:
   - name: technitium-dnsserver
     namespace: '{{ .Values.namespace1 }}'
     chart: obeone/technitium-dnsserver
+    version: 1.5.4 # FUTUREWORK: Upgrade to later version (values need to be adjusted)
     values:
       - './helm_vars/technitium/values.yaml.gotmpl'


### PR DESCRIPTION
This version is known to work. Newer versions probably need adjustment(s) to their values.

CI deployments started to fail with:
```
Error: template: technitium-dnsserver/templates/NOTES.txt:2:18: executing "technitium-dnsserver/templates/NOTES.txt" at <include "common.names.namespace" .>: error calling include: template: no template "common.names.namespace" associated with template "gotpl"
```
(https://concourse.ops.zinfra.io/teams/main/pipelines/wire-server-pr/jobs/integration-tests-kube-ci/builds/482.1#L67ecfd7c:448)

Ticket: https://wearezeta.atlassian.net/browse/WPB-17472

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
