### PR TITLE
background-worker/dead-user-notifs-watcher: Reconnect when connection with RabbitMQ is broken

### DIFF
--- a/changelog.d/2-features/bw-metrics
+++ b/changelog.d/2-features/bw-metrics
@@ -1,0 +1,3 @@
+background-worker: New gauge metric `wire_background_worker_running_workers`,
+contains label `worker` for each worker. Set to `1` when the worker is running,
+set to `0` when the worker is not running.

--- a/changelog.d/3-bug-fixes/rabbitmq-reconnect
+++ b/changelog.d/3-bug-fixes/rabbitmq-reconnect
@@ -1,0 +1,1 @@
+background-worker/dead-user-notifs-watcher: Reconnect when connection with RabbitMQ is broken

--- a/integration/test/Test/Cells.hs
+++ b/integration/test/Test/Cells.hs
@@ -172,7 +172,7 @@ connectToCellsQueue sm messages = do
           skipAsyncExceptions
           ( const $ do
               connOpts <-
-                mkConnectionOpts opts
+                mkConnectionOpts opts Nothing
               liftIO $ openConnection'' connOpts
           )
   conn <-

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -493,7 +493,7 @@ testEventsDeadLetteredWithReconnect = do
         ackEvent ws e
 
       -- We've consumed the whole queue.
-      consumeEventsUntilEndOfInitialSync ws endMarker `shouldMatch` ([] :: [Value])
+      assertEndOfIniitalSync ws endMarker
   where
     killAllDeadUserNotificationRabbitMqConns :: (HasCallStack) => BackendResource -> App ()
     killAllDeadUserNotificationRabbitMqConns backend = do
@@ -1048,6 +1048,12 @@ consumeEventsUntilEndOfInitialSync ws expectedMarkerId = go []
                 then pure (events <> [e])
                 else assertFailure $ "Expected marker_id " <> expectedMarkerId <> ", but got " <> markerId
             else go (events <> [e])
+
+assertEndOfIniitalSync :: (HasCallStack) => EventWebSocket -> String -> App ()
+assertEndOfIniitalSync ws endMarker =
+  assertEvent ws $ \e -> do
+    e %. "type" `shouldMatch` "synchronization"
+    e %. "data.marker_id" `shouldMatch` endMarker
 
 consumeAllEvents_ :: EventWebSocket -> App ()
 consumeAllEvents_ = void . consumeAllEvents

--- a/integration/test/Test/Events.hs
+++ b/integration/test/Test/Events.hs
@@ -458,6 +458,58 @@ testEventsDeadLettered = do
       -- We've consumed the whole queue.
       assertNoEvent_ ws
 
+testEventsDeadLetteredWithReconnect :: (HasCallStack) => App ()
+testEventsDeadLetteredWithReconnect = do
+  let notifTTL = 1 # Second
+  startDynamicBackendsReturnResources [def {gundeckCfg = setField "settings.notificationTTL" (notifTTL #> Second)}] $ \[resources] -> do
+    let domain :: String = resources.berDomain
+    alice <- randomUser domain def
+
+    -- This generates an event
+    client <- addClient alice def {acapabilities = Just ["consumable-notifications"]} >>= getJSON 201
+    clientId <- objId client
+
+    -- Force a reconnect by deleting the existing connection
+    killAllDeadUserNotificationRabbitMqConns resources
+
+    -- We expire the add client event by waiting it out
+    Timeout.threadDelay (notifTTL + 500 # MilliSecond)
+
+    -- Generate a second event
+    handle1 <- randomHandle
+    putHandle alice handle1 >>= assertSuccess
+
+    runCodensity (createEventsWebSocketWithSync alice (Just clientId)) $ \(endMarker, ws) -> do
+      assertEvent ws $ \e -> do
+        e %. "type" `shouldMatch` "notifications_missed"
+
+      -- Until we ack the full sync, we can't get new events
+      ackFullSync ws
+
+      -- Now we can see the next event
+      assertEvent ws $ \e -> do
+        e %. "data.event.payload.0.type" `shouldMatch` "user.update"
+        e %. "data.event.payload.0.user.handle" `shouldMatch` handle1
+        ackEvent ws e
+
+      -- We've consumed the whole queue.
+      consumeEventsUntilEndOfInitialSync ws endMarker `shouldMatch` ([] :: [Value])
+  where
+    killAllDeadUserNotificationRabbitMqConns :: (HasCallStack) => BackendResource -> App ()
+    killAllDeadUserNotificationRabbitMqConns backend = do
+      rabbitmqAdminClient <- mkRabbitMqAdminClientForResource backend
+      connections <- eventually $ do
+        conns <- getDeadUserNotificationConnections rabbitmqAdminClient backend.berVHost
+        assertAtLeastOne conns
+        pure conns
+      for_ connections $ \connection -> do
+        rabbitmqAdminClient.deleteConnection connection.name
+
+    getDeadUserNotificationConnections :: (HasCallStack) => AdminAPI (AsClientT App) -> String -> App [Connection]
+    getDeadUserNotificationConnections rabbitmqAdminClient vhost = do
+      connections <- rabbitmqAdminClient.listConnectionsByVHost (Text.pack vhost)
+      pure $ filter (\c -> Just (fromString "dead-user-notifications-watcher") == c.userProvidedName) connections
+
 testTransientEventsDoNotTriggerDeadLetters :: (HasCallStack) => App ()
 testTransientEventsDoNotTriggerDeadLetters = do
   let notifTTL = 1 # Second

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -71,7 +71,7 @@ shouldMatch ::
 shouldMatch = shouldMatchWithMsg Nothing
 
 -- | Retries every 100ms until timeOutSeconds from Env is reached
-eventually :: App () -> App ()
+eventually :: App a -> App a
 eventually action = do
   timeout <- asks (.timeOutSeconds)
   recovering

--- a/libs/extended/src/Network/AMQP/Extended.hs
+++ b/libs/extended/src/Network/AMQP/Extended.hs
@@ -138,7 +138,7 @@ mkRabbitMqChannelMVar :: Logger -> AmqpEndpoint -> IO (MVar Q.Channel)
 mkRabbitMqChannelMVar l opts = do
   chanMVar <- newEmptyMVar
   connThread <-
-    async . openConnectionWithRetries l opts $
+    async . openConnectionWithRetries l opts Nothing $
       RabbitMqHooks
         { onNewChannel = \conn -> putMVar chanMVar conn >> forever (threadDelay maxBound),
           onChannelException = \_ -> void $ tryTakeMVar chanMVar,
@@ -160,9 +160,10 @@ withConnection ::
   (MonadIO m, MonadMask m) =>
   Logger ->
   AmqpEndpoint ->
+  Maybe Text ->
   (Q.Connection -> m a) ->
   m a
-withConnection l AmqpEndpoint {..} k = do
+withConnection l AmqpEndpoint {..} connName k = do
   -- Jittered exponential backoff with 1ms as starting delay and 1s as total
   -- wait time.
   let policy = limitRetriesByCumulativeDelay 1_000_000 $ fullJitterBackoff 1000
@@ -180,13 +181,13 @@ withConnection l AmqpEndpoint {..} k = do
           )
           ( const $ do
               Log.info l $ Log.msg (Log.val "Trying to connect to RabbitMQ")
-              connOpts <- mkConnectionOpts AmqpEndpoint {..}
+              connOpts <- mkConnectionOpts AmqpEndpoint {..} connName
               liftIO $ Q.openConnection'' connOpts
           )
   bracket getConn (liftIO . Q.closeConnection) k
 
-mkConnectionOpts :: (MonadIO m) => AmqpEndpoint -> m Q.ConnectionOpts
-mkConnectionOpts AmqpEndpoint {..} = do
+mkConnectionOpts :: (MonadIO m) => AmqpEndpoint -> Maybe Text -> m Q.ConnectionOpts
+mkConnectionOpts AmqpEndpoint {..} name = do
   mTlsSettings <- traverse (liftIO . (mkTLSSettings host)) tls
   (username, password) <- liftIO $ readCredsFromEnv
   pure
@@ -194,7 +195,8 @@ mkConnectionOpts AmqpEndpoint {..} = do
       { Q.coServers = [(host, fromIntegral port)],
         Q.coVHost = vHost,
         Q.coAuth = [Q.plain username password],
-        Q.coTLSSettings = fmap Q.TLSCustom mTlsSettings
+        Q.coTLSSettings = fmap Q.TLSCustom mTlsSettings,
+        Q.coName = name
       }
 
 -- | Connects with RabbitMQ and opens a channel. If the channel is closed for
@@ -205,9 +207,10 @@ openConnectionWithRetries ::
   (MonadIO m, MonadMask m, MonadBaseControl IO m) =>
   Logger ->
   AmqpEndpoint ->
+  Maybe Text ->
   RabbitMqHooks m ->
   m ()
-openConnectionWithRetries l AmqpEndpoint {..} hooks = do
+openConnectionWithRetries l AmqpEndpoint {..} connName hooks = do
   (username, password) <- liftIO $ readCredsFromEnv
   connectWithRetries username password
   where
@@ -230,7 +233,7 @@ openConnectionWithRetries l AmqpEndpoint {..} hooks = do
               )
               ( const $ do
                   Log.info l $ Log.msg (Log.val "Trying to connect to RabbitMQ")
-                  connOpts <- mkConnectionOpts AmqpEndpoint {..}
+                  connOpts <- mkConnectionOpts AmqpEndpoint {..} connName
                   liftIO $ Q.openConnection'' connOpts
               )
       bracket getConn (liftIO . Q.closeConnection) $ \conn -> do

--- a/libs/extended/src/Network/AMQP/Extended.hs
+++ b/libs/extended/src/Network/AMQP/Extended.hs
@@ -134,11 +134,11 @@ demoteOpts :: RabbitMqAdminOpts -> AmqpEndpoint
 demoteOpts RabbitMqAdminOpts {..} = AmqpEndpoint {..}
 
 -- | Useful if the application only pushes into some queues.
-mkRabbitMqChannelMVar :: Logger -> AmqpEndpoint -> IO (MVar Q.Channel)
-mkRabbitMqChannelMVar l opts = do
+mkRabbitMqChannelMVar :: Logger -> Maybe Text -> AmqpEndpoint -> IO (MVar Q.Channel)
+mkRabbitMqChannelMVar l connName opts = do
   chanMVar <- newEmptyMVar
   connThread <-
-    async . openConnectionWithRetries l opts Nothing $
+    async . openConnectionWithRetries l opts connName $
       RabbitMqHooks
         { onNewChannel = \conn -> putMVar chanMVar conn >> forever (threadDelay maxBound),
           onChannelException = \_ -> void $ tryTakeMVar chanMVar,

--- a/services/background-worker/background-worker.cabal
+++ b/services/background-worker/background-worker.cabal
@@ -30,7 +30,6 @@ library
   build-depends:
       aeson
     , amqp
-    , async
     , base
     , bytestring
     , bytestring-conversion
@@ -42,7 +41,6 @@ library
     , http-client
     , http2-manager
     , imports
-    , kan-extensions
     , metrics-wai
     , monad-control
     , prometheus-client

--- a/services/background-worker/background-worker.cabal
+++ b/services/background-worker/background-worker.cabal
@@ -12,13 +12,13 @@ build-type:    Simple
 library
   -- cabal-fmt: expand src
   exposed-modules:
-    Wire.BackendDeadUserNotificationWatcher
     Wire.BackendNotificationPusher
     Wire.BackgroundWorker
     Wire.BackgroundWorker.Env
     Wire.BackgroundWorker.Health
     Wire.BackgroundWorker.Options
     Wire.BackgroundWorker.Util
+    Wire.DeadUserNotificationWatcher
 
   hs-source-dirs:     src
   default-language:   GHC2021

--- a/services/background-worker/background-worker.cabal
+++ b/services/background-worker/background-worker.cabal
@@ -53,7 +53,6 @@ library
     , transformers-base
     , types-common
     , unliftio
-    , utf8-string
     , wai-utilities
     , wire-api
     , wire-api-federation

--- a/services/background-worker/default.nix
+++ b/services/background-worker/default.nix
@@ -38,7 +38,6 @@
 , transformers-base
 , types-common
 , unliftio
-, utf8-string
 , wai
 , wai-utilities
 , wire-api
@@ -76,7 +75,6 @@ mkDerivation {
     transformers-base
     types-common
     unliftio
-    utf8-string
     wai-utilities
     wire-api
     wire-api-federation

--- a/services/background-worker/default.nix
+++ b/services/background-worker/default.nix
@@ -5,7 +5,6 @@
 { mkDerivation
 , aeson
 , amqp
-, async
 , base
 , bytestring
 , bytestring-conversion
@@ -23,7 +22,6 @@
 , http-types
 , http2-manager
 , imports
-, kan-extensions
 , lib
 , metrics-wai
 , monad-control
@@ -55,7 +53,6 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson
     amqp
-    async
     base
     bytestring
     bytestring-conversion
@@ -67,7 +64,6 @@ mkDerivation {
     http-client
     http2-manager
     imports
-    kan-extensions
     metrics-wai
     monad-control
     prometheus-client

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -314,7 +314,6 @@ getRemoteDomains adminClient = do
           . Log.field "queue" ("backend-notifications." <> d)
           . Log.field "error" e
 
--- FUTUREWORK: rework this in the vein of DeadLetterWatcher
 startWorker :: AmqpEndpoint -> AppT IO (IORef (Maybe Q.Channel), IORef (Map Domain (Q.ConsumerTag, MVar ())))
 startWorker rabbitmqOpts = do
   env <- ask

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -333,7 +333,8 @@ startWorker rabbitmqOpts = do
       Log.info $
         Log.msg $
           Log.val "RabbitMQ admin client not available, skipping backend notification pusher."
-    Just client ->
+    Just client -> do
+      markAsNotWorking BackendNotificationPusher
       -- We can fire and forget this thread because it keeps respawning itself using the 'onConnectionClosedHandler'.
       void $
         async $

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -22,6 +22,7 @@ import Network.RabbitMqAdmin qualified as RabbitMqAdmin
 import Network.Wai.Utilities.Error
 import Prometheus
 import Servant.Client qualified as Servant
+import System.Logger qualified as Logger
 import System.Logger.Class qualified as Log
 import UnliftIO
 import Wire.API.Federation.API
@@ -314,7 +315,7 @@ getRemoteDomains adminClient = do
           . Log.field "queue" ("backend-notifications." <> d)
           . Log.field "error" e
 
-startWorker :: AmqpEndpoint -> AppT IO (IORef (Maybe Q.Channel), IORef (Map Domain (Q.ConsumerTag, MVar ())))
+startWorker :: AmqpEndpoint -> AppT IO CleanupAction
 startWorker rabbitmqOpts = do
   env <- ask
   -- These are used in the POSIX signal handlers, so we need to make
@@ -352,4 +353,28 @@ startWorker rabbitmqOpts = do
                     clearRefs
                     runAppT env $ markAsNotWorking BackendNotificationPusher
                 }
-  pure (chanRef, consumersRef)
+  pure $ cleanupWorker env.logger chanRef consumersRef
+
+cleanupWorker :: Logger.Logger -> IORef (Maybe Q.Channel) -> IORef (Map Domain (Q.ConsumerTag, MVar ())) -> CleanupAction
+cleanupWorker l notifChanRef notifConsumersRef = do
+  Logger.info l $ Log.msg (Log.val "Cancelling the notification pusher thread")
+  readIORef notifChanRef >>= traverse_ \chan -> do
+    Logger.info l $ Log.msg (Log.val "Got channel")
+    readIORef notifConsumersRef >>= \m -> for_ (Map.assocs m) \(domain, (consumer, runningFlag)) -> do
+      Logger.info l $ Log.msg (Log.val "Cancelling consumer") . Log.field "Domain" domain._domainText
+      -- Remove the consumer from the channel so it isn't called again
+      Q.cancelConsumer chan consumer
+      -- Take from the mvar. This will only unblock when the consumer callback isn't running.
+      -- This allows us to wait until the currently running tasks are completed, and new ones
+      -- won't be scheduled because we've already removed the callback from the channel.
+      -- If, for some reason, a consumer is invoked after us cancelling it, taking this MVar
+      -- will block that thread from trying to push out the notification. At this point, we're
+      -- relying on Rabbit to requeue the message for us as we won't be able to ACK or NACK it.
+      -- This helps prevent message redelivery to endpoint services during the brief window between
+      -- receiving a message from rabbit, and the signal handler shutting down the AMQP connection
+      -- before notification delivery has finalised.
+      Logger.info l $ Log.msg $ Log.val "Taking MVar. Waiting for current operation to finish"
+      takeMVar runningFlag
+    -- Close the channel. `extended` will then close the connection, flushing messages to the server.
+    Logger.info l $ Log.msg $ Log.val "Closing RabbitMQ channel"
+    Q.closeChannel chan

--- a/services/background-worker/src/Wire/BackendNotificationPusher.hs
+++ b/services/background-worker/src/Wire/BackendNotificationPusher.hs
@@ -338,7 +338,7 @@ startWorker rabbitmqOpts = do
       void $
         async $
           liftIO $
-            openConnectionWithRetries env.logger rabbitmqOpts $
+            openConnectionWithRetries env.logger rabbitmqOpts (Just "backend-notification-pusher") $
               RabbitMqHooks
                 { -- The exception handling in `openConnectionWithRetries` won't open a new
                   -- connection on an explicit close call.

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -14,11 +14,11 @@ import Servant
 import Servant.Server.Generic
 import System.Logger qualified as Log
 import Util.Options
-import Wire.BackendDeadUserNotificationWatcher qualified as DeadUserNotificationWatcher
 import Wire.BackendNotificationPusher qualified as BackendNotificationPusher
 import Wire.BackgroundWorker.Env
 import Wire.BackgroundWorker.Health qualified as Health
 import Wire.BackgroundWorker.Options
+import Wire.DeadUserNotificationWatcher qualified as DeadUserNotificationWatcher
 
 run :: Opts -> IO ()
 run opts = do

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -2,17 +2,14 @@
 
 module Wire.BackgroundWorker where
 
-import Data.Domain
-import Data.Map.Strict qualified as Map
 import Data.Metrics.Servant qualified as Metrics
 import Data.Text qualified as T
 import Imports
-import Network.AMQP qualified as Q
 import Network.AMQP.Extended (demoteOpts)
 import Network.Wai.Utilities.Server
 import Servant
 import Servant.Server.Generic
-import System.Logger qualified as Log
+import UnliftIO (concurrently_)
 import Util.Options
 import Wire.BackendNotificationPusher qualified as BackendNotificationPusher
 import Wire.BackgroundWorker.Env
@@ -24,36 +21,12 @@ run :: Opts -> IO ()
 run opts = do
   env <- mkEnv opts
   let amqpEP = either id demoteOpts opts.rabbitmq.unRabbitMqOpts
-  (notifChanRef, notifConsumersRef) <- runAppT env $ BackendNotificationPusher.startWorker amqpEP
+  cleanupBackendNotifPusher <- runAppT env $ BackendNotificationPusher.startWorker amqpEP
   cleanupDeadUserNotifWatcher <- runAppT env $ DeadUserNotificationWatcher.startWorker amqpEP
   let -- cleanup will run in a new thread when the signal is caught, so we need to use IORefs and
       -- specific exception types to message threads to clean up
-      l = logger env
       cleanup = do
-        cleanupDeadUserNotifWatcher
-
-        -- Notification pusher thread
-        Log.info l $ Log.msg (Log.val "Cancelling the notification pusher thread")
-        readIORef notifChanRef >>= traverse_ \chan -> do
-          Log.info l $ Log.msg (Log.val "Got channel")
-          readIORef notifConsumersRef >>= \m -> for_ (Map.assocs m) \(domain, (consumer, runningFlag)) -> do
-            Log.info l $ Log.msg (Log.val "Cancelling consumer") . Log.field "Domain" domain._domainText
-            -- Remove the consumer from the channel so it isn't called again
-            Q.cancelConsumer chan consumer
-            -- Take from the mvar. This will only unblock when the consumer callback isn't running.
-            -- This allows us to wait until the currently running tasks are completed, and new ones
-            -- won't be scheduled because we've already removed the callback from the channel.
-            -- If, for some reason, a consumer is invoked after us cancelling it, taking this MVar
-            -- will block that thread from trying to push out the notification. At this point, we're
-            -- relying on Rabbit to requeue the message for us as we won't be able to ACK or NACK it.
-            -- This helps prevent message redelivery to endpoint services during the brief window between
-            -- receiving a message from rabbit, and the signal handler shutting down the AMQP connection
-            -- before notification delivery has finalised.
-            Log.info l $ Log.msg $ Log.val "Taking MVar. Waiting for current operation to finish"
-            takeMVar runningFlag
-          -- Close the channel. `extended` will then close the connection, flushing messages to the server.
-          Log.info l $ Log.msg $ Log.val "Closing RabbitMQ channel"
-          Q.closeChannel chan
+        concurrently_ cleanupDeadUserNotifWatcher cleanupBackendNotifPusher
   let server = defaultServer (T.unpack $ opts.backgroundWorker.host) opts.backgroundWorker.port env.logger
   settings <- newSettings server
   -- Additional cleanup when shutting down via signals.

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -134,3 +134,9 @@ markAsWorking worker =
 markAsNotWorking :: (MonadIO m) => Worker -> AppT m ()
 markAsNotWorking worker =
   flip modifyIORef (Map.insert worker False) =<< asks statuses
+
+withNamedLogger :: (MonadIO m) => Text -> AppT m a -> AppT m a
+withNamedLogger name action = do
+  env <- ask
+  namedLogger <- lift $ Log.new $ Log.setName (Just name) $ Log.settings env.logger
+  lift $ runAppT (env {logger = namedLogger}) action

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -148,7 +148,7 @@ markAsNotWorking :: (MonadIO m, MonadMonitor m) => Worker -> AppT m ()
 markAsNotWorking worker = do
   env <- ask
   modifyIORef env.statuses (Map.insert worker False)
-  withLabel env.workerRunningGauge (workerName worker) (flip setGauge 1)
+  withLabel env.workerRunningGauge (workerName worker) (flip setGauge 0)
 
 withNamedLogger :: (MonadIO m) => Text -> AppT m a -> AppT m a
 withNamedLogger name action = do

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -29,7 +29,7 @@ type IsWorking = Bool
 -- | Eventually this will be a sum type of all the types of workers
 data Worker
   = BackendNotificationPusher
-  | BackendDeadUserNoticationWatcher
+  | DeadUserNotificationWatcher
   deriving (Show, Eq, Ord)
 
 data Env = Env

--- a/services/background-worker/src/Wire/BackgroundWorker/Util.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Util.hs
@@ -12,3 +12,5 @@ class RabbitMQEnvelope e where
 instance RabbitMQEnvelope Q.Envelope where
   ack = Q.ackEnv
   reject = Q.rejectEnv
+
+type CleanupAction = IO ()

--- a/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
+++ b/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
@@ -95,16 +95,16 @@ startWorker amqp = do
     RabbitMqHooks
       { onNewChannel = \chan -> do
           consumerTag <- startConsumer chan
-          writeIORef cleanupRef (Just (chan, consumerTag))
+          atomicWriteIORef cleanupRef (Just (chan, consumerTag))
           forever $ threadDelay maxBound,
         onConnectionClose = do
           markAsNotWorking DeadUserNotificationWatcher
-          writeIORef cleanupRef Nothing
+          atomicWriteIORef cleanupRef Nothing
           Log.err env.logger $
             Log.msg (Log.val "RabbitMQ Connection closed."),
         onChannelException = \e -> do
           markAsNotWorking DeadUserNotificationWatcher
-          writeIORef cleanupRef Nothing
+          atomicWriteIORef cleanupRef Nothing
           unless (Q.isNormalChannelClose e) $
             Log.err env.logger $
               Log.msg (Log.val "Caught exception in RabbitMQ channel.")

--- a/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
+++ b/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
@@ -96,6 +96,9 @@ startWorker amqp = do
       { onNewChannel = \chan -> do
           consumerTag <- startConsumer chan
           atomicWriteIORef cleanupRef (Just (chan, consumerTag))
+          -- Wait forever because when onNewChannel hooks finishes, it is
+          -- assumed that the work for RabbitMQ is done and the connection with
+          -- RabbitMQ is closed.
           forever $ threadDelay maxBound,
         onConnectionClose = do
           markAsNotWorking DeadUserNotificationWatcher

--- a/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
+++ b/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
@@ -18,6 +18,7 @@ import System.Logger qualified as Log
 import UnliftIO (async)
 import Wire.API.Notification
 import Wire.BackgroundWorker.Env
+import Wire.BackgroundWorker.Util
 
 getLastDeathQueue :: Maybe FieldTable -> Maybe ByteString
 getLastDeathQueue (Just (FieldTable headers)) = do
@@ -82,11 +83,9 @@ markAsNeedsFullSync cassandra uid cid = do
           VALUES (?, ?)
       |]
 
-type CleanupAction = IO ()
-
 startWorker ::
   AmqpEndpoint ->
-  AppT IO (CleanupAction)
+  AppT IO CleanupAction
 startWorker amqp = do
   env <- ask
   cleanupRef <- newIORef Nothing

--- a/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
+++ b/services/background-worker/src/Wire/DeadUserNotificationWatcher.hs
@@ -89,6 +89,7 @@ startWorker ::
 startWorker amqp = do
   env <- ask
   cleanupRef <- newIORef Nothing
+  markAsNotWorking DeadUserNotificationWatcher
   -- We can fire and forget this thread because it keeps respawning itself using the 'onConnectionClosedHandler'.
   void . async . openConnectionWithRetries env.logger amqp (Just "dead-user-notifications-watcher") $
     RabbitMqHooks

--- a/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
+++ b/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
@@ -331,6 +331,7 @@ spec = do
           backendNotificationsConfig = BackendNotificationsConfig 1000 500000 1000
 
       backendNotificationMetrics <- mkBackendNotificationMetrics
+      workerRunningGauge <- mkWorkerRunningGauge
       domains <- runAppT Env {..} $ getRemoteDomains (fromJust rabbitmqAdminClient)
       domains `shouldBe` map Domain ["foo.example", "bar.example", "baz.example"]
       readTVarIO mockAdmin.listQueuesVHostCalls `shouldReturn` ["test-vhost"]
@@ -348,6 +349,7 @@ spec = do
           defederationTimeout = responseTimeoutNone
           backendNotificationsConfig = BackendNotificationsConfig 1000 500000 1000
       backendNotificationMetrics <- mkBackendNotificationMetrics
+      workerRunningGauge <- mkWorkerRunningGauge
       domainsThread <- async $ runAppT Env {..} $ getRemoteDomains (fromJust rabbitmqAdminClient)
 
       -- Wait for first call

--- a/services/background-worker/test/Test/Wire/Util.hs
+++ b/services/background-worker/test/Test/Wire/Util.hs
@@ -17,6 +17,7 @@ testEnv = do
   let cassandra = undefined
   statuses <- newIORef mempty
   backendNotificationMetrics <- mkBackendNotificationMetrics
+  workerRunningGauge <- mkWorkerRunningGauge
   httpManager <- newManager defaultManagerSettings
   let federatorInternal = Endpoint "localhost" 0
       rabbitmqAdminClient = undefined

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -279,7 +279,7 @@ newEnv opts = do
       Log.info lgr $ Log.msg (Log.val "randomPrekeys: not active; using dynamoDB instead.")
       pure Nothing
   kpLock <- newMVar ()
-  rabbitChan <- traverse (Q.mkRabbitMqChannelMVar lgr) opts.rabbitmq
+  rabbitChan <- traverse (Q.mkRabbitMqChannelMVar lgr (Just "brig")) opts.rabbitmq
   let allDisabledVersions = foldMap expandVersionExp opts.settings.disabledAPIVersions
   idxEnv <- mkIndexEnv opts.elasticsearch lgr (Opt.galley opts) mgr
   rateLimitEnv <- newRateLimitEnv opts.settings.passwordHashingRateLimit

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -175,7 +175,7 @@ createEnv o l = do
     <*> initExtEnv
     <*> maybe (pure Nothing) (fmap Just . Aws.mkEnv l mgr) (o ^. journal)
     <*> traverse loadAllMLSKeys (o ^. settings . mlsPrivateKeyPaths)
-    <*> traverse (mkRabbitMqChannelMVar l) (o ^. rabbitmq)
+    <*> traverse (mkRabbitMqChannelMVar l (Just "galley")) (o ^. rabbitmq)
     <*> pure codeURIcfg
     <*> newRateLimitEnv (o ^. settings . passwordHashingRateLimit)
 

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -104,7 +104,7 @@ createEnv o = do
         { updateAction = Ms . round . (* 1000) <$> getPOSIXTime
         }
   mtbs <- mkThreadBudgetState `mapM` (o ^. settings . maxConcurrentNativePushes)
-  rabbitMqChannelMVar <- Q.mkRabbitMqChannelMVar l (o ^. rabbitmq)
+  rabbitMqChannelMVar <- Q.mkRabbitMqChannelMVar l (Just "gundeck") (o ^. rabbitmq)
   pure $! (rThread : rAdditionalThreads,) $! Env (RequestId defRequestId) o l n p r rAdditional a io mtbs rabbitMqChannelMVar
 
 reqIdMsg :: RequestId -> Logger.Msg -> Logger.Msg


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-18631

Alternative approach for #4632 (Test is copied from there). 

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
