### PR TITLE
Refactor the nginx upstream creation for Joe's PR

### DIFF
--- a/integration/default.nix
+++ b/integration/default.nix
@@ -45,6 +45,7 @@
 , HsOpenSSL
 , http-client
 , http-types
+, interpolate
 , kan-extensions
 , lens
 , lens-aeson
@@ -149,6 +150,7 @@ mkDerivation {
     HsOpenSSL
     http-client
     http-types
+    interpolate
     kan-extensions
     lens
     lens-aeson

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -259,6 +259,7 @@ library
     , HsOpenSSL
     , http-client
     , http-types
+    , interpolate
     , kan-extensions
     , lens
     , lens-aeson

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -527,6 +527,9 @@ startNginzK8s domain sm = do
   conf' <- Text.readFile nginxConfFile
   Text.writeFile nginxConfFile $ replaceUpstreamsInConfig conf' sm
 
+  -- TODO: Remove this debug trace
+  print $ "+++ Final NGINX conf\n" <> Text.unpack conf' <> "\n+++"
+
   ph <- startNginz domain nginxConfFile "/"
   pure $ ServiceInstance ph tmpDir
 

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -617,9 +617,13 @@ makeUpstreamsCfgs sm =
 
 -- | replace 'upstream <name> { ... }' blocks
 replaceUpstreamsInConfig :: Text.Text -> ServiceMap -> Text.Text
-replaceUpstreamsInConfig nginxConf sm = insertGeneratedUpstreams generateUpstreamsText $ removeUpstreamBlocks
+replaceUpstreamsInConfig nginxConf sm =
+  insertGeneratedUpstreams generateUpstreamsText $ removeUpstreamBlocks
   where
-    removeUpstreamBlocks = either (\e -> error ("Parsing for upstreams failed" <> e)) id $ Parser.parseOnly configParser nginxConf
+    removeUpstreamBlocks :: Text.Text
+    removeUpstreamBlocks =
+      either (\e -> error ("Parsing for upstreams failed" <> e)) id $
+        Parser.parseOnly configParser nginxConf
 
     -- Parser for everything except upstream blocks
     configParser :: Parser.Parser Text.Text

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -514,16 +514,14 @@ startNginzK8s domain sm = do
 
   let nginxConfFile = tmpDir </> "conf" </> "nginx.conf"
   conf <- Text.readFile nginxConfFile
-  Text.writeFile nginxConfFile $
-    ( conf
-        & Text.replace "access_log /dev/stdout" "access_log /dev/null"
-        -- FUTUREWORK: Get these ports out of config
-        & Text.replace ("listen 8080;\n    listen 8081 proxy_protocol;") (cs $ "listen " <> show sm.nginz.port <> ";")
-        & Text.replace ("listen 8082;") (cs $ "listen unix:" <> (tmpDir </> "metrics-socket") <> ";")
-        & Text.replace ("/var/run/nginz.pid") (cs $ tmpDir </> "nginz.pid")
-    )
+  let conf' =
+        conf
+          & Text.replace "access_log /dev/stdout" "access_log /dev/null"
+          -- FUTUREWORK: Get these ports out of config
+          & Text.replace ("listen 8080;\n    listen 8081 proxy_protocol;") (cs $ "listen " <> show sm.nginz.port <> ";")
+          & Text.replace ("listen 8082;") (cs $ "listen unix:" <> (tmpDir </> "metrics-socket") <> ";")
+          & Text.replace ("/var/run/nginz.pid") (cs $ tmpDir </> "nginz.pid")
 
-  conf' <- Text.readFile nginxConfFile
   Text.writeFile nginxConfFile $ replaceUpstreamsInConfig conf' sm
 
   ph <- startNginz domain nginxConfFile "/"

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -577,7 +577,7 @@ startNginzLocal resource = do
   liftIO $ do
     whenM (doesFileExist upstreamsCfg) $
       removeFile upstreamsCfg
-    appendFile upstreamsCfg (makeUpstreamsCfgs sm)
+    writeFile upstreamsCfg (makeUpstreamsCfgs sm)
 
   -- override pid configuration
   let pidConfigFile = tmpDir </> "conf" </> "nginz" </> "pid.conf"

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -530,8 +530,6 @@ startNginzK8s domain sm = do
 startNginzLocal :: BackendResource -> App ServiceInstance
 startNginzLocal resource = do
   let domain = berDomain resource
-      http2Port = berNginzHttp2Port resource
-      sslPort = berNginzSslPort resource
   sm <- getServiceMap domain
 
   -- Create a whole temporary directory and copy all nginx's config files.
@@ -558,6 +556,8 @@ startNginzLocal resource = do
 
   -- override port configuration
   let nginzPort = sm.nginz.port
+      http2Port = berNginzHttp2Port resource
+      sslPort = berNginzSslPort resource
       portConfig =
         [i|listen #{nginzPort};
             listen #{http2Port};

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -573,19 +573,12 @@ startNginzLocal resource = do
     writeFile integrationConfFile portConfig
 
   -- override upstreams
-  let federatorExternalPort = sm.federatorExternal.port
-      upstreamFederatorTemplate =
-        [i|upstream federator_external {
-            server 127.0.0.1:#{federatorExternalPort} max_fails=3 weight=1;
-            }
-        |]
-      upstreamsCfg = tmpDir </> "conf" </> "nginz" </> "upstreams"
+  let upstreamsCfg = tmpDir </> "conf" </> "nginz" </> "upstreams"
 
   liftIO $ do
     whenM (doesFileExist upstreamsCfg) $
       removeFile upstreamsCfg
     appendFile upstreamsCfg (makeUpstreamsCfgs sm)
-    appendFile upstreamsCfg upstreamFederatorTemplate
 
   -- override pid configuration
   let pidConfigFile = tmpDir </> "conf" </> "nginz" </> "pid.conf"
@@ -618,7 +611,8 @@ makeUpstreamsCfgs sm =
             (serviceName Gundeck, sm.gundeck.port),
             (serviceName Nginz, sm.nginz.port),
             (serviceName WireProxy, sm.proxy.port),
-            (serviceName Spar, sm.spar.port)
+            (serviceName Spar, sm.spar.port),
+            ("federator_external", sm.federatorExternal.port)
           ]
         $ uncurry upstreamTemplate
 

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -55,7 +55,6 @@ import Testlib.Ports (PortNamespace (..))
 import Testlib.Printing
 import Testlib.ResourcePool
 import Testlib.Types
-import Text.RawString.QQ
 import qualified UnliftIO
 import Prelude
 
@@ -687,10 +686,10 @@ replaceUpstreamsInConfig nginxConf sm = insertGeneratedUpstreams generateUpstrea
           (serviceName WireProxy, sm.proxy.port),
           (serviceName Spar, sm.spar.port)
         ]
-          <&> uncurry upstreamTemplate
+          <&> Text.pack . uncurry upstreamTemplate
       where
         upstreamTemplate _name _port =
-          [r|upstream #{_name} {
+          [i|upstream #{_name} {
               least_conn;
               keepalive 32;
               server 127.0.0.1:#{_port} max_fails=3 weight=1;

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -517,7 +517,7 @@ startNginzK8s domain sm = do
   Text.writeFile nginxConfFile $
     ( conf
         & Text.replace "access_log /dev/stdout" "access_log /dev/null"
-        -- TODO: Get these ports out of config
+        -- FUTUREWORK: Get these ports out of config
         & Text.replace ("listen 8080;\n    listen 8081 proxy_protocol;") (cs $ "listen " <> show sm.nginz.port <> ";")
         & Text.replace ("listen 8082;") (cs $ "listen unix:" <> (tmpDir </> "metrics-socket") <> ";")
         & Text.replace ("/var/run/nginz.pid") (cs $ tmpDir </> "nginz.pid")


### PR DESCRIPTION
My branch to try refactorings on the base branch (instead of messing with it directly.)

Besides minor cleanups, I'm now using an Attoparsec `Parser` to identify and drop `upsteam <name> { <code> }` blocks (blocks can be nested, thus a simple regex won't help) and Interpolate Template Haskell templates to generate new upstream blocks.

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
