### PR TITLE
detached background worker 2nd attempt

### DIFF
--- a/changelog.d/5-internal/log-rabbitmq-channel-cancellations
+++ b/changelog.d/5-internal/log-rabbitmq-channel-cancellations
@@ -1,0 +1,1 @@
+Log AMQP consumer cancellations in backend notification pusher.

--- a/changelog.d/5-internal/rabbitmq-decrease-backendNotificationPusher.remotesRefreshInterval
+++ b/changelog.d/5-internal/rabbitmq-decrease-backendNotificationPusher.remotesRefreshInterval
@@ -1,0 +1,2 @@
+Decrease `backendNotificationPusher.remotesRefreshInterval` for local
+integration tests to give it a better chance to run between test executions.

--- a/deploy/dockerephemeral/federation-v1/background-worker.yaml
+++ b/deploy/dockerephemeral/federation-v1/background-worker.yaml
@@ -25,4 +25,4 @@ rabbitmq:
 backendNotificationPusher:
   pushBackoffMinWait: 1000
   pushBackoffMaxWait: 1000000
-  remotesRefreshInterval: 5000000
+  remotesRefreshInterval: 1000000

--- a/deploy/dockerephemeral/federation-v2/background-worker.yaml
+++ b/deploy/dockerephemeral/federation-v2/background-worker.yaml
@@ -23,4 +23,4 @@ rabbitmq:
 backendNotificationPusher:
   pushBackoffMinWait: 1000
   pushBackoffMaxWait: 1000000
-  remotesRefreshInterval: 5000000
+  remotesRefreshInterval: 1000000

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -947,8 +947,6 @@ testBackendPusherRecoversFromQueueDeletion = do
         print "XXX: After deleteTeamMember"
         hFlush stdout
 
-        Timeout.threadDelay 1500000
-
         -- Check that the queue was recreated
         eventually $ do
           queueNames <- getActiveQueues

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -894,7 +894,7 @@ testBackendPusherRecoversFromQueueDeletion = do
 
   domain1 <- asks (.domain1)
 
-  startDynamicBackendsReturnResources [def] $ \[beResource] -> do
+  startDynamicBackendsReturnResources [def {backgroundWorkerCfg = setField "logLevel" ("Debug" :: String)}] $ \[beResource] -> do
     let domain = beResource.berDomain
     (alice, team, [alex, alison]) <- createTeam domain 3
 
@@ -934,7 +934,11 @@ testBackendPusherRecoversFromQueueDeletion = do
         queueNames <- getActiveQueues
         queueNames `shouldNotContain` [backendNotificationQueueName]
 
+      print "XXX: Before deleteTeamMember"
+      hFlush stdout
       void $ deleteTeamMember team alice alison >>= getBody 202
+      print "XXX: After deleteTeamMember"
+      hFlush stdout
 
       Timeout.threadDelay 1500000
 
@@ -943,6 +947,8 @@ testBackendPusherRecoversFromQueueDeletion = do
         queueNames <- getActiveQueues
         queueNames `shouldContain` [backendNotificationQueueName]
 
+      print "XXX: Before assertConvUserDeletedNotif"
+      hFlush stdout
       assertConvUserDeletedNotif wsBob alisonId
 
 ----------------------------------------------------------------------

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -936,6 +936,8 @@ testBackendPusherRecoversFromQueueDeletion = do
 
       void $ deleteTeamMember team alice alison >>= getBody 202
 
+      Timeout.threadDelay 1500000
+
       -- Check that the queue was recreated
       eventually $ do
         queueNames <- getActiveQueues

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -270,6 +270,17 @@ super `shouldContain` sub = do
   unless (sub `isInfixOf` super) $ do
     assertFailure $ "String or List:\n" <> show super <> "\nDoes not contain:\n" <> show sub
 
+shouldNotContain ::
+  (Eq a, Show a, HasCallStack) =>
+  -- | The actual value
+  [a] ->
+  -- | The expected value
+  [a] ->
+  App ()
+super `shouldNotContain` sub = do
+  when (sub `isInfixOf` super) $ do
+    assertFailure $ "String or List:\n" <> show super <> "\nDoes contain:\n" <> show sub
+
 printFailureDetails :: AssertionFailure -> IO String
 printFailureDetails (AssertionFailure stack mbResponse ctx msg) = do
   s <- prettierCallStack stack

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -55,11 +55,6 @@ startPushingNotifications consumers runningFlag chan domain = do
               . Log.field "domain" (domainText domain)
               . Log.field "consumer" consumerTag
           )
-          >>
-          -- Cleanup the consumer's local state, it's now detached anyways. A
-          -- new consumer will be created if needed by the check loop in
-          -- `startPusher` (after some delay.)
-          (cancelConsumer consumers chan domain)
     )
     (QL.FieldTable M.empty)
 

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -55,7 +55,11 @@ startPushingNotifications consumers runningFlag chan domain = do
               . Log.field "domain" (domainText domain)
               . Log.field "consumer" consumerTag
           )
-          >> (cancelConsumer consumers chan domain)
+          >>
+          -- Cleanup the consumer's local state, it's now detached anyways. A
+          -- new consumer will be created if needed by the check loop in
+          -- `startPusher` (after some delay.)
+          (cancelConsumer consumers chan domain)
     )
     (QL.FieldTable M.empty)
 


### PR DESCRIPTION
Actually, there isn't much we can do when a queue is externally deleted:
- There is a loop which handles the reconfiguration according to existing (!) queues
- Older federation backend versions (`V0` and `V1`) cannot be changed anymore.

To heal the symptoms of detached consumers, I've decreased the cleanup interval for local integration test runs to one Second. That should be a good tradeoff between the time to re-execute tests and not making to many bogus requests to RabbitMQ.

I've also added a test to ensure that reestablishing the consumer works.

Ticket: https://wearezeta.atlassian.net/browse/WPB-17247

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
