### PR TITLE
integration-setup: Use docker registry for bitnami

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ libzauth:
 kube-integration:  kube-integration-setup kube-integration-test
 
 .PHONY: kube-integration-setup
-kube-integration-setup: charts-integration helm-oci-login
+kube-integration-setup: charts-integration
 	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); ./hack/bin/integration-setup-federation.sh
 
 .PHONY: kube-integration-test
@@ -467,9 +467,6 @@ kube-integration-e2e-telepresence:
 kube-restart-%:
 	kubectl delete pod -n $(NAMESPACE) -l app=$(*)
 	kubectl delete pod -n $(NAMESPACE)-fed2 -l app=$(*)
-
-helm-oci-login:
-	./hack/bin/helm-oci-login.sh
 
 .PHONY: latest-tag
 latest-tag:

--- a/charts/redis-ephemeral/requirements.yaml
+++ b/charts/redis-ephemeral/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis
   version: 19.6.4 # redis 7.2.5
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   alias: redis-ephemeral

--- a/hack/bin/helm-oci-login.sh
+++ b/hack/bin/helm-oci-login.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-if [[ -z "${DOCKER_HUB_USERNAME+x}" ]]; then
-    echo "Not logging in to docker hub as there are no credentials provided."
-else
-    helm registry login registry-1.docker.io --username "${DOCKER_HUB_USERNAME}" --password "${DOCKER_HUB_PASSWORD}"
-fi

--- a/hack/bin/integration-setup-federation.sh
+++ b/hack/bin/integration-setup-federation.sh
@@ -51,13 +51,7 @@ export FEDERATION_CA_CERTIFICATE
 echo "Installing charts..."
 
 set +e
-# This exists because we need to run `helmfile` with `--skip-deps`, without that it doesn't work.
-helm repo add bedag https://bedag.github.io/helm-charts/
-helm repo add obeone https://charts.obeone.cloud
-helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm repo add bitnami https://charts.bitnami.com/bitnami
-
-helmfile --environment "$HELMFILE_ENV" --file "${TOP_LEVEL}/hack/helmfile.yaml.gotmpl" sync --skip-deps --concurrency 0
+helmfile --environment "$HELMFILE_ENV" --file "${TOP_LEVEL}/hack/helmfile.yaml.gotmpl" sync --concurrency 0
 EXIT_CODE=$?
 
 if (( EXIT_CODE > 0)); then

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -62,6 +62,9 @@ environments:
           caSecretName: elasticsearch-ephemeral-certificate
 ---
 repositories:
+  - name: incubator
+    url: https://charts.helm.sh/incubator
+
   - name: stable
     url: 'https://charts.helm.sh/stable'
 

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -78,7 +78,10 @@ repositories:
     url: 'https://opensearch-project.github.io/helm-charts/'
 
   - name: bitnami
-    url: https://charts.bitnami.com/bitnami
+    url: registry-1.docker.io/bitnamicharts
+    oci: true
+    username: '{{ env "DOCKER_HUB_USERNAME" }}'
+    password: '{{ env "DOCKER_HUB_PASSWORD" }}'
 
 releases:
   - name: 'fake-aws'


### PR DESCRIPTION
This way helmfile correctly logs in to the repository. To make it happen during `helmfile sync` `--skip-deps` cannot be passed anymore.

https://wearezeta.atlassian.net/browse/WPB-18677

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
