### PR TITLE
Test nginz zauth_timestamp

### DIFF
--- a/changelog.d/5-internal/test-z-timestamp
+++ b/changelog.d/5-internal/test-z-timestamp
@@ -1,0 +1,1 @@
+Assert the value of nginz's `zauth_timestamp` in test.

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -81,6 +81,7 @@
 , transformers
 , transformers-base
 , unix
+, unix-time
 , unliftio
 , uuid
 , vector
@@ -183,6 +184,7 @@ mkDerivation {
     transformers
     transformers-base
     unix
+    unix-time
     unliftio
     uuid
     vector

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -293,6 +293,7 @@ library
     , transformers
     , transformers-base
     , unix
+    , unix-time
     , unliftio
     , uuid
     , vector
@@ -305,4 +306,3 @@ library
     , xml
     , xml-conduit
     , yaml
-    , unix-time

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -305,3 +305,4 @@ library
     , xml
     , xml-conduit
     , yaml
+    , unix-time

--- a/integration/test/Test/NginxZAuthModule.hs
+++ b/integration/test/Test/NginxZAuthModule.hs
@@ -7,6 +7,7 @@ import Control.Monad.Reader
 import qualified Data.ByteString as BS
 import Data.List.Extra
 import Data.Streaming.Network
+import Data.UnixTime
 import qualified Network.HTTP.Client as HTTP
 import Network.HTTP.Types
 import Network.Socket (Socket)
@@ -49,6 +50,10 @@ testBearerToken = do
       resp.status `shouldMatchInt` 200
       resp.json %. "user" `shouldMatch` (alice %. "qualified_id.id")
       resp.json %. "timestamp" `shouldNotMatch` ""
+      timestampI <- (resp.json %. "timestamp" >>= asString)
+      let timestampUnix = UnixTime ((fromInteger . read) timestampI) 0
+      now <- liftIO $ getUnixTime
+      assertBool "not in future" (timestampUnix > now)
 
 -- Happy flow (zauth token encoded in AWS4_HMAC_SHA256)
 --

--- a/services/nginz/integration-test/conf/nginz/common_response.conf
+++ b/services/nginz/integration-test/conf/nginz/common_response.conf
@@ -13,6 +13,7 @@
       proxy_set_header   Z-Provider     $zauth_provider;
       proxy_set_header   Z-Bot          $zauth_bot;
       proxy_set_header   Z-Conversation $zauth_conversation;
+      proxy_set_header   Z-Timestamp    $zauth_timestamp;
       proxy_set_header   Request-Id     $request_id;
 
       # NOTE: This should only be used on endpoints where credentials are needed


### PR DESCRIPTION
Ensure that `Z-Timestamp` / `$zauth_timestamp` is the expiration timestamp of the token, because it is in future.

Ticket: https://wearezeta.atlassian.net/browse/WPB-17736

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
