### PR TITLE
cannon: Replace message count mechanism with detecting the end of initial sync

### DIFF
--- a/changelog.d/2-features/end-of-initial-sync
+++ b/changelog.d/2-features/end-of-initial-sync
@@ -1,0 +1,1 @@
+cannon: Replace message count mechanism with detecting the end of initial sync

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -79,6 +79,7 @@
 , quickcheck-instances
 , random
 , resourcet
+, retry
 , saml2-web-sso
 , schema-profunctor
 , scientific
@@ -191,6 +192,7 @@ mkDerivation {
     quickcheck-instances
     random
     resourcet
+    retry
     saml2-web-sso
     schema-profunctor
     scientific

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -270,7 +270,7 @@ library
     , asn1-encoding
     , attoparsec                 >=0.10
     , barbies
-    , base                       >=4       && <5
+    , base                       >=4        && <5
     , base64-bytestring          >=1.0
     , binary
     , binary-parsers
@@ -330,6 +330,7 @@ library
     , quickcheck-instances       >=0.3.16
     , random                     >=1.2.0
     , resourcet
+    , retry                      ^>=0.9.3.1
     , saml2-web-sso
     , schema-profunctor
     , scientific

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -39,7 +39,6 @@ import Gundeck.Options
 import Gundeck.Push.Data qualified as Data
 import Gundeck.Push.Native.Serialise
 import Gundeck.Push.Native.Types as Types
-import Gundeck.Util
 import Imports
 import Prometheus qualified as Prom
 import System.Logger.Class (MonadLogger, field, msg, val, (.=), (~~))
@@ -47,6 +46,7 @@ import System.Logger.Class qualified as Log
 import UnliftIO (handleAny, mapConcurrently, pooledMapConcurrentlyN_)
 import Wire.API.Event.Gundeck
 import Wire.API.Internal.Notification
+import Wire.API.Notification (mkNotificationId)
 import Wire.API.Push.V2
 
 push :: NativePush -> [Address] -> Gundeck ()

--- a/services/gundeck/src/Gundeck/React.hs
+++ b/services/gundeck/src/Gundeck/React.hs
@@ -41,12 +41,12 @@ import Gundeck.Options (notificationTTL, settings)
 import Gundeck.Push.Data qualified as Push
 import Gundeck.Push.Native.Types
 import Gundeck.Push.Websocket qualified as Web
-import Gundeck.Util
 import Imports
 import System.Logger.Class (Msg, msg, val, (+++), (.=), (~~))
 import System.Logger.Class qualified as Log
 import Wire.API.Event.Gundeck
 import Wire.API.Internal.Notification
+import Wire.API.Notification (mkNotificationId)
 import Wire.API.Push.V2
 
 onEvent :: Event -> Gundeck ()

--- a/services/gundeck/src/Gundeck/Util.hs
+++ b/services/gundeck/src/Gundeck/Util.hs
@@ -18,24 +18,8 @@
 module Gundeck.Util where
 
 import Control.Monad.Catch
-import Control.Retry
-import Data.Id
-import Data.UUID.V1
 import Imports
-import Network.HTTP.Types.Status
-import Network.Wai.Utilities
 import UnliftIO (async, waitCatch)
-import Wire.API.Internal.Notification
-
--- | 'Data.UUID.V1.nextUUID' is sometimes unsuccessful, so we try a few times.
-mkNotificationId :: (MonadIO m, MonadThrow m) => m NotificationId
-mkNotificationId = do
-  ni <- fmap Id <$> retrying x10 fun (const (liftIO nextUUID))
-  maybe (throwM err) pure ni
-  where
-    x10 = limitRetries 10 <> exponentialBackoff 10
-    fun = const (pure . isNothing)
-    err = mkError status500 "internal-error" "unable to generate notification ID"
 
 mapAsync ::
   (MonadUnliftIO m, Traversable t) =>


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-18436

The message count recieved in the queue info gotten as response of declaring the
queue may include some expired messages which have not yet made it to the head
of the queue. This makes the message count mechanism useless to the clients for
detecting the end of initial sync.

This commit detects end of initial sync based on sending a transient
notification in the queue. If we recieve this notification back, it would mean
that the queue is empty and the initial sync is complete.

The timing of sending this notification must be carefully chosen, it is sent in
one of these two conditions:

  1. If the message count in the queue info is 0, the queue must be empty as the
  expired messages are already considered expired when they reach the head of
  the queue. So its a good time to publish our end-of-initial-sync notification.
  If the queue is indeed empty we'll recieve it and forward it to the client,
  letting it know that it can consider itself up to date.

  2. If number of unacked messages becomes 0 right after recieving an
  acknowledgement and the initial sync hasn't already completed, this could mean
  either the queue is empty or there is some delay in receiving the next message
  from RabbitMQ. Here we publish our end-of-initial-sync notification. If there
  was a delay in receiving the next message from RabbitMQ, the consumer thread
  will increase the count for unacked messages and we'll get another opportunity
  to check this. Otherwise, the consumer thread will recieve this
  end-of-initial-sync notification and forward it to the client.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
