### PR TITLE
galley: Make servant calls to brig/spar are sent with tracing and retries [WPB-17847]

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -71,5 +71,8 @@ export AWS_SECRET_ACCESS_KEY="dummysecret"
 # integration test suite timeout
 export TEST_TIMEOUT_SECONDS=2
 
+# OTEL
+OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 # allow local .envrc overrides
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/changelog.d/5-internal/galley-request-id
+++ b/changelog.d/5-internal/galley-request-id
@@ -1,0 +1,1 @@
+galley: Make servant calls to brig/spar with requestId header and retries

--- a/libs/wire-otel/default.nix
+++ b/libs/wire-otel/default.nix
@@ -4,13 +4,20 @@
 # dependencies are added or removed.
 { mkDerivation
 , base
+, bytestring
+, containers
 , gitignoreSource
+, hs-opentelemetry-api
 , hs-opentelemetry-instrumentation-http-client
-, hs-opentelemetry-instrumentation-wai
 , hs-opentelemetry-sdk
+, hs-opentelemetry-utils-exceptions
 , http-client
+, http-types
 , kan-extensions
 , lib
+, mtl
+, servant-client
+, servant-client-core
 , text
 , unliftio
 }:
@@ -20,15 +27,21 @@ mkDerivation {
   src = gitignoreSource ./.;
   libraryHaskellDepends = [
     base
+    bytestring
+    containers
+    hs-opentelemetry-api
     hs-opentelemetry-instrumentation-http-client
-    hs-opentelemetry-instrumentation-wai
     hs-opentelemetry-sdk
+    hs-opentelemetry-utils-exceptions
     http-client
+    http-types
     kan-extensions
+    mtl
+    servant-client
+    servant-client-core
     text
     unliftio
   ];
-  testHaskellDepends = [ base ];
   homepage = "https://wire.com/";
   license = lib.licenses.agpl3Only;
 }

--- a/libs/wire-otel/src/Wire/OpenTelemetry/Servant.hs
+++ b/libs/wire-otel/src/Wire/OpenTelemetry/Servant.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module Wire.OpenTelemetry.Servant where
+
+import Control.Monad (forM_, when)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (ask)
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder (toLazyByteString)
+import Data.Foldable (toList)
+import Data.Sequence qualified as Seq
+import Data.Text qualified as T
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as T
+import Network.HTTP.Types
+import OpenTelemetry.Context hiding (lookup)
+import OpenTelemetry.Context.ThreadLocal
+import OpenTelemetry.Instrumentation.HttpClient.Raw
+import OpenTelemetry.Propagator
+import OpenTelemetry.Trace
+import OpenTelemetry.Trace.Core
+import OpenTelemetry.Utils.Exceptions
+import Servant.Client
+import Servant.Client.Core
+import Servant.Client.Internal.HttpClient
+
+instrumentServantRequest :: Context -> Request -> ClientM Request
+instrumentServantRequest ctx req = do
+  env <- ask
+  tracer <- httpTracerProvider
+  forM_ (lookupSpan ctx) $ \s -> do
+    let path = T.decodeUtf8 (BS.toStrict (toLazyByteString req.requestPath))
+        queryString = T.decodeUtf8 (renderQuery True (toList req.requestQueryString))
+        userAgent = maybe "" T.decodeUtf8 (lookup hUserAgent $ toList req.requestHeaders)
+        url =
+          Text.pack (showBaseUrl env.baseUrl)
+            <> path
+            <> queryString
+        scheme = case env.baseUrl.baseUrlScheme of
+          Https -> "https"
+          Http -> "http"
+        httpVersion = case req.requestHttpVersion of
+          (HttpVersion major minor) -> T.pack (show major <> "." <> show minor)
+    addAttributes
+      s
+      [ ("http.request.method", toAttribute $ T.decodeUtf8 req.requestMethod),
+        ("url.full", toAttribute url),
+        ("url.path", toAttribute path),
+        ("url.query", toAttribute queryString),
+        ("http.host", toAttribute $ T.pack env.baseUrl.baseUrlHost),
+        ("url.scheme", toAttribute $ TextAttribute scheme),
+        ("network.protocol.version", toAttribute httpVersion),
+        ("user_agent.original", toAttribute userAgent)
+      ]
+  hdrs <- inject (getTracerProviderPropagators $ getTracerTracerProvider tracer) ctx $ toList req.requestHeaders
+  pure req {requestHeaders = Seq.fromList hdrs}
+
+instrumentServantResponse :: (MonadIO m) => Context -> Response -> m ()
+instrumentServantResponse ctx0 resp = do
+  tracer <- httpTracerProvider
+  ctx <- extract (getTracerProviderPropagators $ getTracerTracerProvider tracer) (toList resp.responseHeaders) ctx0
+  _ <- attachContext ctx
+  forM_ (lookupSpan ctx) $ \s -> do
+    when (statusCode resp.responseStatusCode >= 400) $ do
+      setStatus s (Error "")
+    addAttributes s [("http.response.statusCode", toAttribute $ statusCode $ resp.responseStatusCode)]
+
+otelClientMiddleware :: Text.Text -> ClientMiddleware
+otelClientMiddleware info app req0 = do
+  tracer <- httpTracerProvider
+  inSpanM tracer info defaultSpanArguments {kind = Client} $ do
+    ctx <- getContext
+    req <- instrumentServantRequest ctx req0
+    resp <- app req
+    instrumentServantResponse ctx resp
+    pure resp

--- a/libs/wire-otel/test/Main.hs
+++ b/libs/wire-otel/test/Main.hs
@@ -1,4 +1,0 @@
-module Main (main) where
-
-main :: IO ()
-main = putStrLn "Test suite not yet implemented."

--- a/libs/wire-otel/wire-otel.cabal
+++ b/libs/wire-otel/wire-otel.cabal
@@ -12,7 +12,7 @@ build-type:      Simple
 extra-doc-files: CHANGELOG.md
 
 common common-all
-  ghc-options:        -O2 -Wall
+  ghc-options:        -O2 -Wall -Wredundant-constraints -Wunused-packages
   default-extensions:
     BlockArguments
     OverloadedLists
@@ -21,26 +21,26 @@ common common-all
 
 library
   import:           common-all
-  exposed-modules:  Wire.OpenTelemetry
+  exposed-modules:
+    Wire.OpenTelemetry
+    Wire.OpenTelemetry.Servant
+
   build-depends:
     , base
+    , bytestring
+    , containers
+    , hs-opentelemetry-api
     , hs-opentelemetry-instrumentation-http-client
-    , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk
+    , hs-opentelemetry-utils-exceptions
     , http-client
+    , http-types
     , kan-extensions
+    , mtl
+    , servant-client
+    , servant-client-core
     , text
     , unliftio
 
   hs-source-dirs:   src
   default-language: GHC2021
-
-test-suite wire-otel-test
-  import:           common-all
-  default-language: GHC2021
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Main.hs
-  build-depends:
-    , base
-    , wire-otel

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -283,6 +283,7 @@ let
         hs-opentelemetry-instrumentation-http-client = "instrumentation/http-client";
         hs-opentelemetry-instrumentation-wai = "instrumentation/wai";
         hs-opentelemetry-exporter-otlp = "exporters/otlp";
+        hs-opentelemetry-utils-exceptions = "utils/exceptions";
       };
     };
 

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -352,6 +352,9 @@ let
               "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
               "LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive"
               "LANG=en_GB.UTF-8"
+              # Use stable conventions for tracing http in opentelemetry
+              # https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#migration-plan
+              "OTEL_SEMCONV_STABILITY_OPT_IN=http"
             ];
             User = "65534";
           };

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -185,6 +185,7 @@ mkDerivation {
     safe-exceptions
     servant
     servant-client
+    servant-client-core
     servant-server
     singletons
     sop-core

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -345,6 +345,7 @@ library
     , safe-exceptions                       >=0.1
     , servant
     , servant-client
+    , servant-client-core
     , servant-server
     , singletons
     , sop-core

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -39,18 +39,14 @@ where
 import Bilge hiding (getHeader, host, options, port, statusCode)
 import Bilge.RPC
 import Control.Error hiding (bool, isRight)
-import Control.Lens (view)
 import Control.Monad.Catch
 import Data.ByteString.Char8 (pack)
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Qualified
-import Data.Sequence (Seq (..))
-import Data.Text qualified as Text
 import Data.Text.Lazy qualified as Lazy
 import Galley.API.Error
-import Galley.Env
 import Galley.Intra.Util
 import Galley.Monad
 import Imports
@@ -61,8 +57,6 @@ import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 import Network.Wai.Utilities.Error qualified as Wai
 import Servant.Client qualified as Client
-import Servant.Client.Core.Request (RequestF (..))
-import Util.Options
 import Wire.API.Connection
 import Wire.API.Error.Galley
 import Wire.API.Routes.Internal.Brig qualified as IAPI


### PR DESCRIPTION
Similar to bilge RPC calls

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
