### PR TITLE
Check consistency of group info

### DIFF
--- a/changelog.d/2-features/group-info-check
+++ b/changelog.d/2-features/group-info-check
@@ -1,0 +1,1 @@
+Add option to check group info consistency on every MLS commit

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -101,6 +101,9 @@ data:
       {{- end }}
       passwordHashingOptions: {{ toYaml .settings.passwordHashingOptions | nindent 8 }}
       passwordHashingRateLimit: {{ toYaml .settings.passwordHashingRateLimit | nindent 8 }}
+      {{- if .settings.checkGroupInfo }}
+      checkGroupInfo: {{ .settings.checkGroupInfo }}
+      {{- end }}
       featureFlags:
         sso: {{ .settings.featureFlags.sso }}
         legalhold: {{ .settings.featureFlags.legalhold }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -91,6 +91,8 @@ config:
       ipAddressExceptions: []
       maxRateLimitedKeys: 100000 # Estimated memory usage: 4 MB
 
+    checkGroupInfo: false
+
     # To disable proteus for new federated conversations:
     # federationProtocols: ["mls"]
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -873,6 +873,20 @@ The `ipAddressExceptions` have to be CIDR blocks which can be specified like
 by pass the rate limits. To limit one particular IP address, it can be specified
 as `127.0.0.1/32`.
 
+#### Group info consistency check
+
+To enable group info consistency checks on MLS commits:
+```
+# galley.yaml
+config:
+  settings:
+    checkGroupInfo: true
+```
+
+Enabling consistency checks makes Galley parse the ratchet tree
+extension in the group info of every commit and compare it to the
+group state after applying the commit.
+
 #### Disabling API versions
 
 It is possible to disable one ore more API versions. When an API version is disabled it won’t be advertised on the `GET /api-version` endpoint, neither in the `supported`, nor in the `development` section. Requests made to any endpoint of a disabled API version will result in the same error response as a request made to an API version that does not exist.

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -973,7 +973,8 @@ testInvalidLeafNodeSignature = do
 
 testGroupInfoMismatch :: (HasCallStack) => App ()
 testGroupInfoMismatch = withModifiedBackend
-  (def { galleyCfg = setField "settings.checkGroupInfo" True }) $ \domain -> do
+  (def {galleyCfg = setField "settings.checkGroupInfo" True})
+  $ \domain -> do
     [alice, bob, charlie] <- createAndConnectUsers [domain, domain, domain]
     [alice1, bob1, bob2, charlie1] <- traverse (createMLSClient def) [alice, bob, bob, charlie]
     traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
@@ -1009,16 +1010,16 @@ testGroupInfoMismatch = withModifiedBackend
 
 testGroupInfoCheckDisabled :: (HasCallStack) => App ()
 testGroupInfoCheckDisabled = do
-    [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain, OwnDomain]
-    [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
-    traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
-    conv <- createNewGroup def alice1
+  [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain, OwnDomain]
+  [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
+  traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
+  conv <- createNewGroup def alice1
 
-    mp1 <- createAddCommit alice1 conv [bob]
-    void $ sendAndConsumeCommitBundle mp1
+  mp1 <- createAddCommit alice1 conv [bob]
+  void $ sendAndConsumeCommitBundle mp1
 
-    -- attempt a commit with an old group info
-    mp2 <- createAddCommit alice1 conv [charlie]
-    bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
-      $ \resp -> do
-        resp.status `shouldMatchInt` 201
+  -- attempt a commit with an old group info
+  mp2 <- createAddCommit alice1 conv [charlie]
+  bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
+    $ \resp -> do
+      resp.status `shouldMatchInt` 201

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -972,36 +972,53 @@ testInvalidLeafNodeSignature = do
         Nothing -> bs
 
 testGroupInfoMismatch :: (HasCallStack) => App ()
-testGroupInfoMismatch = do
-  [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain, OwnDomain]
-  [alice1, bob1, bob2, charlie1] <- traverse (createMLSClient def) [alice, bob, bob, charlie]
-  traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
-  conv <- createNewGroup def alice1
+testGroupInfoMismatch = withModifiedBackend
+  (def { galleyCfg = setField "settings.checkGroupInfo" True }) $ \domain -> do
+    [alice, bob, charlie] <- createAndConnectUsers [domain, domain, domain]
+    [alice1, bob1, bob2, charlie1] <- traverse (createMLSClient def) [alice, bob, bob, charlie]
+    traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
+    conv <- createNewGroup def alice1
 
-  mp1 <- createAddCommit alice1 conv [bob]
-  void $ sendAndConsumeCommitBundle mp1
+    mp1 <- createAddCommit alice1 conv [bob]
+    void $ sendAndConsumeCommitBundle mp1
 
-  -- attempt a commit with an old group info
-  mp2 <- createAddCommit alice1 conv [charlie]
-  bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
-    $ \resp -> do
-      resp.status `shouldMatchInt` 400
-      resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
+    -- attempt a commit with an old group info
+    mp2 <- createAddCommit alice1 conv [charlie]
+    bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
+      $ \resp -> do
+        resp.status `shouldMatchInt` 400
+        resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
 
-  -- check that epoch is still 1
-  bindResponse (getConversation alice conv) $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json %. "epoch" `shouldMatchInt` 1
+    -- check that epoch is still 1
+    bindResponse (getConversation alice conv) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "epoch" `shouldMatchInt` 1
 
-  -- attempt an external commit with an old group info
-  void $ uploadNewKeyPackage def bob2
-  mp3 <- createExternalCommit conv bob2 Nothing
-  bindResponse (postMLSCommitBundle bob2 (mkBundle mp3 {groupInfo = mp1.groupInfo}))
-    $ \resp -> do
-      resp.status `shouldMatchInt` 400
-      resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
+    -- attempt an external commit with an old group info
+    void $ uploadNewKeyPackage def bob2
+    mp3 <- createExternalCommit conv bob2 Nothing
+    bindResponse (postMLSCommitBundle bob2 (mkBundle mp3 {groupInfo = mp1.groupInfo}))
+      $ \resp -> do
+        resp.status `shouldMatchInt` 400
+        resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
 
-  -- check that epoch is still 1
-  bindResponse (getConversation alice conv) $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json %. "epoch" `shouldMatchInt` 1
+    -- check that epoch is still 1
+    bindResponse (getConversation alice conv) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "epoch" `shouldMatchInt` 1
+
+testGroupInfoCheckDisabled :: (HasCallStack) => App ()
+testGroupInfoCheckDisabled = do
+    [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain, OwnDomain]
+    [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
+    traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
+    conv <- createNewGroup def alice1
+
+    mp1 <- createAddCommit alice1 conv [bob]
+    void $ sendAndConsumeCommitBundle mp1
+
+    -- attempt a commit with an old group info
+    mp2 <- createAddCommit alice1 conv [charlie]
+    bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
+      $ \resp -> do
+        resp.status `shouldMatchInt` 201

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -970,3 +970,38 @@ testInvalidLeafNodeSignature = do
       (left, right) -> case B.uncons right of
         Just (h, t) -> left <> B.singleton (h `xor` 0x01) <> t
         Nothing -> bs
+
+testGroupInfoMismatch :: (HasCallStack) => App ()
+testGroupInfoMismatch = do
+  [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain, OwnDomain]
+  [alice1, bob1, bob2, charlie1] <- traverse (createMLSClient def) [alice, bob, bob, charlie]
+  traverse_ (uploadNewKeyPackage def) [bob1, charlie1]
+  conv <- createNewGroup def alice1
+
+  mp1 <- createAddCommit alice1 conv [bob]
+  void $ sendAndConsumeCommitBundle mp1
+
+  -- attempt a commit with an old group info
+  mp2 <- createAddCommit alice1 conv [charlie]
+  bindResponse (postMLSCommitBundle mp2.sender (mkBundle mp2 {groupInfo = mp1.groupInfo}))
+    $ \resp -> do
+      resp.status `shouldMatchInt` 400
+      resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
+
+  -- check that epoch is still 1
+  bindResponse (getConversation alice conv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "epoch" `shouldMatchInt` 1
+
+  -- attempt an external commit with an old group info
+  void $ uploadNewKeyPackage def bob2
+  mp3 <- createExternalCommit conv bob2 Nothing
+  bindResponse (postMLSCommitBundle bob2 (mkBundle mp3 {groupInfo = mp1.groupInfo}))
+    $ \resp -> do
+      resp.status `shouldMatchInt` 400
+      resp.json %. "label" `shouldMatch` "mls-group-info-mismatch"
+
+  -- check that epoch is still 1
+  bindResponse (getConversation alice conv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "epoch" `shouldMatchInt` 1

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -106,6 +106,7 @@ data GalleyError
   | MLSMigrationCriteriaNotSatisfied
   | MLSFederatedOne2OneNotSupported
   | MLSFederatedResetNotSupported
+  | MLSGroupInfoMismatch
   | GroupIdVersionNotSupported
   | -- | MLS and federation are incompatible with legalhold - this error is thrown if a user
     -- tries to create an MLS group while being under legalhold
@@ -267,6 +268,8 @@ type instance MapError 'MLSMigrationCriteriaNotSatisfied = 'StaticError 400 "mls
 type instance MapError 'MLSFederatedOne2OneNotSupported = 'StaticError 400 "mls-federated-one2one-not-supported" "Federated One2One MLS conversations are only supported in API version >= 6"
 
 type instance MapError 'MLSFederatedResetNotSupported = 'StaticError 400 "mls-federated-reset-not-supported" "Reset is not supported by the owning backend of the conversation"
+
+type instance MapError 'MLSGroupInfoMismatch = 'StaticError 400 "mls-group-info-mismatch" "Ratchet tree mismatch in GroupInfo"
 
 type instance MapError 'GroupIdVersionNotSupported = 'StaticError 400 "mls-group-id-not-supported" "The group ID version of the conversation is not supported by one of the federated backends"
 

--- a/libs/wire-api/src/Wire/API/MLS/Extension.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Extension.hs
@@ -37,3 +37,15 @@ instance SerialiseMLS Extension where
   serialiseMLS (Extension ty d) = do
     serialiseMLS ty
     serialiseMLSBytes @VarInt d
+
+class IsExtension e where
+  extensionType :: Word16
+
+findExtension ::
+  forall e.
+  (ParseMLS e, IsExtension e) =>
+  [Extension] ->
+  Either Text [e]
+findExtension =
+  traverse (decodeMLS' . (.extData))
+    . filter (\e -> e.extType == extensionType @e)

--- a/libs/wire-api/src/Wire/API/MLS/GroupInfo.hs
+++ b/libs/wire-api/src/Wire/API/MLS/GroupInfo.hs
@@ -18,6 +18,7 @@
 module Wire.API.MLS.GroupInfo
   ( GroupContext (..),
     GroupInfo (..),
+    GroupInfoTBS (..),
     GroupInfoData (..),
   )
 where

--- a/libs/wire-api/src/Wire/API/MLS/RatchetTree.hs
+++ b/libs/wire-api/src/Wire/API/MLS/RatchetTree.hs
@@ -1,0 +1,61 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.MLS.RatchetTree where
+
+import Imports
+import Wire.API.MLS.Extension
+import Wire.API.MLS.HPKEPublicKey
+import Wire.API.MLS.LeafNode
+import Wire.API.MLS.Serialisation
+
+data RatchetTree = RatchetTree {nodes :: [RatchetTreeNode]}
+
+instance IsExtension RatchetTree where
+  extensionType = 2
+
+instance ParseMLS RatchetTree where
+  parseMLS = RatchetTree <$> parseMLSVector @VarInt parseMLS
+
+data RatchetTreeNodeTag = RatchetTreeLeafNodeTag | RatchetTreeParentNodeTag
+  deriving (Eq, Ord, Enum, Bounded)
+
+instance ParseMLS RatchetTreeNodeTag where
+  parseMLS = parseMLSEnum @Word8 "NodeType"
+
+data RatchetTreeNode
+  = RatchetTreeParentNode RatchetTreeParent
+  | RatchetTreeLeafNode LeafNode
+
+instance ParseMLS RatchetTreeNode where
+  parseMLS =
+    parseMLS >>= \case
+      RatchetTreeParentNodeTag -> RatchetTreeParentNode <$> parseMLS
+      RatchetTreeLeafNodeTag -> RatchetTreeLeafNode <$> parseMLS
+
+data RatchetTreeParent = RatchetTreeParent
+  { encryptionKey :: HPKEPublicKey,
+    parentHash :: ByteString,
+    unmergedLeaves :: [Word32]
+  }
+
+instance ParseMLS RatchetTreeParent where
+  parseMLS =
+    RatchetTreeParent
+      <$> parseMLS
+      <*> parseMLSBytes @VarInt
+      <*> parseMLSVector @VarInt parseMLS

--- a/libs/wire-api/src/Wire/API/MLS/RatchetTree.hs
+++ b/libs/wire-api/src/Wire/API/MLS/RatchetTree.hs
@@ -18,7 +18,6 @@
 module Wire.API.MLS.RatchetTree where
 
 import Data.Functor
-import Debug.Trace
 import Imports
 import Wire.API.MLS.Extension
 import Wire.API.MLS.HPKEPublicKey
@@ -66,15 +65,13 @@ instance ParseMLS RatchetTreeParent where
       <*> parseMLSVector @VarInt parseMLS
 
 ratchetTreeLeaves :: RatchetTree -> [(LeafIndex, LeafNode)]
-ratchetTreeLeaves tree =
-  trace (show (map void tree.nodes)) $
-    foldMap (traverse toNode) . zip [0 ..] . odds . (.nodes) $
-      tree
+ratchetTreeLeaves =
+  foldMap (traverse toNode) . zip [0 ..] . evens . (.nodes)
   where
-    odds :: [a] -> [a]
-    odds [] = []
-    odds [x] = [x]
-    odds (x : _ : xs) = (x : odds xs)
+    evens :: [a] -> [a]
+    evens [] = []
+    evens [x] = [x]
+    evens (x : _ : xs) = (x : evens xs)
 
     toNode :: Maybe RatchetTreeNode -> [LeafNode]
     toNode (Just (RatchetTreeLeafNode n)) = [n]

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -114,6 +114,7 @@ type MLSMessagingAPI =
                :> CanThrow MLSLegalholdIncompatible
                :> CanThrow MLSProposalFailure
                :> CanThrow MLSIdentityMismatch
+               :> CanThrow MLSGroupInfoMismatch
                :> CanThrow NonFederatingBackends
                :> CanThrow UnreachableBackends
                :> CanThrow GroupIdVersionNotSupported

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -121,7 +121,6 @@ library
     Wire.API.MLS.ECDSA
     Wire.API.MLS.Epoch
     Wire.API.MLS.Extension
-    Wire.API.MLS.RatchetTree
     Wire.API.MLS.Group
     Wire.API.MLS.Group.Serialisation
     Wire.API.MLS.GroupInfo
@@ -134,6 +133,7 @@ library
     Wire.API.MLS.Proposal
     Wire.API.MLS.ProposalTag
     Wire.API.MLS.ProtocolVersion
+    Wire.API.MLS.RatchetTree
     Wire.API.MLS.Serialisation
     Wire.API.MLS.Servant
     Wire.API.MLS.SubConversation

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -121,6 +121,7 @@ library
     Wire.API.MLS.ECDSA
     Wire.API.MLS.Epoch
     Wire.API.MLS.Extension
+    Wire.API.MLS.RatchetTree
     Wire.API.MLS.Group
     Wire.API.MLS.Group.Serialisation
     Wire.API.MLS.GroupInfo

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -111,12 +111,12 @@ getCommitData ::
   Epoch ->
   CipherSuiteTag ->
   IncomingBundle ->
-  Sem r ProposalAction
+  Sem r (IndexMap, ProposalAction)
 getCommitData senderIdentity lConvOrSub epoch ciphersuite bundle = do
   let convOrSub = tUnqualified lConvOrSub
       groupId = cnvmlsGroupId convOrSub.mlsMeta
 
-  evalState convOrSub.indexMap $ do
+  runState convOrSub.indexMap $ do
     creatorAction <-
       if epoch == Epoch 0
         then addProposedClient (Left senderIdentity.client)

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -116,7 +116,9 @@ getExternalCommitData senderIdentity lConvOrSub epoch commit = do
       _ -> throw (mlsProtocolError "External commits must contain at most one Remove proposal")
 
     -- add sender client
-    addedIndex <- gets imNextIndex
+    im <- get
+    let (addedIndex, im') = imAddClient im senderIdentity
+    put im'
 
     pure
       ExternalCommitAction

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -17,6 +17,7 @@
 
 module Galley.API.MLS.Commit.ExternalCommit
   ( ExternalCommitAction (..),
+    externalCommitActionApply,
     getExternalCommitData,
     processExternalCommit,
   )
@@ -59,6 +60,11 @@ data ExternalCommitAction = ExternalCommitAction
   { add :: LeafIndex,
     remove :: Maybe LeafIndex
   }
+
+externalCommitActionApply :: ExternalCommitAction -> a -> Map LeafIndex a -> Map LeafIndex a
+externalCommitActionApply action x =
+  Map.insert action.add x
+    . maybe id Map.delete action.remove
 
 getExternalCommitData ::
   forall r.

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -29,6 +29,7 @@ module Galley.API.MLS.Message
   )
 where
 
+import Control.Lens (view)
 import Control.Monad.Codensity
 import Data.Domain
 import Data.Id
@@ -39,7 +40,6 @@ import Data.Set qualified as Set
 import Data.Tagged
 import Data.Text.Lazy qualified as LT
 import Data.Tuple.Extra
-import Control.Lens (view)
 import Galley.API.Action
 import Galley.API.Error
 import Galley.API.LegalHold.Get (getUserStatus)
@@ -332,7 +332,7 @@ checkGroupState ::
   GroupInfo ->
   Sem r ()
 checkGroupState leaves groupInfo = do
-  check <- fromMaybe False <$> (inputs $ view $ settings . checkGroupInfo)
+  check <- fromMaybe False <$> inputs (view $ settings . checkGroupInfo)
   when check $ do
     trees <-
       either
@@ -345,7 +345,6 @@ checkGroupState leaves groupInfo = do
     giLeaves <- imFromList <$> traverse (traverse getIdentity) (ratchetTreeLeaves tree)
     when (leaves /= giLeaves) $ do
       throwS @MLSGroupInfoMismatch
-    pure ()
   where
     getIdentity :: LeafNode -> Sem r ClientIdentity
     getIdentity leaf = case credentialIdentityAndKey leaf.credential of

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -39,7 +39,6 @@ import Data.Set qualified as Set
 import Data.Tagged
 import Data.Text.Lazy qualified as LT
 import Data.Tuple.Extra
-import Debug.Trace
 import Galley.API.Action
 import Galley.API.Error
 import Galley.API.LegalHold.Get (getUserStatus)
@@ -333,8 +332,6 @@ checkGroupState leaves groupInfo = do
     (tree : _) -> pure tree
     _ -> throw $ mlsProtocolError "No ratchet tree extension found in GroupInfo"
   giLeaves <- imFromList <$> traverse (traverse getIdentity) (ratchetTreeLeaves tree)
-  traceM $ "leaves: " <> show leaves
-  traceM $ "giLeaves: " <> show giLeaves
   when (leaves /= giLeaves) $ do
     -- TODO: use specific error
     throw $ mlsProtocolError "GroupInfo mismatch"

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -29,7 +29,6 @@ module Galley.API.MLS.Proposal
     -- * Proposal actions
     paAddClient,
     paRemoveClient,
-    paApply,
 
     -- * Types
     ProposalAction (..),
@@ -95,12 +94,6 @@ paAddClient cid idx kp = mempty {paAdd = cmSingleton cid (idx, kp)}
 
 paRemoveClient :: ClientIdentity -> LeafIndex -> ProposalAction
 paRemoveClient cid idx = mempty {paRemove = cmSingleton cid idx}
-
-paApply :: ProposalAction -> Map LeafIndex ClientIdentity -> Map LeafIndex ClientIdentity
-paApply action =
-  let toInsert = Map.fromList $ map (\(cid, (idx, _)) -> (idx, cid)) (cmAssocs action.paAdd)
-      toDelete = Set.fromList $ map snd (cmAssocs action.paRemove)
-   in flip Map.withoutKeys toDelete . Map.union toInsert
 
 -- | This is used to sort proposals into the correct processing order, as defined by the spec
 data ProposalProcessingStage

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS -Wwarn #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -27,6 +29,7 @@ module Galley.API.MLS.Proposal
     -- * Proposal actions
     paAddClient,
     paRemoveClient,
+    paApply,
 
     -- * Types
     ProposalAction (..),
@@ -92,6 +95,12 @@ paAddClient cid idx kp = mempty {paAdd = cmSingleton cid (idx, kp)}
 
 paRemoveClient :: ClientIdentity -> LeafIndex -> ProposalAction
 paRemoveClient cid idx = mempty {paRemove = cmSingleton cid idx}
+
+paApply :: ProposalAction -> Map LeafIndex ClientIdentity -> Map LeafIndex ClientIdentity
+paApply action =
+  let toInsert = Map.fromList $ map (\(cid, (idx, _)) -> (idx, cid)) (cmAssocs action.paAdd)
+      toDelete = Set.fromList $ map snd (cmAssocs action.paRemove)
+   in flip Map.withoutKeys toDelete . Map.union toInsert
 
 -- | This is used to sort proposals into the correct processing order, as defined by the spec
 data ProposalProcessingStage

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS -Wwarn #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -88,6 +88,9 @@ mkClientMap = foldr addEntry mempty
       | pending_removal = id -- treat as removed, don't add to ClientMap
       | otherwise = Map.insertWith (<>) (Qualified usr dom) (Map.singleton c (fromIntegral leafidx))
 
+cmToMap :: (Ord a) => ClientMap a -> Map a ClientIdentity
+cmToMap = Map.fromList . map swap . cmAssocs
+
 cmLookupIndex :: ClientIdentity -> ClientMap LeafIndex -> Maybe LeafIndex
 cmLookupIndex cid cm = do
   clients <- Map.lookup (cidQualifiedUser cid) cm

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -18,10 +18,12 @@
 
 module Galley.API.MLS.Types where
 
+import Data.Bifunctor
 import Data.Domain
 import Data.Id
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
+import Data.IntSet qualified as IntSet
 import Data.Map qualified as Map
 import Data.Qualified
 import GHC.Records (HasField (..))
@@ -57,6 +59,9 @@ mkIndexMap = IndexMap . foldr addEntry mempty
 imLookup :: IndexMap -> LeafIndex -> Maybe ClientIdentity
 imLookup m i = IntMap.lookup (fromIntegral i) (unIndexMap m)
 
+imFromList :: [(LeafIndex, ClientIdentity)] -> IndexMap
+imFromList = IndexMap . IntMap.fromList . map (first fromIntegral)
+
 imNextIndex :: IndexMap -> LeafIndex
 imNextIndex im =
   fromIntegral . fromJust $
@@ -69,6 +74,12 @@ imRemoveClient :: IndexMap -> LeafIndex -> Maybe (ClientIdentity, IndexMap)
 imRemoveClient im idx = do
   cid <- imLookup im idx
   pure (cid, IndexMap . IntMap.delete (fromIntegral idx) $ unIndexMap im)
+
+imRemoveIndices :: [LeafIndex] -> IndexMap -> IndexMap
+imRemoveIndices keys =
+  IndexMap
+    . flip IntMap.withoutKeys (IntSet.fromList (map fromIntegral keys))
+    . unIndexMap
 
 -- | A two-level map of users to clients to leaf indices.
 --

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -56,6 +56,7 @@ module Galley.Options
     defGuestLinkTTLSeconds,
     passwordHashingOptions,
     passwordHashingRateLimit,
+    checkGroupInfo,
     GuestLinkTTLSeconds (..),
   )
 where
@@ -150,7 +151,9 @@ data Settings = Settings
     _guestLinkTTLSeconds :: !(Maybe GuestLinkTTLSeconds),
     _passwordHashingOptions :: !(PasswordHashingOptions),
     -- | Rate limiting options for hashing passwords (used for conversation codes)
-    _passwordHashingRateLimit :: RateLimitConfig
+    _passwordHashingRateLimit :: RateLimitConfig,
+    -- | Check group info
+    _checkGroupInfo :: !(Maybe Bool)
   }
   deriving (Show, Generic)
 


### PR DESCRIPTION
This PR adds an optional consistency check of the submitted group info on any commit. The ratchet tree extension is parsed and compared with the index map of the group after the commit is applied.

https://wearezeta.atlassian.net/browse/WPB-18394

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
