### PR TITLE
WPB-18562 Propagate a rate limit error with status 429 on internal call to reauthenticate

### DIFF
--- a/changelog.d/5-internal/WPB-18562
+++ b/changelog.d/5-internal/WPB-18562
@@ -1,0 +1,1 @@
+A rate limit error from an internal call to `i/users/:uid/reauthenticate` will now be propagated to the external caller


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
