### PR TITLE
Remove non-backend teams from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
 *		@wireapp/backend
-/changelog.d/	@wireapp/backend @wireapp/platform-engineering @wireapp/customerops
-/charts/	@wireapp/backend @wireapp/platform-engineering @wireapp/customerops
-/docs/		@wireapp/backend @wireapp/platform-engineering @wireapp/customerops


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
