### PR TITLE
Revert change in spelling of validateSAML{e,E}mails feature.

### DIFF
--- a/changelog.d/0-release-notes/WPB-18206-scim-update-email-fix-spelling
+++ b/changelog.d/0-release-notes/WPB-18206-scim-update-email-fix-spelling
@@ -1,1 +1,0 @@
-If you override the `validateSAMLemails` feature in your local instance settings from `values.yaml`, change the spelling to `validateSAMLEmails`.  The non-capitalized spelling was ignored.  See also "bug fixes".  (#4621, #4627)

--- a/changelog.d/1-api-changes/WPB-18206-scim-update-email-fix-spelling
+++ b/changelog.d/1-api-changes/WPB-18206-scim-update-email-fix-spelling
@@ -1,1 +1,0 @@
-Spelling of the `validateSAMLEmails` feature had a typo (`validateSAMLemails`, without the capitalized `E` in `Email`).  This has been fixed.  (#4621, #4627)

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -757,12 +757,9 @@ getTeamFeatures user tid = do
   submit "GET" req
 
 getTeamFeature :: (HasCallStack, MakesValue user, MakesValue tid) => user -> tid -> String -> App Response
-getTeamFeature = getTeamFeatureVersioned Versioned
-
-getTeamFeatureVersioned :: (HasCallStack, MakesValue user, MakesValue tid) => Versioned -> user -> tid -> String -> App Response
-getTeamFeatureVersioned versioned user tid featureName = do
+getTeamFeature user tid featureName = do
   tidStr <- asString tid
-  req <- baseRequest user Galley versioned (joinHttpPath ["teams", tidStr, "features", featureName])
+  req <- baseRequest user Galley Versioned (joinHttpPath ["teams", tidStr, "features", featureName])
   submit "GET" req
 
 setTeamFeatureConfig ::

--- a/integration/test/Test/FeatureFlags/Util.hs
+++ b/integration/test/Test/FeatureFlags/Util.hs
@@ -75,7 +75,7 @@ defAllFeatures =
     [ "legalhold" .= disabled,
       "sso" .= disabled,
       "searchVisibility" .= disabled,
-      "validateSAMLEmails" .= enabled,
+      "validateSAMLemails" .= enabled,
       "digitalSignatures" .= disabled,
       "appLock" .= defEnabledObj (object ["enforceAppLock" .= False, "inactivityTimeoutSecs" .= A.Number 60]),
       "fileSharing" .= enabled,

--- a/integration/test/Test/FeatureFlags/ValidateSAMLEmails.hs
+++ b/integration/test/Test/FeatureFlags/ValidateSAMLEmails.hs
@@ -6,12 +6,12 @@ import Testlib.Prelude
 
 testPatchValidateSAMLEmails :: (HasCallStack) => App ()
 testPatchValidateSAMLEmails =
-  checkPatch OwnDomain "validateSAMLEmails"
+  checkPatch OwnDomain "validateSAMLemails"
     $ object ["status" .= "disabled"]
 
 testValidateSAMLEmailsInternal :: (HasCallStack) => App ()
 testValidateSAMLEmailsInternal = do
   (alice, tid, _) <- createTeam OwnDomain 0
   withWebSocket alice $ \ws -> do
-    setFlag InternalAPI ws tid "validateSAMLEmails" disabled
-    setFlag InternalAPI ws tid "validateSAMLEmails" enabled
+    setFlag InternalAPI ws tid "validateSAMLemails" disabled
+    setFlag InternalAPI ws tid "validateSAMLemails" enabled

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -5,7 +5,6 @@ module Test.Spar where
 import API.Brig as Brig
 import API.BrigInternal as BrigInternal
 import API.Common (randomDomain, randomEmail, randomExternalId, randomHandle)
-import API.Galley as Galley
 import API.GalleyInternal (setTeamFeatureStatus)
 import API.Spar
 import API.SparInternal
@@ -455,11 +454,8 @@ testSsoLoginNoSamlEmailValidation (TaggedBool validateSAMLEmails) = do
   (owner, tid, _) <- createTeam OwnDomain 1
   emailDomain <- randomDomain
 
-  -- the old, inconsistent spelling still works:
-  assertSuccess =<< Galley.getTeamFeatureVersioned (ExplicitVersion 8) owner tid "validateSAMLemails"
-
   let status = if validateSAMLEmails then "enabled" else "disabled"
-  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLEmails" status
+  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLemails" status
 
   void $ setTeamFeatureStatus owner tid "sso" "enabled"
   (idp, idpMeta) <- registerTestIdPWithMetaWithPrivateCreds owner
@@ -507,7 +503,7 @@ testScimUpdateEmailAddress (TaggedBool extIdIsEmail) (TaggedBool validateSAMLEma
   (owner, tid, _) <- createTeam OwnDomain 1
 
   let status = if validateSAMLEmails then "enabled" else "disabled"
-  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLEmails" status
+  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLemails" status
 
   void $ setTeamFeatureStatus owner tid "sso" "enabled"
   (idp, _) <- registerTestIdPWithMetaWithPrivateCreds owner
@@ -595,7 +591,7 @@ testScimUpdateEmailAddressAndExternalId = do
   (owner, tid, _) <- createTeam OwnDomain 1
 
   let status = "disabled"
-  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLEmails" status
+  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLemails" status
 
   void $ setTeamFeatureStatus owner tid "sso" "enabled"
   (idp, _) <- registerTestIdPWithMetaWithPrivateCreds owner
@@ -735,7 +731,7 @@ testScimLoginNoSamlEmailValidation (TaggedBool validateSAMLEmails) = do
   (owner, tid, _) <- createTeam OwnDomain 1
 
   let status = if validateSAMLEmails then "enabled" else "disabled"
-  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLEmails" status
+  assertSuccess =<< setTeamFeatureStatus owner tid "validateSAMLemails" status
 
   void $ setTeamFeatureStatus owner tid "sso" "enabled"
   (idp, _) <- registerTestIdPWithMetaWithPrivateCreds owner

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -95,11 +95,10 @@ type family AllDeprecatedFeatureConfigAPI cfgs where
       :<|> AllDeprecatedFeatureConfigAPI cfgs
 
 type DeprecatedFeatureAPI =
-  FeatureStatusDeprecatedGet DeprecationNotice1 V2 SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedPut DeprecationNotice1 V2 SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedGet DeprecationNotice1 V2 ValidateSAMLEmailsConfig
-    :<|> FeatureStatusDeprecatedGet DeprecationNotice1 V9 ValidateSAMLEmailsConfig
-    :<|> FeatureStatusDeprecatedGet DeprecationNotice2 V2 DigitalSignaturesConfig
+  FeatureStatusDeprecatedGet DeprecationNotice1 SearchVisibilityAvailableConfig V2
+    :<|> FeatureStatusDeprecatedPut DeprecationNotice1 SearchVisibilityAvailableConfig V2
+    :<|> FeatureStatusDeprecatedGet DeprecationNotice1 ValidateSAMLEmailsConfig V2
+    :<|> FeatureStatusDeprecatedGet DeprecationNotice2 DigitalSignaturesConfig V2
 
 type FeatureAPIGet cfg =
   Named
@@ -116,15 +115,15 @@ type FeatureAPIPut cfg =
         :> FeatureStatusBasePutPublic cfg
     )
 
-type FeatureStatusDeprecatedGet d untilVersion feature =
+type FeatureStatusDeprecatedGet d feature untilVersion =
   Named
     '("get-deprecated", '(feature, untilVersion))
-    (ZUser :> FeatureStatusBaseDeprecatedGet d untilVersion feature)
+    (ZUser :> FeatureStatusBaseDeprecatedGet d feature untilVersion)
 
-type FeatureStatusDeprecatedPut d untilVersion feature =
+type FeatureStatusDeprecatedPut d feature untilVersion =
   Named
     '("put-deprecated", '(feature, untilVersion))
-    (ZUser :> FeatureStatusBaseDeprecatedPut d untilVersion feature)
+    (ZUser :> FeatureStatusBaseDeprecatedPut d feature untilVersion)
 
 type FeatureStatusBaseGet featureConfig =
   Summary (AppendSymbol "Get config for " (FeatureSymbol featureConfig))
@@ -152,7 +151,7 @@ type FeatureStatusBasePutPublic featureConfig =
     :> Put '[Servant.JSON] (LockableFeature featureConfig)
 
 -- | A type for a GET endpoint for a feature with a deprecated path
-type FeatureStatusBaseDeprecatedGet desc untilVersion featureConfig =
+type FeatureStatusBaseDeprecatedGet desc featureConfig untilVersion =
   ( Summary
       (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
       :> Until untilVersion
@@ -173,7 +172,7 @@ type FeatureStatusBaseDeprecatedGet desc untilVersion featureConfig =
   )
 
 -- | A type for a PUT endpoint for a feature with a deprecated path
-type FeatureStatusBaseDeprecatedPut desc untilVersion featureConfig =
+type FeatureStatusBaseDeprecatedPut desc featureConfig untilVersion =
   Summary
     (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
     :> Until untilVersion

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -691,13 +691,11 @@ instance Default (LockableFeature ValidateSAMLEmailsConfig) where
   def = defUnlockedFeature
 
 instance IsFeatureConfig ValidateSAMLEmailsConfig where
-  type FeatureSymbol ValidateSAMLEmailsConfig = "validateSAMLEmails"
+  type FeatureSymbol ValidateSAMLEmailsConfig = "validateSAMLemails"
   featureSingleton = FeatureSingletonValidateSAMLEmailsConfig
   objectSchema = pure ValidateSAMLEmailsConfig
 
 type instance DeprecatedFeatureName V2 ValidateSAMLEmailsConfig = "validate-saml-emails"
-
-type instance DeprecatedFeatureName V9 ValidateSAMLEmailsConfig = "validateSAMLemails"
 
 --------------------------------------------------------------------------------
 -- DigitalSignatures feature

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -74,7 +74,6 @@ deprecatedFeatureConfigAPI =
   mkNamedAPI @'("get-deprecated", '(SearchVisibilityAvailableConfig, V2)) getFeature
     <@> mkNamedAPI @'("put-deprecated", '(SearchVisibilityAvailableConfig, V2)) setFeature
     <@> mkNamedAPI @'("get-deprecated", '(ValidateSAMLEmailsConfig, V2)) getFeature
-    <@> mkNamedAPI @'("get-deprecated", '(ValidateSAMLEmailsConfig, V9)) getFeature
     <@> mkNamedAPI @'("get-deprecated", '(DigitalSignaturesConfig, V2)) getFeature
 
 deprecatedFeatureAPI :: API (AllDeprecatedFeatureConfigAPI DeprecatedFeatureConfigs) GalleyEffects

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -105,7 +105,7 @@ assertSSOEnabled tid = do
 
 isEmailValidationEnabledTeam :: (HasCallStack, MonadSparToGalley m) => TeamId -> m Bool
 isEmailValidationEnabledTeam tid = do
-  resp <- call $ method GET . paths ["i", "teams", toByteString' tid, "features", "validateSAMLEmails"]
+  resp <- call $ method GET . paths ["i", "teams", toByteString' tid, "features", "validateSAMLemails"]
   pure
     ( statusCode resp == 200
         && ( ((.status) <$> responseJsonMaybe @(LockableFeature ValidateSAMLEmailsConfig) resp)


### PR DESCRIPTION
We missed two details when "fixing" this: (1) we broke `GET /v8/feature-configs` because we forgot to version-control the response body; (2) events.

Until we have answers to these two points, I'll revert this and we'll keep the typo for backwards compatibility.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
