### PR TITLE
Wpb 16876 allow team admin to add users and user groups to a channel they are not in

### DIFF
--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -153,6 +153,5 @@ setCellsState user conv state = do
 getConversation :: (HasCallStack, MakesValue conv) => conv -> App Response
 getConversation conv = do
   (domain, convId) <- objQid conv
-  print domain
   req <- baseRequest domain Galley Unversioned $ joinHttpPath ["i", "conversations", convId]
   submit "GET" $ req


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
