### PR TITLE
WPB-18478 Fix false positive warning: attempt to send notification about conversation update to users not in the conversation

### DIFF
--- a/changelog.d/5-internal/WPB-18478
+++ b/changelog.d/5-internal/WPB-18478
@@ -1,0 +1,1 @@
+Fix false positive warning of members not being present in remote conversations.

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -38,6 +38,29 @@ import Testlib.Prelude
 import Testlib.ResourcePool
 import Testlib.VersionedFed
 
+testFederatedConversation :: (HasCallStack) => App ()
+testFederatedConversation = do
+  -- This test was created to verify that the false positive log message:
+  -- "Attempt to send notification about conversation update to users not in the conversation"
+  -- does not happen when a user is added to a conversation that is federated.
+  -- Unfortunately, that can only be manually verified by looking at the logs.
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  conv <- postConversation alice defProteus >>= getJSON 201
+
+  withWebSocket bob $ \bobWs -> do
+    addMembers alice conv def {users = [bob]} >>= assertSuccess
+    void $ awaitMatch isMemberJoinNotif bobWs
+
+  checkConvMembers conv alice [bob]
+  retryT $ checkConvMembers conv bob [alice]
+  where
+    checkConvMembers :: (HasCallStack, MakesValue user) => Value -> user -> [Value] -> App ()
+    checkConvMembers conv self others =
+      bindResponse (getConversation self conv) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        mems <- resp.json %. "members.others" & asList
+        for mems (%. "qualified_id") `shouldMatchSet` (for others (%. "qualified_id"))
+
 testDynamicBackendsFullyConnectedWhenAllowAll :: (HasCallStack) => App ()
 testDynamicBackendsFullyConnectedWhenAllowAll = do
   -- The default setting is 'allowAll'

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -1000,8 +1000,8 @@ updateLocalStateOfRemoteConv rcu con = do
   -- however they are included in the alreadyPresentUsers from the incoming request.
   -- To have a meaningful check here, we need to include the extra targets (the newly added users)
   -- when matching the present users against the alreadyPresentUsers.
-  let allUsersExceptExtraTargetsArePresent =
-        Set.fromList (presentUsers <> extraTargets) == Set.fromList cu.alreadyPresentUsers
+  let targets = nubOrd $ presentUsers <> extraTargets
+      allUsersExceptExtraTargetsArePresent = Set.fromList targets == Set.fromList cu.alreadyPresentUsers
   unless allUsersExceptExtraTargetsArePresent $
     P.warn $
       Log.field "conversation" (toByteString' cu.convId)
@@ -1015,7 +1015,6 @@ updateLocalStateOfRemoteConv rcu con = do
   -- Send notifications
   for mActualAction $ \(SomeConversationAction tag action) -> do
     let event = conversationActionToEvent tag cu.time cu.origUserId qconvId Nothing Nothing action
-        targets = nubOrd $ presentUsers <> extraTargets
     -- FUTUREWORK: support bots?
     pushConversationEvent con () event (qualifyAs loc targets) [] $> event
 

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -950,7 +950,7 @@ updateLocalStateOfRemoteConv rcu con = do
   -- Note: we generally do not send notifications to users that are not part of
   -- the conversation (from our point of view), to prevent spam from the remote
   -- backend. See also the comment below.
-  (presentUsers, allUsersArePresent) <-
+  (presentUsers, _) <-
     E.selectRemoteMembers cu.alreadyPresentUsers rconvId
 
   -- Perform action, and determine extra notification targets.
@@ -996,7 +996,13 @@ updateLocalStateOfRemoteConv rcu con = do
       SConversationUpdateAddPermissionTag -> pure (Just sca, [])
       SConversationResetTag -> pure (Just sca, [])
 
-  unless allUsersArePresent $
+  -- On conversation join, the member(s) joining are not included in the presentUsers,
+  -- however they are included in the alreadyPresentUsers from the incoming request.
+  -- To have a meaningful check here, we need to include the extra targets (the newly added users)
+  -- when matching the present users against the alreadyPresentUsers.
+  let allUsersExceptExtraTargetsArePresent =
+        Set.fromList (presentUsers <> extraTargets) == Set.fromList cu.alreadyPresentUsers
+  unless allUsersExceptExtraTargetsArePresent $
     P.warn $
       Log.field "conversation" (toByteString' cu.convId)
         . Log.field "domain" (toByteString' (tDomain rcu))

--- a/services/galley/src/Galley/API/Action/Notify.hs
+++ b/services/galley/src/Galley/API/Action/Notify.hs
@@ -51,11 +51,12 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
       e = conversationActionToEvent tag now quid (tUntagged lcnv) Nothing tid action
       mkUpdate uids =
         ConversationUpdate
-          now
-          quid
-          (tUnqualified lcnv)
-          uids
-          (SomeConversationAction tag action)
+          { time = now,
+            origUserId = quid,
+            convId = tUnqualified lcnv,
+            alreadyPresentUsers = uids,
+            action = SomeConversationAction tag action
+          }
   update <-
     fmap (fromMaybe (mkUpdate []) . asum . map tUnqualified) $
       enqueueNotificationsConcurrently Q.Persistent (toList (bmRemotes targets)) $


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-18478

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
