### PR TITLE
WPB-18192 Allow collaborators to create team conversations

### DIFF
--- a/changelog.d/0-release-notes/galley-postgresql
+++ b/changelog.d/0-release-notes/galley-postgresql
@@ -1,0 +1,1 @@
+Galley now requires a connection to PostgreSQL. This can be configured similar to brig using configs `galley.config.postgresql` and `galley.secrets.pgPassword`. Galley must use the same PostgreSQL instance as brig.

--- a/changelog.d/2-features/team-collaborators-convs
+++ b/changelog.d/2-features/team-collaborators-convs
@@ -1,1 +1,1 @@
-Allow team collaborators to create team conversations
+Allow team collaborators to create team conversations.

--- a/changelog.d/2-features/team-collaborators-convs
+++ b/changelog.d/2-features/team-collaborators-convs
@@ -1,0 +1,1 @@
+Allow team collaborators to create team conversations

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -25,6 +25,11 @@ data:
       tlsCa: /etc/wire/galley/cassandra/{{- (include "tlsSecretRef" . | fromYaml).key }}
       {{- end }}
 
+    postgresql: {{ toYaml .postgresql | nindent 6 }}
+    {{- if hasKey $.Values.secrets  "pgPassword" }}
+    postgresqlPassword: /etc/wire/galley/secrets/pgPassword
+    {{- end }}
+
     brig:
       host: brig
       port: 8080

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
       {{- end }}
 
     postgresql: {{ toYaml .postgresql | nindent 6 }}
-    {{- if hasKey $.Values.secrets  "pgPassword" }}
+    {{- if hasKey $.Values.secrets "pgPassword" }}
     postgresqlPassword: /etc/wire/galley/secrets/pgPassword
     {{- end }}
 

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
           secret:
             secretName: {{ .Values.config.rabbitmq.tlsCaSecretRef.name }}
         {{- end }}
+        {{- if .Values.additionalVolumes }}
+        {{ toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       containers:
         - name: galley
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -73,6 +76,9 @@ spec:
           {{- if .Values.config.rabbitmq.tlsCaSecretRef }}
           - name: "rabbitmq-ca"
             mountPath: "/etc/wire/galley/rabbitmq-ca/"
+          {{- end }}
+          {{- if .Values.additionalVolumeMounts }}
+          {{ toYaml .Values.additionalVolumeMounts | nindent 10 }}
           {{- end }}
           env:
           {{- if hasKey .Values.secrets "awsKeyId" }}

--- a/charts/galley/templates/secret.yaml
+++ b/charts/galley/templates/secret.yaml
@@ -22,5 +22,5 @@ data:
   {{- end }}
 
   {{- if .Values.secrets.pgPassword }}
-  pgPassword: {{ .pgPassword | b64enc | quote }}
+  pgPassword: {{ .Values.secrets.pgPassword | b64enc | quote }}
   {{- end }}

--- a/charts/galley/templates/secret.yaml
+++ b/charts/galley/templates/secret.yaml
@@ -20,3 +20,7 @@ data:
   rabbitmqUsername: {{ .Values.secrets.rabbitmq.username | b64enc | quote }}
   rabbitmqPassword: {{ .Values.secrets.rabbitmq.password | b64enc | quote }}
   {{- end }}
+
+  {{- if .Values.secrets.pgPassword }}
+  pgPassword: {{ .pgPassword | b64enc | quote }}
+  {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -40,7 +40,7 @@ config:
   # To set the password via a brig secret see `secrets.pgPassword`.
   #
   # `additionalVolumeMounts` and `additionalVolumes` can be used to mount
-  # additional files (e.g. certificates) into the brig container. This way
+  # additional files (e.g. certificates) into the galley container. This way
   # does not work for password files (parameter `passfile`), because
   # libpq-connect requires access rights (mask 0600) for them that we cannot
   # provide for random uids.

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -33,6 +33,25 @@ config:
   #   tlsCaSecretRef:
   #     name: <secret-name>
   #     key: <ca-attribute>
+
+  # Postgres connection settings
+  #
+  # Values are described in https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+  # To set the password via a brig secret see `secrets.pgPassword`.
+  #
+  # `additionalVolumeMounts` and `additionalVolumes` can be used to mount
+  # additional files (e.g. certificates) into the brig container. This way
+  # does not work for password files (parameter `passfile`), because
+  # libpq-connect requires access rights (mask 0600) for them that we cannot
+  # provide for random uids.
+  #
+  # Below is an example configuration we're using for our CI tests.
+  postgresql:
+    host: postgresql # DNS name without protocol
+    port: "5432"
+    user: wire-server
+    dbname: wire-server
+
   enableFederation: false # keep in sync with background-worker, brig and cargohold charts' config.enableFederation as well as wire-server chart's tags.federation
   # Not used if enableFederation is false
   rabbitmq:

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1539,7 +1539,7 @@ postgresql:
 postgresqlPassword: /path/to/pgPassword # refers to a PostgreSQL password file
 ```
 
-The `brig` and `galley` helm charts also offers an option to mount files (e.g.
+The `brig` and `galley` helm charts also offer an option to mount files (e.g.
 certificates) into the container by defining `additionalVolumeMounts` and
 `additionalVolumes`. This way does not work for password files (parameter
 `passfile`), because `libpq-connect` requires access rights (mask `0600`) for

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1509,13 +1509,13 @@ server, verification can be turned off by settings `insecureSkipVerifyTls` to
 
 ## Configure PostgreSQL
 
-`brig` requires a PostgreSQL database. The configured user needs to be able to
-write data and change the schema (e.g. create and alter tables.)
+`brig` and `galley` require a PostgreSQL database. The configured user needs to
+be able to write data and change the schema (e.g. create and alter tables.)
 
-`brig`'s internal configuration YAML file format and the Helm chart differ a
-bit.
+The internal configuration YAML file format and the Helm charts for `brig` and
+`galley` differ a bit.
 
-Helm chart `values.yaml`:
+Helm chart `values.yaml` for both:
 
 ```yaml
 config:
@@ -1539,8 +1539,8 @@ postgresql:
 postgresqlPassword: /path/to/pgPassword # refers to a PostgreSQL password file
 ```
 
-The `brig` Helm chart also offers an option to mount files (e.g. certificates)
-into the container by defining `additionalVolumeMounts` and
+The `brig` and `galley` helm charts also offers an option to mount files (e.g.
+certificates) into the container by defining `additionalVolumeMounts` and
 `additionalVolumes`. This way does not work for password files (parameter
 `passfile`), because `libpq-connect` requires access rights (mask `0600`) for
 them that we cannot provide for random uids (brig is executed as user `brig`
@@ -1553,8 +1553,8 @@ The `port` needs to be a number provided as string.
 Besides the password file (`postgresqlPassword`), the fields correspond to
 [libpq-connect
 parameters](https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-PARAMKEYWORDS).
-`postgresqlPassword` is read by `brig`. Its content is used as `password`
-field.
+The `postgresqlPassword` file is read by `brig` and `galley`. Its content is
+used as `password` field.
 
 ## Configure Cells
 

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -278,6 +278,11 @@ galley:
           name: "cassandra-jks-keystore"
           key: "ca.crt"
     {{- end }}
+    postgresql:
+      host: "postgresql"
+      port: "5432"
+      user: wire-server
+      dbname: wire-server
     rabbitmq:
       port: 5671
       enableTls: true
@@ -400,6 +405,7 @@ galley:
     rabbitmq:
       username: {{ .Values.rabbitmqUsername }}
       password: {{ .Values.rabbitmqPassword }}
+    pgPassword: "posty-the-gres"
   {{- if .Values.uploadXml }}
   tests:
     config:

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -279,7 +279,7 @@ galley:
           key: "ca.crt"
     {{- end }}
     postgresql:
-      host: "postgresql"
+      host: postgresql
       port: "5432"
       user: wire-server
       dbname: wire-server
@@ -405,7 +405,7 @@ galley:
     rabbitmq:
       username: {{ .Values.rabbitmqUsername }}
       password: {{ .Values.rabbitmqPassword }}
-    pgPassword: "posty-the-gres"
+    pgPassword: posty-the-gres
   {{- if .Values.uploadXml }}
   tests:
     config:

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -1082,13 +1082,14 @@ removeUserFromGroup user gid uid = do
   req <- baseRequest user Brig Versioned $ joinHttpPath ["user-groups", gid, "users", uid]
   submit "DELETE" req
 
-addTeamCollaborator :: (MakesValue owner) => owner -> String -> String -> [String] -> App Response
-addTeamCollaborator owner tid userId permissions = do
+addTeamCollaborator :: (MakesValue owner, MakesValue collaborator, HasCallStack) => owner -> String -> collaborator -> [String] -> App Response
+addTeamCollaborator owner tid collaborator permissions = do
   req <- baseRequest owner Brig Versioned $ joinHttpPath ["teams", tid, "collaborators"]
+  (_, collabId) <- objQid collaborator
   submit "POST" $
     req
       & addJSONObject
-        [ "user" .= userId,
+        [ "user" .= collabId,
           "permissions" .= permissions
         ]
 

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -76,7 +76,6 @@ testCreateTeamCollaboratorPostTwice = do
   bindResponse add assertSuccess
   bindResponse add $ assertStatus 409
 
--- Question about channels: Do collaborators get to create them when all team members are allowed to create them?
 testCollaboratorCanCreateTeamConv :: (HasCallStack) => TaggedBool "collaborator-has-team" -> App ()
 testCollaboratorCanCreateTeamConv (TaggedBool collaboratorHasTeam) = do
   (owner, team, _) <- createTeam OwnDomain 1

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -32,7 +32,7 @@ testCreateTeamCollaborator = do
           evt %. "transient" `shouldMatch` False
 
     awaitMatch isTeamCollaboratorAddedNotif wsOwner >>= checkEvent
-    awaitMatch isTeamCollaboratorAddedNotif wsAlice >>= checkEvent
+    assertNoEvent 1 wsAlice
 
   bindResponse (getAllTeamCollaborators owner team) $ \resp -> do
     resp.status `shouldMatchInt` 200

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -218,7 +218,8 @@ startDynamicBackend resource beOverrides = do
     setPgDb :: ServiceOverrides
     setPgDb =
       def
-        { brigCfg = setField "postgresql.dbname" resource.berPostgresqlDBName
+        { brigCfg = setField "postgresql.dbname" resource.berPostgresqlDBName,
+          galleyCfg = setField "postgresql.dbname" resource.berPostgresqlDBName
         }
 
     setEsIndex :: ServiceOverrides

--- a/libs/extended/default.nix
+++ b/libs/extended/default.nix
@@ -15,6 +15,8 @@
 , errors
 , exceptions
 , gitignoreSource
+, hasql
+, hasql-pool
 , hspec
 , hspec-discover
 , http-client
@@ -37,6 +39,7 @@
 , tinylog
 , tls
 , transformers
+, types-common
 , unliftio
 , wai
 }:
@@ -56,6 +59,8 @@ mkDerivation {
     data-default
     errors
     exceptions
+    hasql
+    hasql-pool
     http-client
     http-client-tls
     http-types
@@ -73,6 +78,7 @@ mkDerivation {
     tinylog
     tls
     transformers
+    types-common
     unliftio
     wai
   ];

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -20,6 +20,7 @@ library
   -- cabal-fmt: expand src
   exposed-modules:
     Data.Time.Clock.DiffTime
+    Hasql.Pool.Extended
     Network.AMQP.Extended
     Network.RabbitMqAdmin
     Servant.API.Extended
@@ -88,6 +89,8 @@ library
     , data-default
     , errors
     , exceptions
+    , hasql
+    , hasql-pool
     , http-client
     , http-client-tls
     , http-types
@@ -105,6 +108,7 @@ library
     , tinylog
     , tls
     , transformers
+    , types-common
     , unliftio
     , wai
 

--- a/libs/extended/src/Hasql/Pool/Extended.hs
+++ b/libs/extended/src/Hasql/Pool/Extended.hs
@@ -21,7 +21,7 @@ initPostgresPool :: Map Text Text -> Maybe FilePathSecrets -> IO HasqlPool.Pool
 initPostgresPool pgConfig mFpSecrets = do
   mPw <- for mFpSecrets initCredentials
   let pgConfigWithPw = maybe pgConfig (\pw -> Map.insert "password" pw pgConfig) mPw
-  let pgParams = Map.foldMapWithKey (\k v -> [HasqlConfig.other k v]) pgConfigWithPw
+      pgParams = Map.foldMapWithKey (\k v -> [HasqlConfig.other k v]) pgConfigWithPw
   HasqlPool.acquire $
     HasqlPool.settings
       [ HasqlPool.staticConnectionSettings $

--- a/libs/extended/src/Hasql/Pool/Extended.hs
+++ b/libs/extended/src/Hasql/Pool/Extended.hs
@@ -1,0 +1,29 @@
+module Hasql.Pool.Extended where
+
+import Data.Map as Map
+import Hasql.Connection.Setting qualified as HasqlSetting
+import Hasql.Connection.Setting.Connection qualified as HasqlConn
+import Hasql.Connection.Setting.Connection.Param qualified as HasqlConfig
+import Hasql.Pool as HasqlPool
+import Hasql.Pool.Config qualified as HasqlPool
+import Imports
+import Util.Options
+
+-- | Creates a pool from postgres config params
+--
+-- HasqlConn.params translates pgParams into connection (which just holds the connection string and is not a real connection)
+-- HasqlSetting.connection unwraps the connection string out of connection
+-- HasqlPool.staticConnectionSettings translates the connection string to the pool settings
+-- HasqlPool.settings translates the pool settings into pool config
+-- HasqlPool.acquire creates the pool.
+-- ezpz.
+initPostgresPool :: Map Text Text -> Maybe FilePathSecrets -> IO HasqlPool.Pool
+initPostgresPool pgConfig mFpSecrets = do
+  mPw <- for mFpSecrets initCredentials
+  let pgConfigWithPw = maybe pgConfig (\pw -> Map.insert "password" pw pgConfig) mPw
+  let pgParams = Map.foldMapWithKey (\k v -> [HasqlConfig.other k v]) pgConfigWithPw
+  HasqlPool.acquire $
+    HasqlPool.settings
+      [ HasqlPool.staticConnectionSettings $
+          [HasqlSetting.connection $ HasqlConn.params pgParams]
+      ]

--- a/libs/wire-api/src/Wire/API/Team/Collaborator.hs
+++ b/libs/wire-api/src/Wire/API/Team/Collaborator.hs
@@ -7,6 +7,7 @@ import Data.Id
 import Data.OpenApi qualified as S
 import Data.Schema
 import Imports
+import Wire.API.Error
 import Wire.Arbitrary
 
 data CollaboratorPermission = CreateTeamConversation | ImplicitConnection
@@ -28,6 +29,9 @@ data TeamCollaboratorsError
   deriving (Eq, Show)
 
 instance Exception TeamCollaboratorsError
+
+instance APIError TeamCollaboratorsError where
+  toResponse = undefined
 
 data NewTeamCollaborator = NewTeamCollaborator
   { aUser :: UserId,

--- a/libs/wire-api/src/Wire/API/Team/Collaborator.hs
+++ b/libs/wire-api/src/Wire/API/Team/Collaborator.hs
@@ -7,7 +7,6 @@ import Data.Id
 import Data.OpenApi qualified as S
 import Data.Schema
 import Imports
-import Wire.API.Error
 import Wire.Arbitrary
 
 data CollaboratorPermission = CreateTeamConversation | ImplicitConnection
@@ -29,9 +28,6 @@ data TeamCollaboratorsError
   deriving (Eq, Show)
 
 instance Exception TeamCollaboratorsError
-
-instance APIError TeamCollaboratorsError where
-  toResponse = undefined
 
 data NewTeamCollaborator = NewTeamCollaborator
   { aUser :: UserId,

--- a/libs/wire-api/src/Wire/API/Team/Collaborator.hs
+++ b/libs/wire-api/src/Wire/API/Team/Collaborator.hs
@@ -31,7 +31,7 @@ instance Exception TeamCollaboratorsError
 
 data NewTeamCollaborator = NewTeamCollaborator
   { aUser :: UserId,
-    aPermissions :: [CollaboratorPermission]
+    aPermissions :: Set CollaboratorPermission
   }
   deriving (A.FromJSON, A.ToJSON, S.ToSchema) via (Schema NewTeamCollaborator)
 
@@ -40,12 +40,12 @@ instance ToSchema NewTeamCollaborator where
     object "NewTeamCollaborator" $
       NewTeamCollaborator
         <$> (aUser .= field "user" schema)
-        <*> (aPermissions .= field "permissions" (array schema))
+        <*> (aPermissions .= field "permissions" (set schema))
 
 data TeamCollaborator = TeamCollaborator
   { gUser :: UserId,
     gTeam :: TeamId,
-    gPermissions :: [CollaboratorPermission]
+    gPermissions :: Set CollaboratorPermission
   }
   deriving (Eq, Show)
   deriving (A.FromJSON, A.ToJSON, S.ToSchema) via (Schema TeamCollaborator)
@@ -56,4 +56,4 @@ instance ToSchema TeamCollaborator where
       TeamCollaborator
         <$> (gUser .= field "user" schema)
         <*> (gTeam .= field "team" schema)
-        <*> (gPermissions .= field "permissions" (array schema))
+        <*> (gPermissions .= field "permissions" (set schema))

--- a/libs/wire-api/src/Wire/API/Team/HardTruncationLimit.hs
+++ b/libs/wire-api/src/Wire/API/Team/HardTruncationLimit.hs
@@ -1,6 +1,7 @@
 module Wire.API.Team.HardTruncationLimit where
 
 import Data.Proxy
+import Data.Range
 import GHC.TypeLits
 import Imports
 
@@ -8,3 +9,6 @@ type HardTruncationLimit = (2000 :: Nat)
 
 hardTruncationLimit :: (Integral a) => a
 hardTruncationLimit = fromIntegral $ natVal (Proxy @HardTruncationLimit)
+
+hardTruncationLimitRange :: (Integral a, n <= HardTruncationLimit, HardTruncationLimit <= m) => Range n m a
+hardTruncationLimitRange = toRange $ Proxy @HardTruncationLimit

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -594,9 +594,6 @@ instance HasPermError Perm where
 instance HasPermError HiddenPerm where
   type PermError p = OperationDenied
 
--- type family PermError p where
---   PermError (p :: Perm) = 'MissingPermission ('Just p)
---   PermError (_ :: HiddenPerm) = OperationDenied
 
 -- | See Note [hidden team roles]
 class IsPerm teamAssociation perm where

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -610,25 +610,25 @@ instance IsPerm Role Perm where
   mayGrantPermission r p = p `Set.member` ((rolePermissions r).copy)
 
 instance IsPerm Role HiddenPerm where
-  -- type PermError Role p = OperationDenied
   hasPermission r p = p `Set.member` _hself (roleHiddenPermissions r)
   mayGrantPermission r p = p `Set.member` _hcopy (roleHiddenPermissions r)
 
 instance IsPerm TeamMember Perm where
-  -- type PermError TeamMember p = 'MissingPermission ('Just p)
   hasPermission tm p = p `Set.member` ((Wire.API.Team.Member.getPermissions tm).self)
   mayGrantPermission tm p = p `Set.member` ((Wire.API.Team.Member.getPermissions tm).copy)
 
 instance IsPerm TeamMember HiddenPerm where
-  -- type PermError TeamMember p = OperationDenied
   hasPermission tm perm = maybe False (flip hasPermission perm) . permissionsRole $ Wire.API.Team.Member.getPermissions tm
   mayGrantPermission tm perm = maybe False (flip mayGrantPermission perm) . permissionsRole $ Wire.API.Team.Member.getPermissions tm
 
 instance IsPerm TeamCollaborator Perm where
-  -- type PermError TeamCollaborator p = 'MissingPermission ('Just p)
   hasPermission collaborator perm =
     perm `Set.member` collaboratorToTeamPermissions collaborator.gPermissions
   mayGrantPermission _ _ = False
+
+instance IsPerm (Either TeamMember TeamCollaborator) Perm where
+  hasPermission = either hasPermission hasPermission
+  mayGrantPermission = either mayGrantPermission mayGrantPermission
 
 collaboratorToTeamPermissions :: Set CollaboratorPermission -> Set Perm
 collaboratorToTeamPermissions =

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -594,7 +594,6 @@ instance HasPermError Perm where
 instance HasPermError HiddenPerm where
   type PermError p = OperationDenied
 
-
 -- | See Note [hidden team roles]
 class IsPerm teamAssociation perm where
   -- type PermError teamAssociation (p :: perm) :: GalleyError

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -626,7 +626,7 @@ instance IsPerm TeamCollaborator Perm where
     perm `Set.member` collaboratorToTeamPermissions collaborator.gPermissions
   mayGrantPermission _ _ = False
 
-instance IsPerm (Either TeamMember TeamCollaborator) Perm where
+instance (IsPerm a p, IsPerm b p) => IsPerm (Either a b) p where
   hasPermission = either hasPermission hasPermission
   mayGrantPermission = either mayGrantPermission mayGrantPermission
 
@@ -634,7 +634,7 @@ collaboratorToTeamPermissions :: Set CollaboratorPermission -> Set Perm
 collaboratorToTeamPermissions =
   foldMap
     ( \case
-        Collaborator.CreateTeamConversation -> Set.singleton CreateConversation
+        Collaborator.CreateTeamConversation -> Set.fromList [CreateConversation, AddRemoveConvMember]
         Collaborator.ImplicitConnection -> mempty
     )
 

--- a/libs/wire-subsystems/src/Wire/GalleyAPIAccess.hs
+++ b/libs/wire-subsystems/src/Wire/GalleyAPIAccess.hs
@@ -22,6 +22,7 @@ import Data.Currency qualified as Currency
 import Data.Id
 import Data.Json.Util (UTCTimeMillis)
 import Data.Qualified
+import Data.Range
 import Imports
 import Network.Wai.Utilities.Error qualified as Wai
 import Polysemy
@@ -82,6 +83,7 @@ data GalleyAPIAccess m a where
     GalleyAPIAccess m (Maybe Team.TeamMember)
   GetTeamMembers ::
     TeamId ->
+    Maybe (Range 1 Team.HardTruncationLimit Int32) ->
     GalleyAPIAccess m Team.TeamMemberList
   GetTeamId ::
     UserId ->

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore.hs
@@ -10,5 +10,6 @@ import Wire.API.Team.Collaborator
 data TeamCollaboratorsStore m a where
   CreateTeamCollaborator :: UserId -> TeamId -> Set CollaboratorPermission -> TeamCollaboratorsStore m ()
   GetAllTeamCollaborators :: TeamId -> TeamCollaboratorsStore m [TeamCollaborator]
+  GetTeamCollaborator :: TeamId -> UserId -> TeamCollaboratorsStore m (Maybe TeamCollaborator)
 
 makeSem ''TeamCollaboratorsStore

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
@@ -9,6 +9,7 @@ import Data.Bimap qualified as Bimap
 import Data.Id
 import Data.Profunctor
 import Data.Set
+import Data.Set qualified as Set
 import Data.UUID
 import Data.Vector
 import Hasql.Pool
@@ -99,8 +100,8 @@ getAllTeamCollaboratorsImpl teamId = do
     toTeamCollaborator ((Id -> gUser), (Id -> gTeam), (toPermissions -> gPermissions)) =
       TeamCollaborator {..}
 
-    toPermissions :: Vector Int16 -> [CollaboratorPermission]
-    toPermissions = (Data.Vector.toList . Data.Vector.map postgreslRepToCollaboratorPermission)
+    toPermissions :: Vector Int16 -> Set CollaboratorPermission
+    toPermissions = Data.Vector.foldr (Set.insert . postgreslRepToCollaboratorPermission) Set.empty
 
 -- We could rely on an `Ord` instance here. Howver, when the order is changed,
 -- this will mess up spectaculary at run time. So, this extra mapping is meant

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
@@ -11,7 +11,7 @@ import Data.Profunctor
 import Data.Set
 import Data.Set qualified as Set
 import Data.UUID
-import Data.Vector
+import Data.Vector hiding (mapM)
 import Hasql.Pool
 import Hasql.Session
 import Hasql.Statement
@@ -35,6 +35,32 @@ interpretTeamCollaboratorsStoreToPostgres =
   interpret $ \case
     CreateTeamCollaborator userId teamId permissions -> createTeamCollaboratorImpl userId teamId permissions
     GetAllTeamCollaborators teamId -> getAllTeamCollaboratorsImpl teamId
+    GetTeamCollaborator teamId userId -> getTeamCollaboratorImpl teamId userId
+
+getTeamCollaboratorImpl ::
+  ( Member (Input Pool) r,
+    Member (Embed IO) r,
+    Member (Error UsageError) r
+  ) =>
+  TeamId ->
+  UserId ->
+  Sem r (Maybe TeamCollaborator)
+getTeamCollaboratorImpl teamId userId = do
+  pool <- input
+  eitherTeamCollaborator <- liftIO $ use pool session
+  either throw pure eitherTeamCollaborator
+  where
+    session :: Session (Maybe TeamCollaborator)
+    session = statement (teamId, userId) getTeamCollaboratorStatement
+
+    getTeamCollaboratorStatement :: Statement (TeamId, UserId) (Maybe TeamCollaborator)
+    getTeamCollaboratorStatement =
+      dimap
+        (bimap toUUID toUUID)
+        (fmap toTeamCollaborator)
+        $ [maybeStatement|
+          select user_id :: uuid, team_id :: uuid, permissions :: int2[] from collaborators where team_id = ($1 :: uuid) and user_id = ($2 :: uuid)
+          |]
 
 createTeamCollaboratorImpl ::
   ( Member (Input Pool) r,
@@ -96,12 +122,12 @@ getAllTeamCollaboratorsImpl teamId = do
           select user_id :: uuid, team_id :: uuid, permissions :: int2[] from collaborators where team_id = ($1 :: uuid)
           |]
 
-    toTeamCollaborator :: (UUID, UUID, Vector Int16) -> TeamCollaborator
-    toTeamCollaborator ((Id -> gUser), (Id -> gTeam), (toPermissions -> gPermissions)) =
-      TeamCollaborator {..}
+toTeamCollaborator :: (UUID, UUID, Vector Int16) -> TeamCollaborator
+toTeamCollaborator ((Id -> gUser), (Id -> gTeam), (toPermissions -> gPermissions)) =
+  TeamCollaborator {..}
 
-    toPermissions :: Vector Int16 -> Set CollaboratorPermission
-    toPermissions = Data.Vector.foldr (Set.insert . postgreslRepToCollaboratorPermission) Set.empty
+toPermissions :: Vector Int16 -> Set CollaboratorPermission
+toPermissions = Data.Vector.foldr (Set.insert . postgreslRepToCollaboratorPermission) Set.empty
 
 -- We could rely on an `Ord` instance here. Howver, when the order is changed,
 -- this will mess up spectaculary at run time. So, this extra mapping is meant

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
@@ -11,6 +11,6 @@ import Wire.API.Team.Collaborator
 data TeamCollaboratorsSubsystem m a where
   CreateTeamCollaborator :: Local UserId -> UserId -> TeamId -> Set CollaboratorPermission -> TeamCollaboratorsSubsystem m ()
   GetAllTeamCollaborators :: Local UserId -> TeamId -> TeamCollaboratorsSubsystem m [TeamCollaborator]
-  GetTeamCollaborator :: Local UserId -> TeamId -> UserId -> TeamCollaboratorsSubsystem m (Maybe TeamCollaborator)
+  InternalGetTeamCollaborator :: TeamId -> UserId -> TeamCollaboratorsSubsystem m (Maybe TeamCollaborator)
 
 makeSem ''TeamCollaboratorsSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
@@ -11,5 +11,6 @@ import Wire.API.Team.Collaborator
 data TeamCollaboratorsSubsystem m a where
   CreateTeamCollaborator :: Local UserId -> UserId -> TeamId -> Set CollaboratorPermission -> TeamCollaboratorsSubsystem m ()
   GetAllTeamCollaborators :: Local UserId -> TeamId -> TeamCollaboratorsSubsystem m [TeamCollaborator]
+  GetTeamCollaborator :: Local UserId -> TeamId -> UserId -> TeamCollaboratorsSubsystem m (Maybe TeamCollaborator)
 
 makeSem ''TeamCollaboratorsSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -62,7 +62,6 @@ createTeamCollaboratorImpl zUser user team perms = do
 
   now <- get
   let event = newEvent team now (EdCollaboratorAdd user (Set.toList perms))
-  -- TODO: Why fanout to the whole team, it won't work for large teams
   teamMembersList <- internalGetTeamMembers team Nothing
   let teamMembers :: [UserId] = view TeamMember.userId <$> (teamMembersList ^. TeamMember.teamMembers)
   -- TODO: Review the event's values

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -17,14 +17,14 @@ import Wire.API.Push.V2 qualified as Push
 import Wire.API.Team.Collaborator
 import Wire.API.Team.Member qualified as TeamMember
 import Wire.Error
-import Wire.GalleyAPIAccess
 import Wire.NotificationSubsystem
 import Wire.Sem.Now
 import Wire.TeamCollaboratorsStore qualified as Store
 import Wire.TeamCollaboratorsSubsystem
+import Wire.TeamSubsystem
 
 interpretTeamCollaboratorsSubsystem ::
-  ( Member GalleyAPIAccess r,
+  ( Member TeamSubsystem r,
     Member (Error TeamCollaboratorsError) r,
     Member Store.TeamCollaboratorsStore r,
     Member Now r,
@@ -34,9 +34,23 @@ interpretTeamCollaboratorsSubsystem ::
 interpretTeamCollaboratorsSubsystem = interpret $ \case
   CreateTeamCollaborator zUser user team perms -> createTeamCollaboratorImpl zUser user team perms
   GetAllTeamCollaborators zUser team -> getAllTeamCollaboratorsImpl zUser team
+  GetTeamCollaborator zUser team user -> getTeamCollaboratorImpl zUser team user
+
+getTeamCollaboratorImpl ::
+  (Member Store.TeamCollaboratorsStore r, Member TeamSubsystem r, Member (Error TeamCollaboratorsError) r) =>
+  Local UserId ->
+  TeamId ->
+  UserId ->
+  Sem r (Maybe TeamCollaborator)
+getTeamCollaboratorImpl lusr teamId userId = do
+  let usr = tUnqualified lusr
+  -- collaborator should get themselves, too
+  mTm <- internalGetTeamMember usr teamId
+  unless (isJust mTm) $ throw InsufficientRights
+  Store.getTeamCollaborator teamId userId
 
 createTeamCollaboratorImpl ::
-  ( Member GalleyAPIAccess r,
+  ( Member TeamSubsystem r,
     Member (Error TeamCollaboratorsError) r,
     Member Store.TeamCollaboratorsStore r,
     Member Now r,
@@ -53,7 +67,8 @@ createTeamCollaboratorImpl zUser user team perms = do
 
   now <- get
   let event = newEvent team now (EdCollaboratorAdd user (Set.toList perms))
-  teamMembersList <- getTeamMembers team
+  -- TODO: Why fanout to the whole team, it won't work for large teams
+  teamMembersList <- internalGetTeamMembers team
   let teamMembers :: [UserId] = view TeamMember.userId <$> (teamMembersList ^. TeamMember.teamMembers)
   -- TODO: Review the event's values
   pushNotifications
@@ -73,7 +88,7 @@ createTeamCollaboratorImpl zUser user team perms = do
     ]
 
 getAllTeamCollaboratorsImpl ::
-  ( Member GalleyAPIAccess r,
+  ( Member TeamSubsystem r,
     Member (Error TeamCollaboratorsError) r,
     Member Store.TeamCollaboratorsStore r
   ) =>
@@ -87,7 +102,7 @@ getAllTeamCollaboratorsImpl zUser team = do
 -- This is of general usefulness. However, we cannot move this to wire-api as
 -- this would lead to a cyclic dependency.
 guardPermission ::
-  ( Member GalleyAPIAccess r,
+  ( Member TeamSubsystem r,
     Member (Error ex) r,
     TeamMember.IsPerm TeamMember.TeamMember perm
   ) =>
@@ -99,7 +114,7 @@ guardPermission ::
 guardPermission user team perm ex = do
   res <-
     isJust <$> runMaybeT do
-      member <- MaybeT $ getTeamMember user team
+      member <- MaybeT $ internalGetTeamMember user team
       guard (member `TeamMember.hasPermission` perm)
   unless res $
     throw ex

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -62,7 +62,7 @@ createTeamCollaboratorImpl zUser user team perms = do
 
   now <- get
   let event = newEvent team now (EdCollaboratorAdd user (Set.toList perms))
-  teamMembersList <- internalGetTeamMembers team Nothing
+  teamMembersList <- internalGetTeamAdmins team
   let teamMembers :: [UserId] = view TeamMember.userId <$> (teamMembersList ^. TeamMember.teamMembers)
   -- TODO: Review the event's values
   pushNotifications

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -89,7 +89,7 @@ getAllTeamCollaboratorsImpl zUser team = do
 guardPermission ::
   ( Member GalleyAPIAccess r,
     Member (Error ex) r,
-    TeamMember.IsPerm perm
+    TeamMember.IsPerm TeamMember.TeamMember perm
   ) =>
   UserId ->
   TeamId ->

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -34,19 +34,14 @@ interpretTeamCollaboratorsSubsystem ::
 interpretTeamCollaboratorsSubsystem = interpret $ \case
   CreateTeamCollaborator zUser user team perms -> createTeamCollaboratorImpl zUser user team perms
   GetAllTeamCollaborators zUser team -> getAllTeamCollaboratorsImpl zUser team
-  GetTeamCollaborator zUser team user -> getTeamCollaboratorImpl zUser team user
+  InternalGetTeamCollaborator team user -> internalGetTeamCollaboratorImpl team user
 
-getTeamCollaboratorImpl ::
-  (Member Store.TeamCollaboratorsStore r, Member TeamSubsystem r, Member (Error TeamCollaboratorsError) r) =>
-  Local UserId ->
+internalGetTeamCollaboratorImpl ::
+  (Member Store.TeamCollaboratorsStore r) =>
   TeamId ->
   UserId ->
   Sem r (Maybe TeamCollaborator)
-getTeamCollaboratorImpl lusr teamId userId = do
-  let usr = tUnqualified lusr
-  -- collaborator should get themselves, too
-  mTm <- internalGetTeamMember usr teamId
-  unless (isJust mTm) $ throw InsufficientRights
+internalGetTeamCollaboratorImpl teamId userId = do
   Store.getTeamCollaborator teamId userId
 
 createTeamCollaboratorImpl ::

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -63,7 +63,7 @@ createTeamCollaboratorImpl zUser user team perms = do
   now <- get
   let event = newEvent team now (EdCollaboratorAdd user (Set.toList perms))
   -- TODO: Why fanout to the whole team, it won't work for large teams
-  teamMembersList <- internalGetTeamMembers team
+  teamMembersList <- internalGetTeamMembers team Nothing
   let teamMembers :: [UserId] = view TeamMember.userId <$> (teamMembersList ^. TeamMember.teamMembers)
   -- TODO: Review the event's values
   pushNotifications

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
@@ -11,5 +11,6 @@ import Wire.API.Team.Member
 data TeamSubsystem m a where
   InternalGetTeamMember :: UserId -> TeamId -> TeamSubsystem m (Maybe TeamMember)
   InternalGetTeamMembers :: TeamId -> Maybe (Range 1 HardTruncationLimit Int32) -> TeamSubsystem m TeamMemberList
+  InternalGetTeamAdmins :: TeamId -> TeamSubsystem m TeamMemberList
 
 makeSem ''TeamSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
@@ -3,12 +3,13 @@
 module Wire.TeamSubsystem where
 
 import Data.Id
+import Data.Range
 import Imports
 import Polysemy
 import Wire.API.Team.Member
 
 data TeamSubsystem m a where
   InternalGetTeamMember :: UserId -> TeamId -> TeamSubsystem m (Maybe TeamMember)
-  InternalGetTeamMembers :: TeamId -> TeamSubsystem m TeamMemberList
+  InternalGetTeamMembers :: TeamId -> Maybe (Range 1 HardTruncationLimit Int32) -> TeamSubsystem m TeamMemberList
 
 makeSem ''TeamSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Wire.TeamSubsystem where
+
+import Data.Id
+import Imports
+import Polysemy
+import Wire.API.Team.Member
+
+data TeamSubsystem m a where
+  InternalGetTeamMember :: UserId -> TeamId -> TeamSubsystem m (Maybe TeamMember)
+  InternalGetTeamMembers :: TeamId -> TeamSubsystem m TeamMemberList
+
+makeSem ''TeamSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
@@ -10,3 +10,4 @@ intepreterTeamSubsystemToGalleyAPI :: (Member GalleyAPIAccess r) => InterpreterF
 intepreterTeamSubsystemToGalleyAPI = interpret $ \case
   InternalGetTeamMember userId teamId -> GalleyAPIAccess.getTeamMember userId teamId
   InternalGetTeamMembers teamId maxResults -> GalleyAPIAccess.getTeamMembers teamId maxResults
+  InternalGetTeamAdmins teamId -> GalleyAPIAccess.getTeamAdmins teamId

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
@@ -1,0 +1,12 @@
+module Wire.TeamSubsystem.GalleyAPI where
+
+import Imports
+import Polysemy
+import Wire.GalleyAPIAccess (GalleyAPIAccess)
+import Wire.GalleyAPIAccess qualified as GalleyAPIAccess
+import Wire.TeamSubsystem
+
+intepreterTeamSubsystemToGalleyAPI :: (Member GalleyAPIAccess r) => InterpreterFor TeamSubsystem r
+intepreterTeamSubsystemToGalleyAPI = interpret $ \case
+  InternalGetTeamMember userId teamId -> GalleyAPIAccess.getTeamMember userId teamId
+  InternalGetTeamMembers teamId -> GalleyAPIAccess.getTeamMembers teamId

--- a/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
+++ b/libs/wire-subsystems/src/Wire/TeamSubsystem/GalleyAPI.hs
@@ -9,4 +9,4 @@ import Wire.TeamSubsystem
 intepreterTeamSubsystemToGalleyAPI :: (Member GalleyAPIAccess r) => InterpreterFor TeamSubsystem r
 intepreterTeamSubsystemToGalleyAPI = interpret $ \case
   InternalGetTeamMember userId teamId -> GalleyAPIAccess.getTeamMember userId teamId
-  InternalGetTeamMembers teamId -> GalleyAPIAccess.getTeamMembers teamId
+  InternalGetTeamMembers teamId maxResults -> GalleyAPIAccess.getTeamMembers teamId maxResults

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -324,7 +324,7 @@ createEmailChangeToken lusr email updateOrigin = do
 ------------------------------------------
 
 ensurePermissions ::
-  ( IsPerm perm,
+  ( IsPerm TeamMember perm,
     Member GalleyAPIAccess r,
     Member (Error UserSubsystemError) r
   ) =>

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -40,11 +40,10 @@ import Wire.BlockListStore qualified as BlockListStore
 import Wire.DomainRegistrationStore (DomainRegistrationStore)
 import Wire.DomainRegistrationStore qualified as DomainRegistrationStore
 import Wire.EmailSubsystem
-import Wire.GalleyAPIAccess (GalleyAPIAccess)
-import Wire.GalleyAPIAccess qualified as GalleyAPIAccess
 import Wire.InvitationStore
 import Wire.SparAPIAccess (SparAPIAccess, getIdentityProviders)
 import Wire.StoredUser qualified as SU
+import Wire.TeamSubsystem
 import Wire.UserKeyStore
 import Wire.UserSearch.Types
 import Wire.UserStore
@@ -325,15 +324,15 @@ createEmailChangeToken lusr email updateOrigin = do
 
 ensurePermissions ::
   ( IsPerm TeamMember perm,
-    Member GalleyAPIAccess r,
-    Member (Error UserSubsystemError) r
+    Member (Error UserSubsystemError) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   TeamId ->
   [perm] ->
   Sem r ()
 ensurePermissions u t perms = do
-  m <- GalleyAPIAccess.getTeamMember u t
+  m <- internalGetTeamMember u t
   unless (check m) $
     throw UserSubsystemInsufficientPermissions
   where

--- a/libs/wire-subsystems/test/unit/Wire/MiniBackend.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MiniBackend.hs
@@ -106,6 +106,8 @@ import Wire.StoredUser
 import Wire.TeamCollaboratorsStore
 import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamCollaboratorsSubsystem.Interpreter
+import Wire.TeamSubsystem (TeamSubsystem)
+import Wire.TeamSubsystem.GalleyAPI
 import Wire.UserKeyStore
 import Wire.UserStore
 import Wire.UserSubsystem
@@ -211,7 +213,8 @@ data MiniBackendParams r = MiniBackendParams
 -- organize along effect types ("all `State`s"), but the domain ("everything about block
 -- lists").
 type MiniBackendLowerEffects =
-  '[ EmailSubsystem,
+  '[ TeamSubsystem,
+     EmailSubsystem,
      NotificationSubsystem,
      GalleyAPIAccess,
      SparAPIAccess,
@@ -279,6 +282,7 @@ miniBackendLowerEffectsInterpreters mb@(MiniBackendParams {..}) =
     . miniGalleyAPIAccess teams galleyConfigs
     . inMemoryNotificationSubsystemInterpreter
     . noopEmailSubsystemInterpreter
+    . intepreterTeamSubsystemToGalleyAPI
 
 type StateEffects =
   '[ State [Push],

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
@@ -3,7 +3,6 @@ module Wire.MockInterpreters.TeamCollaboratorsStore where
 import Data.Id
 import Data.Map qualified as Map
 import Data.Maybe
-import Data.Set qualified as Set
 import Imports
 import Polysemy
 import Polysemy.State
@@ -17,7 +16,7 @@ inMemoryTeamCollaboratorsStoreInterpreter ::
 inMemoryTeamCollaboratorsStoreInterpreter =
   interpret $ \case
     CreateTeamCollaborator userId teamId permissions ->
-      let teamCollaborator = TeamCollaborator userId teamId (Set.toList permissions)
+      let teamCollaborator = TeamCollaborator {gUser = userId, gTeam = teamId, gPermissions = permissions}
        in modify $ Map.alter (Just . maybe [teamCollaborator] (teamCollaborator :)) teamId
     GetAllTeamCollaborators teamId ->
       gets $ \(s :: Map TeamId [TeamCollaborator]) -> (fromMaybe []) (Map.lookup teamId s)

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
@@ -20,3 +20,5 @@ inMemoryTeamCollaboratorsStoreInterpreter =
        in modify $ Map.alter (Just . maybe [teamCollaborator] (teamCollaborator :)) teamId
     GetAllTeamCollaborators teamId ->
       gets $ \(s :: Map TeamId [TeamCollaborator]) -> (fromMaybe []) (Map.lookup teamId s)
+    GetTeamCollaborator teamId userId ->
+      gets $ \(s :: Map TeamId [TeamCollaborator]) -> find (\tc -> tc.gUser == userId) =<< Map.lookup teamId s

--- a/libs/wire-subsystems/test/unit/Wire/TeamCollaboratorsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/TeamCollaboratorsSubsystem/InterpreterSpec.hs
@@ -5,7 +5,6 @@ import Data.Id
 import Data.LegalHold (UserLegalHoldStatus (..))
 import Data.Map qualified as Map
 import Data.Qualified
-import Data.Set qualified as Set
 import Imports
 import Test.Hspec
 import Test.Hspec.QuickCheck
@@ -38,7 +37,7 @@ spec = do
                 do
                   createTeamCollaborator authUser collaborator.id tid collabPerms
                   collaborators <- getAllTeamCollaborators authUser tid
-                  pure $ collaborators === [TeamCollaborator collaborator.id tid (Set.toAscList collabPerms)]
+                  pure $ collaborators === [TeamCollaborator collaborator.id tid collabPerms]
 
     prop "can get empty team collaborator list" $
       \(collaborator :: StoredUser)

--- a/libs/wire-subsystems/test/unit/Wire/TeamInvitationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/TeamInvitationSubsystem/InterpreterSpec.hs
@@ -34,12 +34,15 @@ import Wire.Sem.Random
 import Wire.TeamInvitationSubsystem
 import Wire.TeamInvitationSubsystem.Error
 import Wire.TeamInvitationSubsystem.Interpreter
+import Wire.TeamSubsystem
+import Wire.TeamSubsystem.GalleyAPI
 import Wire.UserSubsystem
 
 type AllEffects =
   [ Error TeamInvitationSubsystemError,
     EnterpriseLoginSubsystem,
     TinyLog,
+    TeamSubsystem,
     GalleyAPIAccess,
     Random,
     State StdGen,
@@ -74,6 +77,7 @@ runAllEffects args =
     . evalState (mkStdGen 3)
     . randomToStatefulStdGen
     . miniGalleyAPIAccess args.teams def
+    . intepreterTeamSubsystemToGalleyAPI
     . discardTinyLogs
     . enterpriseLoginSubsystemTestInterpreter args.constGuardResult
     . runError

--- a/libs/wire-subsystems/test/unit/Wire/UserGroupSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserGroupSubsystem/InterpreterSpec.hs
@@ -37,6 +37,8 @@ import Wire.GalleyAPIAccess
 import Wire.MockInterpreters as Mock
 import Wire.NotificationSubsystem
 import Wire.Sem.Random qualified as Rnd
+import Wire.TeamSubsystem (TeamSubsystem)
+import Wire.TeamSubsystem.GalleyAPI
 import Wire.UserGroupStore (UserGroupStore)
 import Wire.UserGroupSubsystem
 import Wire.UserGroupSubsystem.Interpreter
@@ -47,6 +49,7 @@ runDependencies ::
   Map TeamId [TeamMember] ->
   Sem
     '[ UserSubsystem,
+       TeamSubsystem,
        GalleyAPIAccess,
        UserGroupStore,
        State UserGroupInMemState,
@@ -67,6 +70,7 @@ runDependencies initialUsers initialTeams =
     . runInputConst (toLocalUnsafe (Domain "example.com") ())
     . runInMemoryUserGroupStore def
     . miniGalleyAPIAccess initialTeams def
+    . intepreterTeamSubsystemToGalleyAPI
     . userSubsystemTestInterpreter initialUsers
 
 runDependenciesWithReturnState ::
@@ -74,6 +78,7 @@ runDependenciesWithReturnState ::
   Map TeamId [TeamMember] ->
   Sem
     ( '[ UserSubsystem,
+         TeamSubsystem,
          GalleyAPIAccess
        ]
         `Append` EffectStack
@@ -93,6 +98,7 @@ runDependenciesWithReturnState initialUsers initialTeams =
     . runInputConst (toLocalUnsafe (Domain "example.com") ())
     . runInMemoryUserGroupStore def
     . miniGalleyAPIAccess initialTeams def
+    . intepreterTeamSubsystemToGalleyAPI
     . userSubsystemTestInterpreter initialUsers
 
 expectRight :: (Show err) => Either err Property -> Property

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -242,6 +242,8 @@ library
     Wire.TeamInvitationSubsystem
     Wire.TeamInvitationSubsystem.Error
     Wire.TeamInvitationSubsystem.Interpreter
+    Wire.TeamSubsystem
+    Wire.TeamSubsystem.GalleyAPI
     Wire.UserGroupStore
     Wire.UserGroupStore.Postgres
     Wire.UserGroupSubsystem

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -249,7 +249,6 @@ library
     , fsnotify                              >=0.4
     , galley-types                          >=0.75.3
     , hashable                              >=1.2
-    , hasql
     , hasql-pool
     , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -50,7 +50,6 @@
 , galley-types
 , gitignoreSource
 , hashable
-, hasql
 , hasql-pool
 , hs-opentelemetry-instrumentation-wai
 , hs-opentelemetry-sdk
@@ -202,7 +201,6 @@ mkDerivation {
     fsnotify
     galley-types
     hashable
-    hasql
     hasql-pool
     hs-opentelemetry-instrumentation-wai
     hs-opentelemetry-sdk

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -70,6 +70,7 @@ import Wire.FederationConfigStore
 import Wire.GalleyAPIAccess
 import Wire.GalleyAPIAccess qualified as GalleyAPIAccess
 import Wire.NotificationSubsystem
+import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.UserStore
 import Wire.UserSubsystem
 
@@ -87,7 +88,8 @@ createConnection ::
     Member TinyLog r,
     Member UserStore r,
     Member UserSubsystem r,
-    Member (Embed HttpClientIO) r
+    Member (Embed HttpClientIO) r,
+    Member TeamSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -108,7 +110,8 @@ createConnectionToLocalUser ::
     Member TinyLog r,
     Member UserStore r,
     Member UserSubsystem r,
-    Member (Embed HttpClientIO) r
+    Member (Embed HttpClientIO) r,
+    Member TeamSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -196,7 +199,7 @@ createConnectionToLocalUser self conn target = do
 -- FUTUREWORK: we may want to move this to the LH application logic, so we can recycle it for
 -- group conv creation and possibly other situations.
 checkLegalholdPolicyConflict ::
-  (Member GalleyAPIAccess r, Member UserSubsystem r) =>
+  (Member TeamSubsystem r, Member UserSubsystem r) =>
   Local UserId ->
   Local UserId ->
   ExceptT ConnectionError (AppT r) ()

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -127,6 +127,7 @@ import Wire.Sem.Random (Random)
 import Wire.SessionStore (SessionStore)
 import Wire.SparAPIAccess (SparAPIAccess)
 import Wire.TeamInvitationSubsystem
+import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.UserKeyStore
 import Wire.UserStore as UserStore
 import Wire.UserSubsystem
@@ -148,6 +149,7 @@ servantSitemap ::
     Member GalleyAPIAccess r,
     Member NotificationSubsystem r,
     Member UserSubsystem r,
+    Member TeamSubsystem r,
     Member TeamInvitationSubsystem r,
     Member UserStore r,
     Member InvitationStore r,
@@ -202,7 +204,8 @@ ejpdAPI ::
   ( Member GalleyAPIAccess r,
     Member NotificationSubsystem r,
     Member UserStore r,
-    Member Rpc r
+    Member Rpc r,
+    Member TeamSubsystem r
   ) =>
   ServerT BrigIRoutes.EJPDRequest (Handler r)
 ejpdAPI = Named @"ejpd-request" Brig.User.EJPD.ejpdRequest
@@ -291,6 +294,7 @@ teamsAPI ::
     Member InvitationStore r,
     Member TeamInvitationSubsystem r,
     Member UserSubsystem r,
+    Member TeamSubsystem r,
     Member (Polysemy.Error UserSubsystemError) r,
     Member Events r,
     Member (Input (Local ())) r,

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -187,6 +187,8 @@ import Wire.SessionStore (SessionStore)
 import Wire.SparAPIAccess
 import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamInvitationSubsystem
+import Wire.TeamSubsystem (TeamSubsystem)
+import Wire.TeamSubsystem qualified as TeamSubsystem
 import Wire.UserGroupSubsystem (UserGroupSubsystem)
 import Wire.UserGroupSubsystem qualified as UserGroup
 import Wire.UserKeyStore
@@ -401,7 +403,8 @@ servantSitemap ::
     Member CryptoSign r,
     Member Random r,
     Member UserGroupSubsystem r,
-    Member TeamCollaboratorsSubsystem r
+    Member TeamCollaboratorsSubsystem r,
+    Member TeamSubsystem r
   ) =>
   ServerT BrigAPI (Handler r)
 servantSitemap =
@@ -1270,7 +1273,8 @@ createConnectionUnqualified ::
     Member TinyLog r,
     Member UserStore r,
     Member UserSubsystem r,
-    Member (Embed HttpClientIO) r
+    Member (Embed HttpClientIO) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   ConnId ->
@@ -1288,7 +1292,8 @@ createConnection ::
     Member UserStore r,
     Member UserSubsystem r,
     Member TinyLog r,
-    Member (Embed HttpClientIO) r
+    Member (Embed HttpClientIO) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   ConnId ->
@@ -1433,7 +1438,6 @@ updateUserEmail ::
   forall r.
   ( Member BlockListStore r,
     Member UserKeyStore r,
-    Member GalleyAPIAccess r,
     Member EmailSubsystem r,
     Member UserSubsystem r,
     Member UserStore r,
@@ -1442,7 +1446,8 @@ updateUserEmail ::
     Member (Input UserSubsystemConfig) r,
     Member DomainRegistrationStore r,
     Member TinyLog r,
-    Member SparAPIAccess r
+    Member SparAPIAccess r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   UserId ->
@@ -1467,7 +1472,7 @@ updateUserEmail zuserId emailOwnerId (Public.EmailUpdate email) = do
       where
         check = runMaybeT $ do
           teamId <- hoistMaybe maybeTeamId
-          teamMember <- MaybeT $ lift $ liftSem $ GalleyAPIAccess.getTeamMember zuserId teamId
+          teamMember <- MaybeT $ lift $ liftSem $ TeamSubsystem.internalGetTeamMember zuserId teamId
           pure $ teamMember `hasPermission` ChangeTeamMemberProfiles
 
 -- activation

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -146,6 +146,8 @@ import Wire.RateLimit
 import Wire.Sem.Concurrency
 import Wire.Sem.Paging.Cassandra
 import Wire.SessionStore (SessionStore)
+import Wire.TeamSubsystem (TeamSubsystem)
+import Wire.TeamSubsystem qualified as TeamSubsystem
 import Wire.UserKeyStore
 import Wire.UserStore
 import Wire.UserSubsystem as User
@@ -1110,7 +1112,7 @@ enqueueMultiDeleteCallsCounter =
         }
 
 getLegalHoldStatus ::
-  ( Member GalleyAPIAccess r,
+  ( Member TeamSubsystem r,
     Member UserSubsystem r
   ) =>
   Local UserId ->
@@ -1121,14 +1123,14 @@ getLegalHoldStatus uid =
       =<< User.getLocalAccountBy NoPendingInvitations uid
 
 getLegalHoldStatus' ::
-  (Member GalleyAPIAccess r) =>
+  (Member TeamSubsystem r) =>
   User ->
   Sem r UserLegalHoldStatus
 getLegalHoldStatus' user =
   case userTeam user of
     Nothing -> pure defUserLegalHoldStatus
     Just tid -> do
-      teamMember <- GalleyAPIAccess.getTeamMember (userId user) tid
+      teamMember <- TeamSubsystem.internalGetTeamMember (userId user) tid
       pure $ maybe defUserLegalHoldStatus (^. legalHoldStatus) teamMember
 
 isBlacklisted :: (Member BlockListStore r) => EmailAddress -> AppT r Bool

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -127,7 +127,6 @@ import Data.ByteString.Conversion
 import Data.Credentials (Credentials (..))
 import Data.Domain
 import Data.Id
-import Data.Map qualified as Map
 import Data.Misc
 import Data.Qualified
 import Data.Text qualified as Text
@@ -137,11 +136,8 @@ import Data.Text.IO qualified as Text
 import Data.Time.Clock
 import Database.Bloodhound qualified as ES
 import HTTP2.Client.Manager (Http2Manager, http2ManagerWithSSLCtx)
-import Hasql.Connection.Setting qualified as HasqlSetting
-import Hasql.Connection.Setting.Connection qualified as HasqlConn
-import Hasql.Connection.Setting.Connection.Param qualified as HasqlConfig
 import Hasql.Pool qualified as HasqlPool
-import Hasql.Pool.Config qualified as HasqlPool
+import Hasql.Pool.Extended
 import Imports
 import Network.AMQP qualified as Q
 import Network.AMQP.Extended qualified as Q
@@ -466,25 +462,6 @@ initCassandra o g =
     (Opt.discoUrl o)
     (Just schemaVersion)
     g
-
--- | Creates a pool from postgres config params
---
--- HasqlConn.params translates pgParams into connection (which just holds the connection string and is not a real connection)
--- HasqlSetting.connection unwraps the connection string out of connection
--- HasqlPool.staticConnectionSettings translates the connection string to the pool settings
--- HasqlPool.settings translates the pool settings into pool config
--- HasqlPool.acquire creates the pool.
--- ezpz.
-initPostgresPool :: Map Text Text -> Maybe FilePathSecrets -> IO HasqlPool.Pool
-initPostgresPool pgConfig mFpSecrets = do
-  mPw <- for mFpSecrets initCredentials
-  let pgConfigWithPw = maybe pgConfig (\pw -> Map.insert "password" pw pgConfig) mPw
-  let pgParams = Map.foldMapWithKey (\k v -> [HasqlConfig.other k v]) pgConfigWithPw
-  HasqlPool.acquire $
-    HasqlPool.settings
-      [ HasqlPool.staticConnectionSettings $
-          [HasqlSetting.connection $ HasqlConn.params pgParams]
-      ]
 
 teamTemplatesWithLocale :: (MonadReader Env m) => Maybe Locale -> m (Locale, TeamTemplates)
 teamTemplatesWithLocale l = forLocale l <$> asks (.teamTemplates)

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -133,14 +133,14 @@ type BrigCanonicalEffects =
      EnterpriseLoginSubsystem,
      UserGroupSubsystem,
      UserSubsystem,
-     TeamCollaboratorsSubsystem,
-     TeamSubsystem
+     TeamCollaboratorsSubsystem
    ]
     `Append` BrigLowerLevelEffects
 
 -- | These effects have interpreters which don't depend on each other
 type BrigLowerLevelEffects =
-  '[ TeamCollaboratorsStore,
+  '[ TeamSubsystem,
+     TeamCollaboratorsStore,
      EmailSubsystem,
      VerificationCodeSubsystem,
      PropertySubsystem,

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -109,6 +109,8 @@ import Wire.TeamCollaboratorsSubsystem.Interpreter
 import Wire.TeamInvitationSubsystem
 import Wire.TeamInvitationSubsystem.Error
 import Wire.TeamInvitationSubsystem.Interpreter
+import Wire.TeamSubsystem
+import Wire.TeamSubsystem.GalleyAPI
 import Wire.UserGroupStore
 import Wire.UserGroupStore.Postgres (interpretUserGroupStoreToPostgres)
 import Wire.UserGroupSubsystem
@@ -131,7 +133,8 @@ type BrigCanonicalEffects =
      EnterpriseLoginSubsystem,
      UserGroupSubsystem,
      UserSubsystem,
-     TeamCollaboratorsSubsystem
+     TeamCollaboratorsSubsystem,
+     TeamSubsystem
    ]
     `Append` BrigLowerLevelEffects
 
@@ -346,6 +349,7 @@ runBrigToIO e (AppT ma) = do
               . interpretVerificationCodeSubsystem
               . emailSubsystemInterpreter e.userTemplates e.teamTemplates e.templateBranding
               . interpretTeamCollaboratorsStoreToPostgres
+              . intepreterTeamSubsystemToGalleyAPI
               . interpretTeamCollaboratorsSubsystem
               . userSubsystemInterpreter
               . interpretUserGroupSubsystem

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -137,6 +137,7 @@ import Wire.RateLimit
 import Wire.Sem.Concurrency (Concurrency, ConcurrencySafety (Unsafe))
 import Wire.Sem.Now (Now)
 import Wire.SessionStore (SessionStore)
+import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.UserKeyStore (mkEmailKey)
 import Wire.UserSubsystem
 import Wire.UserSubsystem.Error
@@ -175,7 +176,8 @@ servicesAPI ::
   ( Member GalleyAPIAccess r,
     Member AuthenticationSubsystem r,
     Member DeleteQueue r,
-    Member (Error UserSubsystemError) r
+    Member (Error UserSubsystemError) r,
+    Member TeamSubsystem r
   ) =>
   ServerT ServicesAPI (Handler r)
 servicesAPI =
@@ -685,6 +687,7 @@ getServiceTagList _ = do
 
 updateServiceWhitelist ::
   ( Member GalleyAPIAccess r,
+    Member TeamSubsystem r,
     Member (Error UserSubsystemError) r
   ) =>
   UserId ->

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -40,7 +40,6 @@ import Data.Id
 import Data.List1 qualified as List1
 import Data.Qualified
 import Data.Range
-import Data.Set qualified as Set
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy qualified as LT
 import Imports hiding (head)
@@ -110,7 +109,7 @@ servantAPI =
     :<|> Named @"head-team-invitations" (lift . liftSem . headInvitationByEmail)
     :<|> Named @"get-team-size" (\uid tid -> lift . liftSem $ teamSizePublic uid tid)
     :<|> Named @"accept-team-invitation" (\luid req -> lift $ liftSem $ acceptTeamInvitation luid req.password req.code)
-    :<|> Named @"add-team-collaborator" (\zuid tid (NewTeamCollaborator uid (Set.fromList -> perms)) -> lift . liftSem $ createTeamCollaborator zuid uid tid perms)
+    :<|> Named @"add-team-collaborator" (\zuid tid (NewTeamCollaborator uid perms) -> lift . liftSem $ createTeamCollaborator zuid uid tid perms)
     :<|> Named @"get-team-collaborators" (\zuid tid -> lift . liftSem $ getAllTeamCollaborators zuid tid)
 
 teamSizePublic ::

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -411,7 +411,7 @@ changeTeamAccountStatuses tid s = do
   team <- Team.tdTeam <$> lift (liftSem $ GalleyAPIAccess.getTeam tid)
   unless (team ^. teamBinding == Binding) $
     throwStd noBindingTeam
-  uids <- toList1 =<< lift (fmap (view Teams.userId) . view teamMembers <$> liftSem (GalleyAPIAccess.getTeamMembers tid))
+  uids <- toList1 =<< lift (fmap (view Teams.userId) . view teamMembers <$> liftSem (GalleyAPIAccess.getTeamMembers tid Nothing))
   API.changeAccountStatus uids s !>> accountStatusError
   where
     toList1 (x : xs) = pure $ List1.list1 x xs

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -98,7 +98,8 @@ servantAPI ::
     Member (Input (Local ())) r,
     Member (Error UserSubsystemError) r,
     Member IndexedUserStore r,
-    Member TeamCollaboratorsSubsystem r
+    Member TeamCollaboratorsSubsystem r,
+    Member TeamSubsystem r
   ) =>
   ServerT TeamsAPI (Handler r)
 servantAPI =
@@ -115,9 +116,9 @@ servantAPI =
     :<|> Named @"get-team-collaborators" (\zuid tid -> lift . liftSem $ getAllTeamCollaborators zuid tid)
 
 teamSizePublic ::
-  ( Member GalleyAPIAccess r,
-    Member (Error UserSubsystemError) r,
-    Member IndexedUserStore r
+  ( Member (Error UserSubsystemError) r,
+    Member IndexedUserStore r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   TeamId ->
@@ -201,9 +202,9 @@ logInvitationRequest context action =
         pure (Right result)
 
 deleteInvitation ::
-  ( Member GalleyAPIAccess r,
-    Member InvitationStore r,
-    Member (Error UserSubsystemError) r
+  ( Member InvitationStore r,
+    Member (Error UserSubsystemError) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   TeamId ->
@@ -221,7 +222,8 @@ listInvitations ::
     Member (Input TeamTemplates) r,
     Member (Input (Local ())) r,
     Member UserSubsystem r,
-    Member (Error UserSubsystemError) r
+    Member (Error UserSubsystemError) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   TeamId ->
@@ -285,7 +287,8 @@ getInvitation ::
     Member InvitationStore r,
     Member TinyLog r,
     Member (Input TeamTemplates) r,
-    Member (Error UserSubsystemError) r
+    Member (Error UserSubsystemError) r,
+    Member TeamSubsystem r
   ) =>
   UserId ->
   TeamId ->

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -101,7 +101,7 @@ ejpdRequest (fromMaybe False -> includeContacts) (EJPDRequestBody handles) = do
       mbTeamContacts <-
         case (reallyIncludeContacts, userTeam target) of
           (True, Just tid) -> do
-            memberList <- liftSem $ GalleyAPIAccess.getTeamMembers tid
+            memberList <- liftSem $ GalleyAPIAccess.getTeamMembers tid Nothing
             let members = (view Team.userId <$> (memberList ^. Team.teamMembers)) \\ [uid]
 
             contactsFull <-

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -49,6 +49,8 @@ import Wire.GalleyAPIAccess (GalleyAPIAccess)
 import Wire.GalleyAPIAccess qualified as GalleyAPIAccess
 import Wire.NotificationSubsystem
 import Wire.Rpc
+import Wire.TeamSubsystem (TeamSubsystem)
+import Wire.TeamSubsystem qualified as TeamSubsystem
 import Wire.UserStore (UserStore)
 
 -- FUTUREWORK(mangoiv): this uses 'UserStore' and should hence go to 'UserSubSystem'
@@ -57,7 +59,8 @@ ejpdRequest ::
   ( Member GalleyAPIAccess r,
     Member NotificationSubsystem r,
     Member UserStore r,
-    Member Rpc r
+    Member Rpc r,
+    Member TeamSubsystem r
   ) =>
   Maybe Bool ->
   EJPDRequestBody ->
@@ -101,7 +104,7 @@ ejpdRequest (fromMaybe False -> includeContacts) (EJPDRequestBody handles) = do
       mbTeamContacts <-
         case (reallyIncludeContacts, userTeam target) of
           (True, Just tid) -> do
-            memberList <- liftSem $ GalleyAPIAccess.getTeamMembers tid Nothing
+            memberList <- liftSem $ TeamSubsystem.internalGetTeamMembers tid Nothing
             let members = (view Team.userId <$> (memberList ^. Team.teamMembers)) \\ [uid]
 
             contactsFull <-

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -41,6 +41,7 @@
 , filepath
 , galley-types
 , gitignoreSource
+, hasql-pool
 , hex
 , hs-opentelemetry-instrumentation-wai
 , hs-opentelemetry-sdk
@@ -159,6 +160,7 @@ mkDerivation {
     extended
     extra
     galley-types
+    hasql-pool
     hex
     hs-opentelemetry-instrumentation-wai
     hs-opentelemetry-sdk

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -286,6 +286,7 @@ library
     Galley.Schema.V96_GroupConversationType
     Galley.Schema.V97_CellsConversation
     Galley.Schema.V98_ChannelAddPermission
+    Galley.TeamSubsystem
     Galley.Types.Clients
     Galley.Types.ToUserRole
     Galley.Types.UserList
@@ -324,6 +325,7 @@ library
     , extended
     , extra                                 >=1.3
     , galley-types                          >=0.65.0
+    , hasql-pool
     , hex
     , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -9,6 +9,13 @@ cassandra:
   keyspace: galley_test
   # filterNodesByDatacentre: datacenter1
 
+postgresql:
+  host: 127.0.0.1
+  port: "5432"
+  user: wire-server
+  dbname: backendA
+  password: posty-the-gres
+
 brig:
   host: 0.0.0.0
   port: 8082

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -100,6 +100,7 @@ import Wire.API.User.Client
 import Wire.NotificationSubsystem
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+import Wire.TeamSubsystem qualified as TeamSubsystem
 
 internalAPI :: API InternalAPI GalleyEffects
 internalAPI =
@@ -211,7 +212,7 @@ iTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
         <@> mkNamedAPI @"update-team-status" (Teams.updateTeamStatus tid)
         <@> hoistAPISegment
           ( mkNamedAPI @"unchecked-add-team-member" (Teams.uncheckedAddTeamMember tid)
-              <@> mkNamedAPI @"unchecked-get-team-members" (Teams.uncheckedGetTeamMembersH tid)
+              <@> mkNamedAPI @"unchecked-get-team-members" (TeamSubsystem.internalGetTeamMembers tid)
               <@> mkNamedAPI @"unchecked-get-team-member" (Teams.uncheckedGetTeamMember tid)
               <@> mkNamedAPI @"can-user-join-team" (Teams.canUserJoinTeam tid)
               <@> mkNamedAPI @"unchecked-update-team-member" (Teams.uncheckedUpdateTeamMember Nothing Nothing tid)

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -216,7 +216,7 @@ iTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
               <@> mkNamedAPI @"unchecked-get-team-member" (Teams.uncheckedGetTeamMember tid)
               <@> mkNamedAPI @"can-user-join-team" (Teams.canUserJoinTeam tid)
               <@> mkNamedAPI @"unchecked-update-team-member" (Teams.uncheckedUpdateTeamMember Nothing Nothing tid)
-              <@> mkNamedAPI @"unchecked-get-team-admins" (Teams.uncheckedGetTeamAdmins tid)
+              <@> mkNamedAPI @"unchecked-get-team-admins" (TeamSubsystem.internalGetTeamAdmins tid)
           )
         <@> mkNamedAPI @"user-is-team-owner" (Teams.userIsTeamOwner tid)
         <@> hoistAPISegment

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -47,7 +47,6 @@ module Galley.API.Teams
     uncheckedGetTeamMember,
     uncheckedDeleteTeamMember,
     uncheckedUpdateTeamMember,
-    uncheckedGetTeamAdmins,
     userIsTeamOwner,
     canUserJoinTeam,
     ensureNotTooLargeForLegalHold,
@@ -616,12 +615,6 @@ uncheckedAddTeamMember tid nmem = do
   (TeamSize sizeBeforeAdd) <- addTeamMemberInternal tid Nothing Nothing nmem
   owners <- E.getBillingTeamMembers tid
   Journal.teamUpdate tid (sizeBeforeAdd + 1) owners
-
-uncheckedGetTeamAdmins :: forall r. (Member TeamStore r) => TeamId -> Sem r TeamMemberList
-uncheckedGetTeamAdmins tid = do
-  admins <- E.getTeamAdmins tid
-  membs <- E.selectTeamMembers tid admins
-  pure $ newTeamMemberList membs ListComplete
 
 uncheckedUpdateTeamMember ::
   forall r.

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -294,16 +294,16 @@ getMLSData conv = case Data.convProtocol conv of
 
 -- | Same as 'permissionCheck', but for a statically known permission.
 permissionCheckS ::
-  forall perm (p :: perm) r.
+  forall teamAssociation perm (p :: perm) r.
   ( SingKind perm,
-    IsPerm (Demote perm),
+    IsPerm teamAssociation (Demote perm),
     ( Member (ErrorS (PermError p)) r,
       Member (ErrorS 'NotATeamMember) r
     )
   ) =>
   Sing p ->
-  Maybe TeamMember ->
-  Sem r TeamMember
+  Maybe teamAssociation ->
+  Sem r teamAssociation
 permissionCheckS p =
   \case
     Just m -> do
@@ -317,14 +317,14 @@ permissionCheckS p =
 -- member does not have the given permission, throw 'operationDenied'.
 -- Otherwise, return the team member.
 permissionCheck ::
-  ( IsPerm perm,
+  ( IsPerm teamAssociation perm,
     ( Member (ErrorS OperationDenied) r,
       Member (ErrorS 'NotATeamMember) r
     )
   ) =>
   perm ->
-  Maybe TeamMember ->
-  Sem r TeamMember
+  Maybe teamAssociation ->
+  Sem r teamAssociation
 -- FUTUREWORK: factor `noteS` out of this function.
 permissionCheck p = \case
   Just m -> do

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -122,7 +122,7 @@ import Wire.Sem.Delay
 import Wire.Sem.Now.IO (nowToIO)
 import Wire.Sem.Random.IO
 import Wire.TeamCollaboratorsStore.Postgres (interpretTeamCollaboratorsStoreToPostgres)
-import Wire.TeamCollaboratorsSubsystem.Interpreter (interpretTeamCollaboratorsSubsystem)
+import Wire.TeamCollaboratorsSubsystem.Interpreter
 
 -- Effects needed by the interpretation of other effects
 type GalleyEffects0 =
@@ -266,7 +266,7 @@ evalGalley e =
     . asyncToIOFinal
     . mapError httpErrorToJSONResponse
     . mapError postgresUsageErrorToHttpError
-    . mapError toResponse
+    . mapError teamCollaboratorsSubsystemErrorToHttpError
     . mapError toResponse
     . mapError toResponse
     . mapError toResponse

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -81,8 +81,11 @@ import Galley.Options hiding (brig, endpoint, federator)
 import Galley.Options qualified as O
 import Galley.Queue
 import Galley.Queue qualified as Q
+import Galley.TeamSubsystem (interpretTeamSubsystem)
 import Galley.Types.Teams
 import HTTP2.Client.Manager (Http2Manager, http2ManagerWithSSLCtx)
+import Hasql.Pool qualified as Hasql
+import Hasql.Pool.Extended (initPostgresPool)
 import Imports hiding (forkIO)
 import Network.AMQP.Extended (mkRabbitMqChannelMVar)
 import Network.HTTP.Client (responseTimeoutMicro)
@@ -106,6 +109,7 @@ import UnliftIO.Exception qualified as UnliftIO
 import Wire.API.Conversation.Protocol
 import Wire.API.Error
 import Wire.API.Federation.Error
+import Wire.API.Team.Collaborator
 import Wire.API.Team.Feature
 import Wire.Error
 import Wire.GundeckAPIAccess (runGundeckAPIAccess)
@@ -115,17 +119,24 @@ import Wire.RateLimit
 import Wire.RateLimit.Interpreter
 import Wire.Rpc
 import Wire.Sem.Delay
+import Wire.Sem.Now.IO (nowToIO)
 import Wire.Sem.Random.IO
+import Wire.TeamCollaboratorsStore.Postgres (interpretTeamCollaboratorsStoreToPostgres)
+import Wire.TeamCollaboratorsSubsystem.Interpreter (interpretTeamCollaboratorsSubsystem)
 
 -- Effects needed by the interpretation of other effects
 type GalleyEffects0 =
   '[ Input ClientState,
+     Input Hasql.Pool,
      Input Env,
      Error InvalidInput,
      Error InternalError,
      -- federation errors can be thrown by almost every endpoint, so we avoid
      -- having to declare it every single time, and simply handle it here
      Error FederationError,
+     Error TeamCollaboratorsError,
+     Error Hasql.UsageError,
+     Error HttpError,
      Async,
      Delay,
      Fail,
@@ -170,7 +181,8 @@ createEnv o l = do
   mgr <- initHttpManager o
   h2mgr <- initHttp2Manager
   codeURIcfg <- validateOptions o
-  Env (RequestId defRequestId) o l mgr h2mgr (o ^. O.federator) (o ^. O.brig) cass
+  postgres <- initPostgresPool o._postgresql o._postgresqlPassword
+  Env (RequestId defRequestId) o l mgr h2mgr (o ^. O.federator) (o ^. O.brig) cass postgres
     <$> Q.new 16000
     <*> initExtEnv
     <*> maybe (pure Nothing) (fmap Just . Aws.mkEnv l mgr) (o ^. journal)
@@ -252,16 +264,20 @@ evalGalley e =
     . failToEmbed @IO
     . runDelay
     . asyncToIOFinal
+    . mapError httpErrorToJSONResponse
+    . mapError postgresUsageErrorToHttpError
+    . mapError toResponse
     . mapError toResponse
     . mapError toResponse
     . mapError toResponse
     . runInputConst e
+    . runInputConst (e ^. hasqlPool)
     . runInputConst (e ^. cstate)
-    . mapError httpErrorToJSONResponse
     . mapError rateLimitExceededToHttpError
     . mapError toResponse -- DynError
     . interpretTinyLog e
     . interpretQueue (e ^. deleteQueue)
+    . nowToIO
     . runInputSem (embed getCurrentTime) -- FUTUREWORK: could we take the time only once instead?
     . runInputConst (e ^. options)
     . runInputConst (toLocalUnsafe (e ^. options . settings . federationDomain) ())
@@ -290,6 +306,7 @@ evalGalley e =
     . interpretProposalStoreToCassandra
     . interpretCodeStoreToCassandra
     . interpretClientStoreToCassandra
+    . interpretTeamCollaboratorsStoreToPostgres
     . interpretFireAndForget
     . interpretBotAccess
     . interpretBackendNotificationQueueAccess
@@ -297,7 +314,9 @@ evalGalley e =
     . interpretExternalAccess
     . runRpcWithHttp (e ^. manager) (e ^. reqId)
     . runGundeckAPIAccess (e ^. options . gundeck)
+    . interpretTeamSubsystem
     . runNotificationSubsystemGundeck (notificationSubsystemConfig e)
+    . interpretTeamCollaboratorsSubsystem
     . interpretSparAccess
     . interpretBrigAccess
   where

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -99,20 +99,25 @@ import Polysemy.Input
 import Polysemy.TinyLog
 import Wire.API.Error
 import Wire.API.Team.Feature
-import Wire.Error
 import Wire.GundeckAPIAccess
 import Wire.HashPassword
 import Wire.NotificationSubsystem
 import Wire.RateLimit
 import Wire.Rpc
+import Wire.Sem.Now
 import Wire.Sem.Paging.Cassandra
 import Wire.Sem.Random
+import Wire.TeamCollaboratorsStore (TeamCollaboratorsStore)
+import Wire.TeamCollaboratorsSubsystem (TeamCollaboratorsSubsystem)
+import Wire.TeamSubsystem (TeamSubsystem)
 
 -- All the possible high-level effects.
 type GalleyEffects1 =
   '[ BrigAccess,
      SparAccess,
+     TeamCollaboratorsSubsystem,
      NotificationSubsystem,
+     TeamSubsystem,
      GundeckAPIAccess,
      Rpc,
      ExternalAccess,
@@ -120,6 +125,7 @@ type GalleyEffects1 =
      BackendNotificationQueueAccess,
      BotAccess,
      FireAndForget,
+     TeamCollaboratorsStore,
      ClientStore,
      CodeStore,
      ProposalStore,
@@ -147,10 +153,10 @@ type GalleyEffects1 =
      Input (Maybe [TeamId], FeatureDefaults LegalholdConfig),
      Input (Local ()),
      Input Opts,
-     Input UTCTime,
+     Input UTCTime, -- TODO: Use 'Now' instead of this
+     Now,
      Queue DeleteItem,
      TinyLog,
      Error DynError,
-     Error RateLimitExceeded,
-     Error HttpError
+     Error RateLimitExceeded
    ]

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -32,6 +32,7 @@ import Galley.Options
 import Galley.Options qualified as O
 import Galley.Queue qualified as Q
 import HTTP2.Client.Manager (Http2Manager)
+import Hasql.Pool
 import Imports
 import Network.AMQP qualified as Q
 import Network.HTTP.Client
@@ -59,6 +60,7 @@ data Env = Env
     _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type here? E.g. to avoid fresh connections all the time?
     _brig :: Endpoint, -- FUTUREWORK: see _federator
     _cstate :: ClientState,
+    _hasqlPool :: Pool,
     _deleteQueue :: Q.Queue DeleteItem,
     _extEnv :: ExtEnv,
     _aEnv :: Maybe Aws.Env,

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -41,6 +41,8 @@ module Galley.Options
     Opts (..),
     galley,
     cassandra,
+    postgresqlPassword,
+    postgresql,
     brig,
     gundeck,
     spar,
@@ -182,6 +184,10 @@ data Opts = Opts
     _galley :: !Endpoint,
     -- | Cassandra settings
     _cassandra :: !CassandraOpts,
+    -- | Postgresql settings, the key values must be in libpq format.
+    -- https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+    _postgresql :: !(Map Text Text),
+    _postgresqlPassword :: !(Maybe FilePathSecrets),
     -- | Brig endpoint
     _brig :: !Endpoint,
     -- | Gundeck endpoint

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -43,6 +43,7 @@ import Galley.App
 import Galley.App qualified as App
 import Galley.Aws (awsEnv)
 import Galley.Cassandra
+import Galley.Env
 import Galley.Monad
 import Galley.Options
 import Galley.Queue qualified as Q
@@ -67,11 +68,13 @@ import Wire.API.Routes.Public.Galley
 import Wire.API.Routes.Version
 import Wire.API.Routes.Version.Wai
 import Wire.OpenTelemetry (withTracerC)
+import Wire.PostgresMigrations (runAllMigrations)
 
 run :: Opts -> IO ()
 run opts = lowerCodensity do
   tracer <- withTracerC
   (app, env) <- mkApp opts
+  lift $ runAllMigrations env._hasqlPool env._applog
   let settings' =
         newSettings $
           defaultServer

--- a/services/galley/src/Galley/TeamSubsystem.hs
+++ b/services/galley/src/Galley/TeamSubsystem.hs
@@ -5,6 +5,7 @@ import Galley.Effects.TeamStore qualified as E
 import Imports
 import Polysemy
 import Wire.API.Team.HardTruncationLimit
+import Wire.API.Team.Member
 import Wire.TeamSubsystem
 
 -- This interpreter exists so galley code doesn't end up depending on
@@ -17,6 +18,10 @@ import Wire.TeamSubsystem
 -- They also depend on entire galley env.
 interpretTeamSubsystem :: (Member TeamStore r) => InterpreterFor TeamSubsystem r
 interpretTeamSubsystem = interpret $ \case
-  InternalGetTeamMember userId teamId -> E.getTeamMember teamId userId
-  InternalGetTeamMembers teamId maxResults ->
-    E.getTeamMembersWithLimit teamId $ fromMaybe hardTruncationLimitRange maxResults
+  InternalGetTeamMember uid tid -> E.getTeamMember tid uid
+  InternalGetTeamMembers tid maxResults ->
+    E.getTeamMembersWithLimit tid $ fromMaybe hardTruncationLimitRange maxResults
+  InternalGetTeamAdmins tid -> do
+    admins <- E.getTeamAdmins tid
+    membs <- E.selectTeamMembers tid admins
+    pure $ newTeamMemberList membs ListComplete

--- a/services/galley/src/Galley/TeamSubsystem.hs
+++ b/services/galley/src/Galley/TeamSubsystem.hs
@@ -1,0 +1,20 @@
+module Galley.TeamSubsystem where
+
+import Galley.Effects.TeamStore (TeamStore)
+import Galley.Effects.TeamStore qualified as E
+import Imports
+import Polysemy
+import Wire.TeamSubsystem
+
+-- This interpreter exists so galley code doesn't end up depending on
+-- GalleyAPIAccess, while it is possible to implement that, it'd add unnecesary
+-- HTTP calls for tiny things.
+--
+-- When we actually implement TeamSubsystem this can move to wire-subsystem.
+-- Moving this to wire-subsystem before that would be too much work as the Store
+-- effects in galley are not as thin as we're doing them in wire-subsystems.
+-- They also depend on entire galley env.
+interpretTeamSubsystem :: (Member TeamStore r) => InterpreterFor TeamSubsystem r
+interpretTeamSubsystem = interpret $ \case
+  InternalGetTeamMember userId teamId -> E.getTeamMember teamId userId
+  InternalGetTeamMembers teamId -> E.getTeamMembersWithLimit teamId =<< E.fanoutLimit

--- a/services/galley/src/Galley/TeamSubsystem.hs
+++ b/services/galley/src/Galley/TeamSubsystem.hs
@@ -4,6 +4,7 @@ import Galley.Effects.TeamStore (TeamStore)
 import Galley.Effects.TeamStore qualified as E
 import Imports
 import Polysemy
+import Wire.API.Team.HardTruncationLimit
 import Wire.TeamSubsystem
 
 -- This interpreter exists so galley code doesn't end up depending on
@@ -17,4 +18,5 @@ import Wire.TeamSubsystem
 interpretTeamSubsystem :: (Member TeamStore r) => InterpreterFor TeamSubsystem r
 interpretTeamSubsystem = interpret $ \case
   InternalGetTeamMember userId teamId -> E.getTeamMember teamId userId
-  InternalGetTeamMembers teamId -> E.getTeamMembersWithLimit teamId =<< E.fanoutLimit
+  InternalGetTeamMembers teamId maxResults ->
+    E.getTeamMembersWithLimit teamId $ fromMaybe hardTruncationLimitRange maxResults

--- a/services/spar/src/Spar/Intra/BrigApp.hs
+++ b/services/spar/src/Spar/Intra/BrigApp.hs
@@ -59,7 +59,7 @@ import Spar.Sem.BrigAccess (BrigAccess)
 import qualified Spar.Sem.BrigAccess as BrigAccess
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.GalleyAccess as GalleyAccess
-import Wire.API.Team.Member (HiddenPerm (CreateReadDeleteScimToken), IsPerm)
+import Wire.API.Team.Member (HiddenPerm (CreateReadDeleteScimToken), IsPerm, TeamMember)
 import Wire.API.User
 import Wire.API.User.Scim (ValidScimId (..))
 
@@ -136,7 +136,7 @@ getZUsrCheckPerm ::
       Member GalleyAccess r,
       Member (Error SparError) r
     ),
-    IsPerm perm,
+    IsPerm TeamMember perm,
     Show perm
   ) =>
   Maybe UserId ->

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -74,7 +74,7 @@ getTeamMember tid uid = do
 
 -- | user is member of a given team and has a given permission there.
 assertHasPermission ::
-  (HasCallStack, MonadSparToGalley m, MonadError SparError m, IsPerm perm, Show perm) =>
+  (HasCallStack, MonadSparToGalley m, MonadError SparError m, IsPerm TeamMember perm, Show perm) =>
   TeamId ->
   perm ->
   UserId ->

--- a/services/spar/src/Spar/Sem/GalleyAccess.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess.hs
@@ -37,7 +37,7 @@ import Wire.API.Team.Role
 data GalleyAccess m a where
   GetTeamMembers :: TeamId -> GalleyAccess m [TeamMember]
   GetTeamMember :: TeamId -> UserId -> GalleyAccess m (Maybe TeamMember)
-  AssertHasPermission :: (Show perm, IsPerm perm) => TeamId -> perm -> UserId -> GalleyAccess m ()
+  AssertHasPermission :: (Show perm, IsPerm TeamMember perm) => TeamId -> perm -> UserId -> GalleyAccess m ()
   AssertSSOEnabled :: TeamId -> GalleyAccess m ()
   IsEmailValidationEnabledTeam :: TeamId -> GalleyAccess m Bool
   UpdateTeamMember :: UserId -> TeamId -> Role -> GalleyAccess m ()


### PR DESCRIPTION
Also in this PR:
- Team Collaboarator creation event is only fanned out to team admins and owners
- Introduce TeamSubsystem to avoid using `GalleyAPIAccess` from galley.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
