### PR TITLE
Fix: postgres migrations, added migration for foreign key constraint

### DIFF
--- a/changelog.d/2-features/WPB-16870-user-groups-everything-except-search
+++ b/changelog.d/2-features/WPB-16870-user-groups-everything-except-search
@@ -1,1 +1,1 @@
-Add update, delete, add/remove users to UserGroups. (#4600, #4604)
+Add update, delete, add/remove users to UserGroups. (#4600, #4604, #4605)

--- a/integration/test/Test/Auth.hs
+++ b/integration/test/Test/Auth.hs
@@ -162,7 +162,7 @@ testInvalidCookie = do
           pure . fromJust $ getCookie "zuid" resp
 
       -- Wait for both cookies to expire
-      threadDelay $ (cookieTimeout + 1) * 1_000_000
+      threadDelay $ (cookieTimeout + 2) * 1_000_000
       -- Assert that the cookies are considered expired
       for_ [userCookie, lhCookie] $ \cookie ->
         Nginz.access domain ("zuid=" <> cookie) `bindResponse` \resp -> do

--- a/libs/wire-subsystems/postgres-migrations/20250604084743-user_group_member_delete_on_cascade.sql
+++ b/libs/wire-subsystems/postgres-migrations/20250604084743-user_group_member_delete_on_cascade.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_group_member
+DROP CONSTRAINT fk_user_group,
+ADD CONSTRAINT fk_user_group
+    FOREIGN KEY (user_group_id)
+    REFERENCES user_group(id)
+    ON DELETE CASCADE;

--- a/libs/wire-subsystems/src/Wire/UserGroupSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserGroupSubsystem/Interpreter.hs
@@ -169,7 +169,7 @@ deleteGroupImpl ::
   Sem r ()
 deleteGroupImpl deleter groupId =
   getTeamAsMember deleter >>= \case
-    Nothing -> pure ()
+    Nothing -> throw UserGroupNotFound
     Just (team, member) -> do
       if isAdminOrOwner (member ^. permissions)
         then do


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
