### PR TITLE
Add a webapp url field to email domain registration (2)

### DIFF
--- a/changelog.d/1-api-changes/WPB-17032_add_webapp_url
+++ b/changelog.d/1-api-changes/WPB-17032_add_webapp_url
@@ -13,3 +13,6 @@ object in the `backend` field:
   }
 }
 ```
+
+The same change is applied to the internal endpoints `PUT
+/i/domain-registration` and `GET /i/domain-registration`.

--- a/integration/test/Test/User.hs
+++ b/integration/test/Test/User.hs
@@ -284,8 +284,13 @@ testActivateEmailForEmailDomainForAnotherBackend = do
   sso <- randomId
   object
     [ "domain_redirect" .= "backend",
-      "backend_url" .= "https://example.com",
-      "team_invite" .= "not-allowed"
+      "backend"
+        .= object
+          [ "config_url" .= "https://example.com",
+            "webapp_url" .= "https://webapp.example.com"
+          ],
+      "team_invite"
+        .= "not-allowed"
     ]
     & testActivateEmailShouldBeAllowed False
   object

--- a/libs/wire-api/src/Wire/API/EnterpriseLogin.hs
+++ b/libs/wire-api/src/Wire/API/EnterpriseLogin.hs
@@ -240,7 +240,7 @@ instance ToSchema DomainRegistrationUpdate where
   schema =
     object "DomainRegistrationUpdate" $
       DomainRegistrationUpdate
-        <$> (.domainRedirect) .= domainRedirectSchemaV8
+        <$> (.domainRedirect) .= domainRedirectSchema
         <*> (.teamInvite) .= teamInviteObjectSchema
 
 data DomainRegistrationResponse = DomainRegistrationResponse
@@ -262,7 +262,7 @@ instance ToSchema DomainRegistrationResponse where
       DomainRegistrationResponse
         <$> (.domain) .= field "domain" schema
         <*> (.authorizedTeam) .= maybe_ (optField "authorized_team" schema)
-        <*> (.domainRedirect) .= domainRedirectSchemaV8
+        <*> (.domainRedirect) .= domainRedirectSchema
         <*> (.teamInvite) .= teamInviteObjectSchema
         <*> (.dnsVerificationToken) .= optField "dns_verification_token" (maybeWithDefault Aeson.Null schema)
 

--- a/libs/wire-api/test/golden/testObject_DomainRegistrationResponse_4.json
+++ b/libs/wire-api/test/golden/testObject_DomainRegistrationResponse_4.json
@@ -1,5 +1,7 @@
 {
-    "backend_url": "https://example.com/inv14",
+    "backend": {
+        "config_url": "https://example.com/inv14"
+    },
     "dns_verification_token": null,
     "domain": "example.com",
     "domain_redirect": "backend",

--- a/libs/wire-api/test/golden/testObject_DomainRegistrationResponse_7.json
+++ b/libs/wire-api/test/golden/testObject_DomainRegistrationResponse_7.json
@@ -1,5 +1,8 @@
 {
-    "backend_url": "https://example.com/inv14",
+    "backend": {
+        "config_url": "https://example.com/inv14",
+        "webapp_url": "https://webapp.example.com/inv14"
+    },
     "dns_verification_token": null,
     "domain": "example.com",
     "domain_redirect": "backend",

--- a/libs/wire-api/test/golden/testObject_DomainRegistrationUpdate_4.json
+++ b/libs/wire-api/test/golden/testObject_DomainRegistrationUpdate_4.json
@@ -1,5 +1,7 @@
 {
-    "backend_url": "https://example.com/inv14",
+    "backend": {
+        "config_url": "https://example.com/inv14"
+    },
     "domain_redirect": "backend",
     "team_invite": "allowed"
 }

--- a/libs/wire-api/test/golden/testObject_DomainRegistrationUpdate_7.json
+++ b/libs/wire-api/test/golden/testObject_DomainRegistrationUpdate_7.json
@@ -1,5 +1,8 @@
 {
-    "backend_url": "https://example.com/inv14",
+    "backend": {
+        "config_url": "https://example.com/inv14",
+        "webapp_url": "https://webapp.example.com/inv14"
+    },
     "domain_redirect": "backend",
     "team_invite": "allowed"
 }


### PR DESCRIPTION
`PUT /i/domain-registration` and `GET /i/domain-registration` (both are internal endpoints used only by Stern) are changed in their payloads:
- `backend_url` becomes `config_url` in a new `backend` field / object. 
- The `webapp_url` field is new.

Old payload:

```json
{
 "backend_url": "{url}",
...
}
```

New payload:
```json
{
 "backend": {
   "config_url": "{url}",
   "webapp_url": "{url}"
  },
...
}
```

This change of the payload has also been documented here: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1570832467/Email+domain+registration+and+configuration#API-changes

Because we don't have system tests for Stern, I also made a quick manual smoke test: Checked that the redirect URL can still be configured and fetched.

Ticket: https://wearezeta.atlassian.net/browse/WPB-17032

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
