### PR TITLE
Make `newSettings` pure

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -92,16 +92,15 @@ data Server = Server
 defaultServer :: String -> Word16 -> Logger -> Server
 defaultServer h p l = Server h p l Nothing
 
-newSettings :: (MonadIO m) => Server -> m Settings
-newSettings (Server h p l t) = do
-  pure
-    $ setHost (fromString h)
-      . setPort (fromIntegral p)
-      . setBeforeMainLoop logStart
-      . setOnOpen (const $ connStart >> pure True)
-      . setOnClose (const connEnd)
-      . setTimeout (fromMaybe 300 t)
-    $ defaultSettings
+newSettings :: Server -> Settings
+newSettings (Server h p l t) =
+  setHost (fromString h)
+  . setPort (fromIntegral p)
+  . setBeforeMainLoop logStart
+  . setOnOpen (const $ connStart >> pure True)
+  . setOnClose (const connEnd)
+  . setTimeout (fromMaybe 300 t)
+  $ defaultSettings
   where
     connStart = Prom.incGauge netConnections
     connEnd = Prom.decGauge netConnections

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -95,12 +95,12 @@ defaultServer h p l = Server h p l Nothing
 newSettings :: Server -> Settings
 newSettings (Server h p l t) =
   setHost (fromString h)
-  . setPort (fromIntegral p)
-  . setBeforeMainLoop logStart
-  . setOnOpen (const $ connStart >> pure True)
-  . setOnClose (const connEnd)
-  . setTimeout (fromMaybe 300 t)
-  $ defaultSettings
+    . setPort (fromIntegral p)
+    . setBeforeMainLoop logStart
+    . setOnOpen (const $ connStart >> pure True)
+    . setOnClose (const connEnd)
+    . setTimeout (fromMaybe 300 t)
+    $ defaultSettings
   where
     connStart = Prom.incGauge netConnections
     connEnd = Prom.decGauge netConnections

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -34,7 +34,7 @@ run opts = do
       cleanup = do
         concurrently_ cleanupDeadUserNotifWatcher cleanupBackendNotifPusher
   let server = defaultServer (T.unpack $ opts.backgroundWorker.host) opts.backgroundWorker.port env.logger
-  settings <- newSettings server
+  let settings = newSettings server
   -- Additional cleanup when shutting down via signals.
   runSettingsWithCleanup cleanup settings (servantApp env) Nothing
 

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -83,7 +83,7 @@ run :: Opts -> IO ()
 run opts = withTracer \tracer -> do
   (app, e) <- mkApp opts
   runAllMigrations e.hasqlPool e.appLogger
-  s <- Server.newSettings (server e)
+  let s = Server.newSettings (server e)
   internalEventListener <-
     Async.async $
       runBrigToIO e $

--- a/services/cannon/src/Cannon/Run.hs
+++ b/services/cannon/src/Cannon/Run.hs
@@ -92,7 +92,7 @@ run o = lowerCodensity $ do
     mkEnv ext o cassandra g d1 d2 man rnd clk (o ^. Cannon.Options.rabbitmq)
 
   void $ Codensity $ Async.withAsync $ runCannon e refreshMetrics
-  s <- newSettings $ Server (o ^. cannon . host) (o ^. cannon . port) (applog e) (Just idleTimeout)
+  let s = newSettings $ Server (o ^. cannon . host) (o ^. cannon . port) (applog e) (Just idleTimeout)
 
   otelMiddleWare <- lift newOpenTelemetryWaiMiddleware
   let middleware :: Wai.Middleware

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -59,14 +59,12 @@ run :: Opts -> IO ()
 run o = lowerCodensity $ do
   (app, e) <- mkApp o
   void $ Codensity $ Async.withAsync (collectAuthMetrics e.aws.amazonkaEnv)
-  liftIO $ do
-    s <-
-      Server.newSettings $
+  let s = Server.newSettings $
         defaultServer
           (unpack . host $ o.cargohold)
           (port o.cargohold)
           e.appLogger
-    runSettingsWithShutdown s app Nothing
+  liftIO $ runSettingsWithShutdown s app Nothing
 
 mkApp :: Opts -> Codensity IO (Application, Env)
 mkApp o = Codensity $ \k ->

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -59,11 +59,12 @@ run :: Opts -> IO ()
 run o = lowerCodensity $ do
   (app, e) <- mkApp o
   void $ Codensity $ Async.withAsync (collectAuthMetrics e.aws.amazonkaEnv)
-  let s = Server.newSettings $
-        defaultServer
-          (unpack . host $ o.cargohold)
-          (port o.cargohold)
-          e.appLogger
+  let s =
+        Server.newSettings $
+          defaultServer
+            (unpack . host $ o.cargohold)
+            (port o.cargohold)
+            e.appLogger
   liftIO $ runSettingsWithShutdown s app Nothing
 
 mkApp :: Opts -> Codensity IO (Application, Env)

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -72,11 +72,12 @@ run :: Opts -> IO ()
 run opts = lowerCodensity do
   tracer <- withTracerC
   (app, env) <- mkApp opts
-  let settings' = newSettings $
-        defaultServer
-          (unpack $ opts._galley.host)
-          (portNumber $ fromIntegral opts._galley.port)
-          (env ^. App.applog)
+  let settings' =
+        newSettings $
+          defaultServer
+            (unpack $ opts._galley.host)
+            (portNumber $ fromIntegral opts._galley.port)
+            (env ^. App.applog)
 
   forM_ (env ^. aEnv) $ \aws ->
     void $ Codensity $ Async.withAsync $ collectAuthMetrics (aws ^. awsEnv)

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -72,9 +72,7 @@ run :: Opts -> IO ()
 run opts = lowerCodensity do
   tracer <- withTracerC
   (app, env) <- mkApp opts
-  settings' <-
-    lift $
-      newSettings $
+  let settings' = newSettings $
         defaultServer
           (unpack $ opts._galley.host)
           (portNumber $ fromIntegral opts._galley.port)

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -72,7 +72,7 @@ run opts = withTracer \tracer -> do
 
   runClient (env ^. cstate) $
     versionCheck lastSchemaVersion
-  s <- newSettings $ defaultServer (unpack . host $ opts ^. gundeck) (port $ opts ^. gundeck) logger
+  let s = newSettings $ defaultServer (unpack . host $ opts ^. gundeck) (port $ opts ^. gundeck) logger
   let throttleMillis = fromMaybe defSqsThrottleMillis $ opts ^. (settings . sqsThrottleMillis)
 
   lst <- Async.async $ Aws.execute (env ^. awsEnv) (Aws.listen throttleMillis (runDirect env . onEvent))

--- a/services/proxy/src/Proxy/Run.hs
+++ b/services/proxy/src/Proxy/Run.hs
@@ -51,7 +51,7 @@ combinedSitemap env = I.servantSitemap Servant.:<|> P.servantSitemap env
 run :: Opts -> IO ()
 run o = do
   e <- createEnv o
-  s <- newSettings $ defaultServer (o ^. proxy . to (T.unpack . host)) (o ^. proxy . to port) (e ^. applog)
+  let s = newSettings $ defaultServer (o ^. proxy . to (T.unpack . host)) (o ^. proxy . to port) (e ^. applog)
 
   let metricsMW :: Middleware
       metricsMW = waiPrometheusMiddlewarePaths (routesToPaths @ProxyAPI <> routesToPaths @InternalAPI)

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -80,7 +80,7 @@ default (ByteString)
 start :: Opts -> IO ()
 start o = do
   e <- newEnv o
-  s <- Server.newSettings (server e)
+  let s = Server.newSettings (server e)
   Server.runSettingsWithShutdown s (requestIdMiddleware e.appLogger defaultRequestIdHeaderName $ servantApp e) Nothing
   where
     server :: Env -> Server.Server


### PR DESCRIPTION
This makes `newSettings` a pure function as it doesn't actually do any IO (it used to do so in the past though, so that's why it had it).

! This also requires changing the use site of `newSettings` in wire-server-enterprise as well, so I guess we will need to wait for a PR in that repo, too.

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`: not required to add anything there 
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html): as it's a no-op functionally, then didn't change anything but the code
