### PR TITLE
cannon: Log parse error when message from client fails to parse

### DIFF
--- a/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
+++ b/services/cannon/src/Cannon/RabbitMqConsumerApp.hs
@@ -95,9 +95,10 @@ rabbitMQWebSocketApp uid mcid e pendingConn = do
     handleClientMisbehaving wsConn =
       Handler $ \(err :: WebSocketServerError) -> do
         case err of
-          FailedToParseClientMessage _ -> do
+          FailedToParseClientMessage parseError -> do
             Log.info e.logg $
               Log.msg (Log.val "Failed to parse received message, closing websocket")
+                . Log.field "parse_error" parseError
                 . logClient
             WS.sendCloseCode wsConn 1003 ("failed-to-parse" :: ByteString)
           UnexpectedAck -> do


### PR DESCRIPTION
## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
