### PR TITLE
Timestamps for failing integration tests.

### DIFF
--- a/changelog.d/5-internal/timestamps-for-failing-integration-tests
+++ b/changelog.d/5-internal/timestamps-for-failing-integration-tests
@@ -1,0 +1,1 @@
+Timestamps for failing integration tests.


### PR DESCRIPTION
looks like this now:

```
----- Spar.testSparUserCreationInvitationTimeout FAIL (0.00 s; failed at 2025-07-02T09:51:02.723Z) -----
assertion failure:
[...]
```

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
