### PR TITLE
Update docs: nginx-ingress-controller -> ingress-nginx-controller

### DIFF
--- a/docs/src/how-to/install/infrastructure-configuration.md
+++ b/docs/src/how-to/install/infrastructure-configuration.md
@@ -243,11 +243,12 @@ nginz:
 By default, incoming network traffic for websockets comes through these network
 hops:
 
-Internet -> LoadBalancer -> kube-proxy -> nginx-ingress-controller -> nginz -> cannon
+Internet -> LoadBalancer -> kube-proxy -> ingress-nginx-controller -> nginz -> cannon
 
-In order to have graceful draining of websockets when something gets restarted, as it is not easily
-possible to implement the graceful draining on nginx-ingress-controller or nginz by itself, there is
-a configuration option to get the following network hops:
+In order to have graceful draining of websockets when something gets restarted,
+as it is not easily possible to implement the graceful draining on
+ingress-nginx-controller (`nginx-ingress` controller) or nginz by itself, there
+is a configuration option to get the following network hops:
 
 Internet -> separate LoadBalancer for cannon only -> kube-proxy -> [nginz->cannon (2 containers in the same pod)]
 
@@ -391,10 +392,11 @@ helm upgrade --install --namespace metallb-system metallb wire/metallb \
     --wait --timeout 1800
 ```
 
-Install `nginx-ingress-[controller,services]`:
+Install `ingress-nginx-controller` (`nginx-ingress` controller) and
+`nginx-ingress-services`:
 
 ::
-: helm upgrade –install –namespace demo demo-nginx-ingress-controller wire/nginx-ingress-controller
+: helm upgrade –install –namespace demo demo-ingress-nginx-controller wire/ingress-nginx-controller
 
 : –wait
 


### PR DESCRIPTION
These were two parent charts for `nginx-ingress`, referencing different versions. We deleted the deprecated nginx-ingress-controller chart, thus the docs had to be updated.

Ticket: https://wearezeta.atlassian.net/browse/WPB-16781

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
