### PR TITLE
WPB-16887 Allow Team Admin to Change a Channel Name

### DIFF
--- a/changelog.d/2-features/WPB-16887
+++ b/changelog.d/2-features/WPB-16887
@@ -1,0 +1,1 @@
+Allow team admin to change the name of a channel

--- a/integration/test/Test/Channels.hs
+++ b/integration/test/Test/Channels.hs
@@ -436,6 +436,25 @@ testNonTeamAdminCannotAddMembersWithoutJoining = do
     resp.status `shouldMatchInt` 404
     resp.json %. "label" `shouldMatch` "no-conversation"
 
+testTeamAdminCanChangeChannelNameWithoutJoining :: (HasCallStack) => App ()
+testTeamAdminCanChangeChannelNameWithoutJoining = do
+  (owner, tid, _) <- createTeam OwnDomain 2
+  setTeamFeatureLockStatus owner tid "channels" "unlocked"
+  void $ setTeamFeatureConfig owner tid "channels" (config "everyone")
+  conv <-
+    postConversation
+      owner
+      defMLS {name = Just "foo", groupConvType = Just "channel", team = Just tid, skipCreator = Just True}
+      >>= getJSON 201
+  I.getConversation conv `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "name" `shouldMatch` "foo"
+  newName <- randomName
+  changeConversationName owner conv newName >>= assertSuccess
+  I.getConversation conv `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "name" `shouldMatch` newName
+
 testTeamAdminCanAddMembersWithoutJoining :: (HasCallStack) => App ()
 testTeamAdminCanAddMembersWithoutJoining = do
   (owner, tid, mems@(m1 : m2 : m3 : m4 : m5 : _)) <- createTeam OwnDomain 6

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -418,6 +418,7 @@ ensureAllowed ::
   Sem r ()
 ensureAllowed tag _ action conv (TeamMember tm) = do
   case tag of
+    SConversationRenameTag -> ensureChannelAndTeamAdmin conv tm
     SConversationJoinTag -> do
       case action of
         ConversationJoin _ _ InternalAdd -> throwS @'ConvNotFound
@@ -881,7 +882,8 @@ updateLocalConversationUnchecked lconv qusr con action = do
       ensureAllowed tag loc action conv self
 
     skipConversationRoleCheck :: Sing tag -> Conversation -> Maybe TeamMember -> Bool
-    skipConversationRoleCheck SConversationJoinTag conv (Just _) = conv.convMetadata.cnvmChannelAddPermission == Just AddPermission.Everyone
+    skipConversationRoleCheck SConversationJoinTag conv (Just _) =
+      conv.convMetadata.cnvmChannelAddPermission == Just AddPermission.Everyone
     skipConversationRoleCheck _ _ _ = False
 
 -- --------------------------------------------------------------------------------

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -882,8 +882,7 @@ updateLocalConversationUnchecked lconv qusr con action = do
       ensureAllowed tag loc action conv self
 
     skipConversationRoleCheck :: Sing tag -> Conversation -> Maybe TeamMember -> Bool
-    skipConversationRoleCheck SConversationJoinTag conv (Just _) =
-      conv.convMetadata.cnvmChannelAddPermission == Just AddPermission.Everyone
+    skipConversationRoleCheck SConversationJoinTag conv (Just _) = conv.convMetadata.cnvmChannelAddPermission == Just AddPermission.Everyone
     skipConversationRoleCheck _ _ _ = False
 
 -- --------------------------------------------------------------------------------


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
