### PR TITLE
integration-setup: Add explicit helm login to docker hub 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ libzauth:
 kube-integration:  kube-integration-setup kube-integration-test
 
 .PHONY: kube-integration-setup
-kube-integration-setup: charts-integration
+kube-integration-setup: charts-integration helm-oci-login
 	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); ./hack/bin/integration-setup-federation.sh
 
 .PHONY: kube-integration-test
@@ -462,6 +462,9 @@ kube-integration-teardown:
 .PHONY: kube-integration-e2e-telepresence
 kube-integration-e2e-telepresence:
 	./services/brig/federation-tests.sh $(NAMESPACE)
+
+helm-oci-login:
+	./hack/bin/helm-oci-login.sh
 
 .PHONY: kube-restart-%
 kube-restart-%:

--- a/Makefile
+++ b/Makefile
@@ -463,6 +463,7 @@ kube-integration-teardown:
 kube-integration-e2e-telepresence:
 	./services/brig/federation-tests.sh $(NAMESPACE)
 
+.PHONY: helm-oci-login
 helm-oci-login:
 	./hack/bin/helm-oci-login.sh
 

--- a/hack/bin/helm-oci-login.sh
+++ b/hack/bin/helm-oci-login.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${DOCKER_HUB_USERNAME+x}" ]]; then
+    echo "Not logging in to docker hub as there are no credentials provided."
+else
+    helm registry login registry-1.docker.io --username "${DOCKER_HUB_USERNAME}" --password "${DOCKER_HUB_PASSWORD}"
+fi

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -86,6 +86,12 @@ repositories:
     username: '{{ env "DOCKER_HUB_USERNAME" }}'
     password: '{{ env "DOCKER_HUB_PASSWORD" }}'
 
+  # Uses creds from DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD automatically.
+  # https://helmfile.readthedocs.io/en/latest/#oci-registries
+  - name: docker_hub
+    url: registry-1.docker.io
+    oci: true
+
 releases:
   - name: 'fake-aws'
     namespace: '{{ .Values.namespace1 }}'


### PR DESCRIPTION
This is required because we have to run `helm dep update` manually before
running `helmfile` even if we run `helmfile` without `--skip-sync` because `helm
dep update` needs to happen in a certain order to make sure all nested local
dependencies are packaged correctly.

It was removed in #4664 because it was wrongly considered unnecessary. 

https://wearezeta.atlassian.net/browse/WPB-18677

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
