### PR TITLE
background-worker: Set metric gauge `wire_background_worker_running_workers` to 1 when a worker is running instead of 0

### DIFF
--- a/changelog.d/3-bug-fixes/bw-metrics
+++ b/changelog.d/3-bug-fixes/bw-metrics
@@ -1,0 +1,1 @@
+background-worker: Set metric gauge `wire_background_worker_running_workers` to 1 when a worker is running instead of 0.

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -148,7 +148,7 @@ updateWorkingStatus :: (MonadIO m, MonadMonitor m) => Bool -> Worker -> AppT m (
 updateWorkingStatus isWorking worker = do
   env <- ask
   modifyIORef env.statuses (Map.insert worker isWorking)
-  withLabel env.workerRunningGauge (workerName worker) (flip setGauge (if isWorking then 0 else 1))
+  withLabel env.workerRunningGauge (workerName worker) (flip setGauge (if isWorking then 1 else 0))
 
 withNamedLogger :: (MonadIO m) => Text -> AppT m a -> AppT m a
 withNamedLogger name action = do


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
