### PR TITLE
brig,galley: Use the `Now` effect instead of `Input UTCTime`

### DIFF
--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -84,7 +84,6 @@ import Data.Qualified
 import Data.Range
 import Data.Schema ()
 import Data.Text.Encoding qualified as Text
-import Data.Time.Clock
 import Data.ZAuth.CryptoSign (CryptoSign)
 import Data.ZAuth.Token qualified as ZAuth
 import FileEmbedLzma
@@ -360,7 +359,6 @@ servantSitemap ::
     Member (Embed IO) r,
     Member (Error UserSubsystemError) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
     Member (UserPendingActivationStore p) r,
     Member AuthenticationSubsystem r,
     Member DeleteQueue r,
@@ -865,7 +863,7 @@ upgradePersonalToTeam ::
     Member (Embed HttpClientIO) r,
     Member GalleyAPIAccess r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member NotificationSubsystem r,
     Member TinyLog r,
     Member UserSubsystem r,

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -144,6 +144,7 @@ import Wire.PasswordStore (PasswordStore, lookupHashedPassword, upsertHashedPass
 import Wire.PropertySubsystem as PropertySubsystem
 import Wire.RateLimit
 import Wire.Sem.Concurrency
+import Wire.Sem.Now (Now)
 import Wire.Sem.Paging.Cassandra
 import Wire.SessionStore (SessionStore)
 import Wire.TeamSubsystem (TeamSubsystem)
@@ -264,7 +265,7 @@ upgradePersonalToTeam ::
     Member (Embed HttpClientIO) r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (ConnectionStore InternalPaging) r,
     Member EmailSending r
   ) =>

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -29,10 +29,9 @@ import Polysemy.Async
 import Polysemy.Conc
 import Polysemy.Embed (runEmbedded)
 import Polysemy.Error (Error, errorToIOFinal, mapError, runError)
-import Polysemy.Input (Input, runInputConst, runInputSem)
+import Polysemy.Input (Input, runInputConst)
 import Polysemy.Internal.Kind
 import Polysemy.TinyLog (TinyLog)
-import Util.Timeout
 import Wire.API.Federation.Client qualified
 import Wire.API.Federation.Error
 import Wire.API.Team.Collaborator
@@ -180,7 +179,6 @@ type BrigLowerLevelEffects =
      Input Hasql.Pool,
      Input UserSubsystemConfig,
      Input VerificationCodeThrottleTTL,
-     Input UTCTime,
      Input (Local ()),
      Input (AuthenticationSubsystemConfig),
      Input TeamTemplates,
@@ -308,7 +306,6 @@ runBrigToIO e (AppT ma) = do
               . runInputConst (teamTemplatesNoLocale e)
               . runInputConst authenticationSubsystemConfig
               . runInputConst localUnit
-              . runInputSem (embed getCurrentTime)
               . runInputConst (fromIntegral $ Opt.twoFACodeGenerationDelaySecs e.settings)
               . runInputConst userSubsystemConfig
               . runInputConst e.hasqlPool

--- a/services/galley/src/Galley/API/Action/Kick.hs
+++ b/services/galley/src/Galley/API/Action/Kick.hs
@@ -4,7 +4,6 @@ import Data.Default
 import Data.Id
 import Data.Qualified
 import Data.Singletons
-import Data.Time.Clock
 import Galley.API.Action.Leave
 import Galley.API.Action.Notify
 import Galley.API.Util
@@ -21,6 +20,7 @@ import Wire.API.Conversation.Action
 import Wire.API.Event.LeaveReason
 import Wire.API.Federation.Error
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 -- | Kick a user from a conversation and send notifications.
 --
@@ -33,7 +33,7 @@ kickMember ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member ProposalStore r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input Env) r,
     Member MemberStore r,
     Member SubConversationStore r,

--- a/services/galley/src/Galley/API/Action/Leave.hs
+++ b/services/galley/src/Galley/API/Action/Leave.hs
@@ -3,7 +3,6 @@ module Galley.API.Action.Leave (leaveConversation) where
 import Control.Lens
 import Data.Id
 import Data.Qualified
-import Data.Time.Clock
 import Galley.API.MLS.Removal
 import Galley.API.Util
 import Galley.Data.Conversation
@@ -17,6 +16,7 @@ import Polysemy.Input
 import Polysemy.TinyLog
 import Wire.API.Federation.Error
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 leaveConversation ::
   ( Member TinyLog r,
@@ -29,7 +29,7 @@ leaveConversation ::
     Member Random r,
     Member SubConversationStore r,
     Member (Input Env) r,
-    Member (Input UTCTime) r
+    Member Now r
   ) =>
   Qualified UserId ->
   Local Conversation ->

--- a/services/galley/src/Galley/API/Action/Notify.hs
+++ b/services/galley/src/Galley/API/Action/Notify.hs
@@ -3,7 +3,6 @@ module Galley.API.Action.Notify where
 import Data.Id
 import Data.Qualified
 import Data.Singletons
-import Data.Time.Clock
 import Galley.API.Util
 import Galley.Data.Conversation
 import Galley.Effects
@@ -12,7 +11,6 @@ import Imports hiding ((\\))
 import Network.AMQP qualified as Q
 import Polysemy
 import Polysemy.Error
-import Polysemy.Input
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.Conversation.Action
 import Wire.API.Event.Conversation
@@ -20,6 +18,8 @@ import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 data LocalConversationUpdate = LocalConversationUpdate
   { lcuEvent :: Event,
@@ -33,7 +33,7 @@ notifyConversationAction ::
     Member ExternalAccess r,
     Member (Error FederationError) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r
+    Member Now r
   ) =>
   Sing tag ->
   Qualified UserId ->
@@ -45,7 +45,7 @@ notifyConversationAction ::
   ExtraConversationData ->
   Sem r LocalConversationUpdate
 notifyConversationAction tag quid notifyOrigDomain con lconv targets action extraData = do
-  now <- input
+  now <- Now.get
   let lcnv = fmap (.convId) lconv
       conv = tUnqualified lconv
       tid = conv.convMetadata.cnvmTeam

--- a/services/galley/src/Galley/API/Action/Reset.hs
+++ b/services/galley/src/Galley/API/Action/Reset.hs
@@ -5,7 +5,6 @@ import Data.Aeson qualified as A
 import Data.ByteString.Conversion (toByteString')
 import Data.Id
 import Data.Qualified
-import Data.Time.Clock
 import Galley.API.Action.Kick
 import Galley.API.MLS.Util
 import Galley.API.Util
@@ -36,10 +35,11 @@ import Wire.API.MLS.SubConversation
 import Wire.API.Routes.Public.Galley.MLS
 import Wire.API.VersionInfo
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 resetLocalMLSMainConversation ::
   ( Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (ErrorS MLSStaleMessage) r,
     Member (ErrorS ConvNotFound) r,
     Member (ErrorS InvalidOperation) r,

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -25,7 +25,6 @@ import Data.Id
 import Data.Proxy
 import Data.Qualified
 import Data.Range
-import Data.Time
 import Galley.API.Error
 import Galley.API.MLS.Removal
 import Galley.API.Query qualified as Query
@@ -49,6 +48,7 @@ import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.API.Routes.MultiTablePaging
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 import Wire.Sem.Paging.Cassandra (CassandraPaging)
 
 getClients ::
@@ -73,7 +73,7 @@ rmClient ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (ListItems p1 ConvId) r,
     Member (ListItems p1 (Remote ConvId)) r,
     Member MemberStore r,

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -37,7 +37,6 @@ import Data.Set qualified as Set
 import Data.Singletons (SingI (..), demote, sing)
 import Data.Tagged
 import Data.Text.Lazy qualified as LT
-import Data.Time.Clock
 import Galley.API.Action
 import Galley.API.Error
 import Galley.API.MLS
@@ -100,6 +99,8 @@ import Wire.API.Routes.Public.Galley.MLS
 import Wire.API.ServantProto
 import Wire.API.User (BaseProtocolTag (..))
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 type FederationAPI = "federation" :> FedApi 'Galley
 
@@ -139,7 +140,7 @@ onClientRemoved ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -271,7 +272,7 @@ leaveConversation ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -397,7 +398,7 @@ sendMessage ::
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member ExternalAccess r,
     Member TeamStore r,
     Member P.TinyLog r
@@ -421,7 +422,7 @@ onUserDeleted ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input Env) r,
     Member MemberStore r,
     Member ProposalStore r,
@@ -487,7 +488,7 @@ updateConversation ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,
@@ -619,7 +620,7 @@ sendMLSCommitBundle ::
     Member (Input (Local ())) r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member Resource r,
@@ -675,7 +676,7 @@ sendMLSMessage ::
     Member (Input (Local ())) r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member TeamStore r,
@@ -914,7 +915,7 @@ mlsSendWelcome ::
     Member P.TinyLog r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r
+    Member Now r
   ) =>
   Domain ->
   MLSWelcomeRequest ->
@@ -925,7 +926,7 @@ mlsSendWelcome origDomain req = do
     $ do
       assertMLSEnabled
       loc <- qualifyLocal ()
-      now <- input
+      now <- Now.get
       welcome <-
         either (throw . InternalErrorWithDescription . LT.fromStrict) pure $
           decodeMLS' (fromBase64ByteString req.welcomeMessage)
@@ -964,7 +965,7 @@ updateTypingIndicator ::
   ( Member NotificationSubsystem r,
     Member FederatorAccess r,
     Member ConversationStore r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input (Local ())) r,
     Member TeamStore r
   ) =>

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -98,6 +98,8 @@ import Wire.API.Routes.MultiTablePaging qualified as MTP
 import Wire.API.Team.Feature
 import Wire.API.User.Client
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
 import Wire.TeamSubsystem qualified as TeamSubsystem
@@ -317,7 +319,7 @@ rmUser ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (ListItems p1 ConvId) r,
     Member (ListItems p1 (Remote ConvId)) r,
     Member (ListItems p2 TeamId) r,
@@ -385,7 +387,7 @@ rmUser lusr conn = do
     leaveLocalConversations ids = do
       let qUser = tUntagged lusr
       cc <- getConversations ids
-      now <- input
+      now <- Now.get
       pp <- for cc $ \c -> case Data.convType c of
         SelfConv -> pure Nothing
         One2OneConv -> E.deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -42,7 +42,6 @@ import Data.Misc
 import Data.Proxy (Proxy (Proxy))
 import Data.Qualified
 import Data.Range (toRange)
-import Data.Time.Clock
 import Galley.API.Error
 import Galley.API.LegalHold.Get
 import Galley.API.LegalHold.Team
@@ -82,6 +81,7 @@ import Wire.API.Team.LegalHold.External hiding (userId)
 import Wire.API.Team.Member
 import Wire.API.User.Client.Prekey
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
 
@@ -161,7 +161,7 @@ removeSettingsInternalPaging ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -207,7 +207,7 @@ removeSettings ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -259,7 +259,7 @@ removeSettings' ::
     Member FederatorAccess r,
     Member FireAndForget r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input (Local ())) r,
     Member (Input Env) r,
     Member LegalHoldStore r,
@@ -312,7 +312,7 @@ grantConsent ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -361,7 +361,7 @@ requestDevice ::
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -455,7 +455,7 @@ approveDevice ::
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -533,7 +533,7 @@ disableForUser ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -598,7 +598,7 @@ changeLegalholdStatusAndHandlePolicyConflicts ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
@@ -715,7 +715,7 @@ handleGroupConvPolicyConflicts ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (ListItems LegacyPaging ConvId) r,
     Member MemberStore r,
     Member ProposalStore r,

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -31,7 +31,6 @@ where
 import Control.Comonad
 import Data.Id
 import Data.Qualified
-import Data.Time
 import Galley.API.Error
 import Galley.API.MLS.Conversation
 import Galley.API.MLS.IncomingMessage
@@ -70,6 +69,7 @@ import Wire.API.MLS.Validation
 import Wire.API.MLS.Validation.Error (toText)
 import Wire.API.User.Client
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 type HasProposalActionEffects r =
   ( Member BackendNotificationQueueAccess r,
@@ -90,7 +90,7 @@ type HasProposalActionEffects r =
     Member FederatorAccess r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -93,6 +93,7 @@ import Wire.API.MLS.Serialisation
 import Wire.API.MLS.SubConversation
 import Wire.API.Team.LegalHold
 import Wire.NotificationSubsystem
+import Wire.Sem.Now qualified as Now
 
 -- FUTUREWORK
 -- - Check that the capabilities of a leaf node in an add proposal contains all
@@ -159,7 +160,7 @@ postMLSMessageFromLocalUser lusr c conn smsg = do
   events <-
     map lcuEvent
       <$> postMLSMessage lusr (tUntagged lusr) c ctype cnvOrSub (Just conn) imsg
-  t <- toUTCTimeMillis <$> input
+  t <- toUTCTimeMillis <$> Now.get
   pure $ MLSMessageSendingStatus events t
 
 postMLSCommitBundle ::
@@ -211,7 +212,7 @@ postMLSCommitBundleFromLocalUser lusr c conn bundle = do
   events <-
     map lcuEvent
       <$> postMLSCommitBundle lusr (tUntagged lusr) c ctype qConvOrSub (Just conn) ibundle
-  t <- toUTCTimeMillis <$> input
+  t <- toUTCTimeMillis <$> Now.get
   pure $ MLSMessageSendingStatus events t
 
 postMLSCommitBundleToLocalConv ::

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -24,7 +24,6 @@ import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.List1
 import Data.Map qualified as Map
 import Data.Qualified
-import Data.Time
 import Galley.API.MLS.Types
 import Galley.API.Push
 import Galley.Data.Services
@@ -35,7 +34,6 @@ import Imports
 import Network.AMQP qualified as Q
 import Polysemy
 import Polysemy.Error
-import Polysemy.Input
 import Polysemy.TinyLog hiding (trace)
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API
@@ -49,6 +47,8 @@ import Wire.API.MLS.SubConversation
 import Wire.API.Message
 import Wire.API.Push.V2 (RecipientClients (..))
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 -- | Propagate a message.
 -- The message will not be propagated to the sender client if provided. This is
@@ -57,7 +57,7 @@ propagateMessage ::
   ( Member BackendNotificationQueueAccess r,
     Member (Error FederationError) r,
     Member ExternalAccess r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TinyLog r,
     Member NotificationSubsystem r
   ) =>
@@ -69,7 +69,7 @@ propagateMessage ::
   ClientMap LeafIndex ->
   Sem r ()
 propagateMessage qusr mSenderClient lConvOrSub con msg cm = do
-  now <- input @UTCTime
+  now <- Now.get
   let mlsConv = (.conv) <$> lConvOrSub
       lmems = mcLocalMembers . tUnqualified $ mlsConv
       rmems = mcRemoteMembers . tUnqualified $ mlsConv

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -38,7 +38,6 @@ import Data.Id
 import Data.Map qualified as Map
 import Data.Qualified
 import Data.Set qualified as Set
-import Data.Time
 import Galley.API.Error
 import Galley.API.MLS.IncomingMessage
 import Galley.API.MLS.Types
@@ -71,6 +70,7 @@ import Wire.API.MLS.Validation
 import Wire.API.MLS.Validation.Error (toText)
 import Wire.API.Message
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 data ProposalAction = ProposalAction
   { paAdd :: ClientMap (LeafIndex, Maybe KeyPackage),
@@ -132,7 +132,7 @@ type HasProposalEffects r =
     Member (Input Env) r,
     Member (Input (Local ())) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -31,7 +31,6 @@ import Data.Map qualified as Map
 import Data.Proxy
 import Data.Qualified
 import Data.Set qualified as Set
-import Data.Time
 import Galley.API.MLS.Conversation
 import Galley.API.MLS.Keys
 import Galley.API.MLS.Propagate
@@ -61,13 +60,14 @@ import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
 import Wire.API.MLS.SubConversation
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 import Wire.Sem.Random
 
 -- | Send remove proposals for a set of clients to clients in the ClientMap.
 createAndSendRemoveProposals ::
   forall r t.
   ( Member (Error FederationError) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TinyLog r,
     Member BackendNotificationQueueAccess r,
     Member ExternalAccess r,
@@ -124,7 +124,7 @@ createAndSendRemoveProposals lConvOrSubConv indices qusr cm = Codensity $ \k -> 
 
 removeClientsWithClientMapRecursively ::
   ( Member (Error FederationError) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TinyLog r,
     Member BackendNotificationQueueAccess r,
     Member ExternalAccess r,
@@ -157,7 +157,7 @@ removeClientsWithClientMapRecursively lMlsConv getClients qusr = do
 
 removeClientsFromSubConvs ::
   ( Member (Error FederationError) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TinyLog r,
     Member BackendNotificationQueueAccess r,
     Member ExternalAccess r,
@@ -201,7 +201,7 @@ removeClient ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -238,7 +238,7 @@ removeUser ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -285,7 +285,7 @@ removeExtraneousClients ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,

--- a/services/galley/src/Galley/API/MLS/Reset.hs
+++ b/services/galley/src/Galley/API/MLS/Reset.hs
@@ -19,7 +19,6 @@ module Galley.API.MLS.Reset (resetMLSConversation) where
 
 import Data.Id
 import Data.Qualified
-import Data.Time.Clock
 import Galley.API.Action
 import Galley.API.Error
 import Galley.API.MLS.Enabled
@@ -40,10 +39,11 @@ import Wire.API.Federation.Error
 import Wire.API.MLS.SubConversation
 import Wire.API.Routes.Public.Galley.MLS
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 resetMLSConversation ::
   ( Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input (Local ())) r,
     Member (ErrorS MLSNotEnabled) r,
     Member (ErrorS MLSStaleMessage) r,

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -36,7 +36,6 @@ import Control.Monad.Codensity hiding (reset)
 import Data.Id
 import Data.Map qualified as Map
 import Data.Qualified
-import Data.Time.Clock
 import Galley.API.MLS
 import Galley.API.MLS.Conversation
 import Galley.API.MLS.GroupInfo
@@ -71,6 +70,7 @@ import Wire.API.MLS.GroupInfo
 import Wire.API.MLS.SubConversation
 import Wire.API.Routes.Public.Galley.MLS
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 
 type MLSGetSubConvStaticErrors =
   '[ ErrorS 'ConvNotFound,
@@ -274,7 +274,7 @@ type HasLeaveSubConversationEffects r =
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -36,7 +36,6 @@ import Galley.Effects.FederatorAccess
 import Imports
 import Network.Wai.Utilities.JSONResponse
 import Polysemy
-import Polysemy.Input
 import Polysemy.TinyLog qualified as P
 import System.Logger.Class qualified as Logger
 import Wire.API.Error
@@ -53,12 +52,14 @@ import Wire.API.MLS.Welcome
 import Wire.API.Message
 import Wire.API.Push.V2 (RecipientClients (..))
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 sendWelcomes ::
   ( Member FederatorAccess r,
     Member ExternalAccess r,
     Member P.TinyLog r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member NotificationSubsystem r
   ) =>
   Local ConvOrSubConvId ->
@@ -68,7 +69,7 @@ sendWelcomes ::
   RawMLS Welcome ->
   Sem r ()
 sendWelcomes loc qusr con cids welcome = do
-  now <- input
+  now <- Now.get
   let qcnv = convFrom <$> tUntagged loc
       (locals, remotes) = partitionQualified loc (map cidQualifiedClient cids)
       msg = mkRawMLS $ mkMessage (MessageWelcome welcome)

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -134,6 +134,8 @@ import Wire.API.Team.SearchVisibility
 import Wire.API.Team.SearchVisibility qualified as Public
 import Wire.API.User qualified as U
 import Wire.NotificationSubsystem
+import Wire.Sem.Now
+import Wire.Sem.Now qualified as Now
 import Wire.Sem.Paging.Cassandra
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem qualified as TeamSubsystem
@@ -222,7 +224,7 @@ createNonBindingTeamH _ _ _ = do
 
 createBindingTeam ::
   ( Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   TeamId ->
@@ -235,7 +237,7 @@ createBindingTeam tid zusr body = do
     E.createTeam (Just tid) zusr body.newTeamName body.newTeamIcon body.newTeamIconKey Binding
 
   E.createTeamMember tid owner
-  now <- input
+  now <- Now.get
   let e = newEvent tid now (EdTeamCreate team)
   pushNotifications
     [ def
@@ -250,7 +252,7 @@ updateTeamStatus ::
   ( Member BrigAccess r,
     Member (ErrorS 'InvalidTeamStatusUpdate) r,
     Member (ErrorS 'TeamNotFound) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   TeamId ->
@@ -289,7 +291,7 @@ updateTeamH ::
   ( Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS ('MissingPermission ('Just 'SetTeamData))) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   UserId ->
@@ -301,7 +303,7 @@ updateTeamH zusr zcon tid updateData = do
   zusrMembership <- E.getTeamMember tid zusr
   void $ permissionCheckS SSetTeamData zusrMembership
   E.setTeamData tid updateData
-  now <- input
+  now <- Now.get
   admins <- E.getTeamAdmins tid
   let e = newEvent tid now (EdTeamUpdate updateData)
   let r = userRecipient zusr : map userRecipient (filter (/= zusr) admins)
@@ -378,7 +380,7 @@ uncheckedDeleteTeam ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member SparAccess r,
@@ -392,7 +394,7 @@ uncheckedDeleteTeam lusr zcon tid = do
   team <- E.getTeam tid
   when (isJust team) $ do
     Spar.deleteTeam tid
-    now <- input
+    now <- Now.get
     convs <- E.getTeamConversations tid
     -- Even for LARGE TEAMS, we _DO_ want to fetch all team members here because we
     -- want to generate conversation deletion events for non-team users. This should
@@ -559,7 +561,7 @@ addTeamMember ::
     Member (ErrorS 'UserBindingExists) r,
     Member (ErrorS 'TooManyTeamMembersOnTeamWithLegalhold) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member TeamFeatureStore r,
     Member TeamNotificationStore r,
@@ -599,7 +601,7 @@ uncheckedAddTeamMember ::
     Member (ErrorS 'TooManyTeamAdmins) r,
     Member (ErrorS 'TooManyTeamMembersOnTeamWithLegalhold) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member P.TinyLog r,
     Member TeamFeatureStore r,
@@ -623,7 +625,7 @@ uncheckedUpdateTeamMember ::
     Member (ErrorS 'TeamMemberNotFound) r,
     Member (ErrorS 'TooManyTeamAdmins) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member P.TinyLog r,
     Member TeamStore r
   ) =>
@@ -658,7 +660,7 @@ uncheckedUpdateTeamMember mlzusr mZcon tid newMember = do
     owners <- E.getBillingTeamMembers tid
     Journal.teamUpdate tid size owners
 
-  now <- input
+  now <- Now.get
   let event = newEvent tid now (EdMemberUpdate targetId (Just targetPermissions))
   pushNotifications
     [ def
@@ -681,7 +683,7 @@ updateTeamMember ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member P.TinyLog r,
     Member TeamStore r
   ) =>
@@ -737,7 +739,7 @@ deleteTeamMember ::
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member NotificationSubsystem r,
     Member MemberStore r,
     Member TeamFeatureStore r,
@@ -766,7 +768,7 @@ deleteNonBindingTeamMember ::
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member NotificationSubsystem r,
     Member MemberStore r,
     Member TeamFeatureStore r,
@@ -795,7 +797,7 @@ deleteTeamMember' ::
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member NotificationSubsystem r,
     Member MemberStore r,
     Member TeamFeatureStore r,
@@ -857,7 +859,7 @@ uncheckedDeleteTeamMember ::
     Member NotificationSubsystem r,
     Member (Error FederationError) r,
     Member ExternalAccess r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -868,7 +870,7 @@ uncheckedDeleteTeamMember ::
   Either [UserId] TeamMemberList ->
   Sem r ()
 uncheckedDeleteTeamMember lusr zcon tid remove (Left admins) = do
-  now <- input
+  now <- Now.get
   pushMemberLeaveEvent now
   E.deleteTeamMember tid remove
   -- notify all conversation members not in this team.
@@ -891,7 +893,7 @@ uncheckedDeleteTeamMember lusr zcon tid remove (Left admins) = do
             }
         ]
 uncheckedDeleteTeamMember lusr zcon tid remove (Right mems) = do
-  now <- input
+  now <- Now.get
   pushMemberLeaveEventToAll now
   E.deleteTeamMember tid remove
   -- notify all conversation members not in this team.
@@ -921,7 +923,7 @@ removeFromConvsAndPushConvLeaveEvent ::
     Member (Error FederationError) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -1007,7 +1009,7 @@ deleteTeamConversation ::
     Member ProposalStore r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member SubConversationStore r,
     Member TeamStore r
   ) =>
@@ -1165,7 +1167,7 @@ addTeamMemberInternal ::
     Member (ErrorS 'TooManyTeamAdmins) r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamNotificationStore r,
     Member TeamStore r,
     Member P.TinyLog r
@@ -1187,7 +1189,7 @@ addTeamMemberInternal tid origin originConn (ntmNewTeamMember -> new) = do
 
   E.createTeamMember tid new
 
-  now <- input
+  now <- Now.get
   let e = newEvent tid now (EdMemberJoin (new ^. userId))
   let recipients = case origin of
         Just o -> userRecipient <$> o : filter (/= o) ((new ^. userId) : admins')

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -40,7 +40,6 @@ import Data.Id
 import Data.Json.Util
 import Data.Kind
 import Data.Qualified (Local)
-import Data.Time (UTCTime)
 import Galley.API.Error (InternalError)
 import Galley.API.LegalHold qualified as LegalHold
 import Galley.API.LegalHold.Team qualified as LegalHold
@@ -68,6 +67,7 @@ import Wire.API.Federation.Error
 import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
 
@@ -327,7 +327,7 @@ instance SetFeatureConfig LegalholdConfig where
         Member NotificationSubsystem r,
         Member (Input (Local ())) r,
         Member (Input Env) r,
-        Member (Input UTCTime) r,
+        Member Now r,
         Member LegalHoldStore r,
         Member (ListItems LegacyPaging ConvId) r,
         Member MemberStore r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -86,7 +86,6 @@ import Data.Misc
 import Data.Qualified
 import Data.Set qualified as Set
 import Data.Singletons
-import Data.Time
 import Galley.API.Action
 import Galley.API.Action.Kick (kickMember)
 import Galley.API.Cells
@@ -143,6 +142,8 @@ import Wire.API.User.Client
 import Wire.HashPassword as HashPassword
 import Wire.NotificationSubsystem
 import Wire.RateLimit
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 acceptConv ::
   ( Member ConversationStore r,
@@ -150,7 +151,7 @@ acceptConv ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TinyLog r
   ) =>
@@ -214,7 +215,7 @@ unblockConv ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TinyLog r
   ) =>
@@ -234,7 +235,7 @@ unblockConvUnqualified ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TinyLog r
   ) =>
@@ -280,7 +281,6 @@ type UpdateConversationAccessEffects =
      FireAndForget,
      NotificationSubsystem,
      Input Env,
-     Input UTCTime,
      MemberStore,
      ProposalStore,
      Random,
@@ -290,7 +290,8 @@ type UpdateConversationAccessEffects =
    ]
 
 updateConversationAccess ::
-  ( Members UpdateConversationAccessEffects r
+  ( Members UpdateConversationAccessEffects r,
+    Member Now r
   ) =>
   Local UserId ->
   ConnId ->
@@ -303,7 +304,8 @@ updateConversationAccess lusr con qcnv update = do
     updateLocalConversation @'ConversationAccessDataTag lcnv (tUntagged lusr) (Just con) update
 
 updateConversationAccessUnqualified ::
-  ( Members UpdateConversationAccessEffects r
+  ( Members UpdateConversationAccessEffects r,
+    Member Now r
   ) =>
   Local UserId ->
   ConnId ->
@@ -332,7 +334,7 @@ updateConversationReceiptMode ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TinyLog r,
     Member TeamStore r
@@ -412,7 +414,7 @@ updateConversationReceiptModeUnqualified ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TinyLog r,
     Member TeamStore r
@@ -433,7 +435,7 @@ updateConversationMessageTimer ::
     Member (Error FederationError) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -466,7 +468,7 @@ updateConversationMessageTimerUnqualified ::
     Member (Error FederationError) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -492,7 +494,7 @@ deleteLocalConversation ::
     Member SubConversationStore r,
     Member MemberStore r,
     Member ProposalStore r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -514,7 +516,7 @@ addCodeUnqualifiedWithReqBody ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member HashPassword r,
     Member (Input Opts) r,
     Member TeamFeatureStore r,
@@ -540,7 +542,7 @@ addCodeUnqualified ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input Opts) r,
     Member HashPassword r,
     Member TeamFeatureStore r,
@@ -569,7 +571,7 @@ addCode ::
     Member ExternalAccess r,
     Member HashPassword r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input Opts) r,
     Member TeamFeatureStore r,
     Member RateLimit r,
@@ -596,7 +598,7 @@ addCode lusr mbZHost mZcon lcnv mReq = do
       code <- E.generateCode (tUnqualified lcnv) ReusableCode (Timeout ttl)
       mPw <- for (mReq >>= (.password)) $ HashPassword.hashPassword8 (RateLimitUser (tUnqualified lusr))
       E.createCode code mPw
-      now <- input
+      now <- Now.get
       let event = Event (tUntagged lcnv) Nothing (tUntagged lusr) now Nothing (EdConvCodeUpdate (mkConversationCodeInfo (isJust mPw) (codeKey code) (codeValue code) convUri))
       let (bots, users) = localBotsAndUsers $ Data.convLocalMembers conv
       pushConversationEvent mZcon conv event (qualifyAs lusr (map lmId users)) bots
@@ -622,7 +624,7 @@ rmCodeUnqualified ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -640,7 +642,7 @@ rmCode ::
     Member (ErrorS 'ConvNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -656,7 +658,7 @@ rmCode lusr zcon lcnv = do
   let (bots, users) = localBotsAndUsers $ Data.convLocalMembers conv
   key <- E.makeKey (tUnqualified lcnv)
   E.deleteCode key ReusableCode
-  now <- input
+  now <- Now.get
   let event = Event (tUntagged lcnv) Nothing (tUntagged lusr) now Nothing EdConvCodeDelete
   pushConversationEvent (Just zcon) conv event (qualifyAs lusr (map lmId users)) bots
   pure event
@@ -720,7 +722,7 @@ updateConversationProtocolWithLocalUser ::
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'TeamNotFound) r,
     Member (Error InternalError) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member (Input Env) r,
     Member (Input (Local ())) r,
     Member (Input Opts) r,
@@ -769,7 +771,7 @@ updateChannelAddPermission ::
     Member (Error FederationError) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r,
     Member (Input (Local ())) r,
     Member TinyLog r,
@@ -822,7 +824,7 @@ joinConversationByReusableCode ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r,
     Member TeamFeatureStore r,
@@ -853,7 +855,7 @@ joinConversationById ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -877,7 +879,7 @@ joinConversation ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -934,7 +936,7 @@ addMembers ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,
@@ -979,7 +981,7 @@ addMembersUnqualifiedV2 ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,
@@ -1022,7 +1024,7 @@ addMembersUnqualified ::
     Member NotificationSubsystem r,
     Member (Input Env) r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,
@@ -1045,7 +1047,7 @@ updateSelfMember ::
     Member (ErrorS 'ConvNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r
   ) =>
   Local UserId ->
@@ -1057,7 +1059,7 @@ updateSelfMember lusr zcon qcnv update = do
   exists <- foldQualified lusr checkLocalMembership checkRemoteMembership qcnv
   unless exists $ throwS @'ConvNotFound
   E.setSelfMember qcnv lusr update
-  now <- input
+  now <- Now.get
   let e = Event qcnv Nothing (tUntagged lusr) now Nothing (EdMemberUpdate (updateData lusr))
   pushConversationEvent (Just zcon) () e (fmap pure lusr) []
   where
@@ -1092,7 +1094,7 @@ updateUnqualifiedSelfMember ::
     Member (ErrorS 'ConvNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r
   ) =>
   Local UserId ->
@@ -1115,7 +1117,7 @@ updateOtherMemberLocalConv ::
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -1142,7 +1144,7 @@ updateOtherMemberUnqualified ::
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -1168,7 +1170,7 @@ updateOtherMember ::
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member TeamStore r
   ) =>
@@ -1204,7 +1206,7 @@ removeMemberUnqualified ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -1234,7 +1236,7 @@ removeMemberQualified ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -1265,7 +1267,7 @@ removeMemberFromRemoteConv ::
   ( Member FederatorAccess r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r,
     Member (ErrorS 'ConvNotFound) r,
-    Member (Input UTCTime) r
+    Member Now r
   ) =>
   Remote ConvId ->
   Local UserId ->
@@ -1290,9 +1292,9 @@ removeMemberFromRemoteConv cnv lusr victim
     handleError RemoveFromConversationErrorNotFound = throwS @'ConvNotFound
     handleError RemoveFromConversationErrorUnchanged = pure Nothing
 
-    handleSuccess :: (Member (Input UTCTime) r) => () -> Sem r (Maybe Event)
+    handleSuccess :: (Member Now r) => () -> Sem r (Maybe Event)
     handleSuccess _ = do
-      t <- input
+      t <- Now.get
       pure . Just $
         Event (tUntagged cnv) Nothing (tUntagged lusr) t Nothing $
           EdMembersLeaveRemoved (QualifiedUserIdList [victim])
@@ -1311,7 +1313,7 @@ removeMemberFromLocalConv ::
     Member FederatorAccess r,
     Member NotificationSubsystem r,
     Member (Input Env) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ProposalStore r,
     Member Random r,
@@ -1354,7 +1356,7 @@ removeMemberFromChannel ::
     Member (Error NoChanges) r,
     Member SubConversationStore r,
     Member ProposalStore r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member ExternalAccess r,
     Member FederatorAccess r,
     Member NotificationSubsystem r,
@@ -1391,7 +1393,7 @@ postProteusMessage ::
     Member NotificationSubsystem r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r,
     Member TinyLog r
   ) =>
@@ -1416,7 +1418,7 @@ postProteusBroadcast ::
     Member NotificationSubsystem r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r,
     Member TinyLog r
   ) =>
@@ -1469,7 +1471,7 @@ postBotMessageUnqualified ::
     Member (Input Opts) r,
     Member TeamStore r,
     Member TinyLog r,
-    Member (Input UTCTime) r
+    Member Now r
   ) =>
   BotId ->
   ConvId ->
@@ -1496,7 +1498,7 @@ postOtrBroadcastUnqualified ::
     Member NotificationSubsystem r,
     Member ExternalAccess r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r,
     Member TinyLog r
   ) =>
@@ -1520,7 +1522,7 @@ postOtrMessageUnqualified ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r,
     Member TinyLog r
   ) =>
@@ -1547,7 +1549,7 @@ updateConversationName ::
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -1573,7 +1575,7 @@ updateUnqualifiedConversationName ::
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -1595,7 +1597,7 @@ updateLocalConversationName ::
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member TeamStore r
   ) =>
   Local UserId ->
@@ -1611,7 +1613,7 @@ memberTyping ::
   ( Member NotificationSubsystem r,
     Member (ErrorS 'ConvNotFound) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member ConversationStore r,
     Member MemberStore r,
     Member FederatorAccess r,
@@ -1650,7 +1652,7 @@ memberTypingUnqualified ::
   ( Member NotificationSubsystem r,
     Member (ErrorS 'ConvNotFound) r,
     Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member ConversationStore r,
     Member FederatorAccess r,
@@ -1676,7 +1678,7 @@ addBot ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input Opts) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r
   ) =>
   Local UserId ->
@@ -1688,7 +1690,7 @@ addBot lusr zcon b = do
     E.getConversation (b ^. addBotConv) >>= noteS @'ConvNotFound
   -- Check some preconditions on adding bots to a conversation
   (bots, users) <- regularConvChecks c
-  t <- input
+  t <- Now.get
   E.createClient (botUserId (b ^. addBotId)) (b ^. addBotClient)
   bm <- E.createBotMember (b ^. addBotService) (b ^. addBotId) (b ^. addBotConv)
   let e =
@@ -1740,7 +1742,7 @@ rmBot ::
     Member (ErrorS 'ConvNotFound) r,
     Member ExternalAccess r,
     Member NotificationSubsystem r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r
   ) =>
@@ -1766,7 +1768,7 @@ rmBot lusr zcon b = do
   if not (any ((== b ^. rmBotId) . botMemId) bots)
     then pure Unchanged
     else do
-      t <- input
+      t <- Now.get
       do
         let evd = EdMembersLeaveRemoved (QualifiedUserIdList [tUntagged (qualifyAs lusr (botUserId (b ^. rmBotId)))])
         let e = Event (tUntagged lcnv) Nothing (tUntagged lusr) t Nothing evd

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -97,6 +97,8 @@ import Wire.HashPassword (HashPassword)
 import Wire.HashPassword qualified as HashPassword
 import Wire.NotificationSubsystem
 import Wire.RateLimit
+import Wire.Sem.Now (Now)
+import Wire.Sem.Now qualified as Now
 
 data NoChanges = NoChanges
 
@@ -364,7 +366,7 @@ acceptOne2One ::
     Member (ErrorS 'ConvNotFound) r,
     Member (Error InternalError) r,
     Member (ErrorS 'InvalidOperation) r,
-    Member (Input UTCTime) r,
+    Member Now r,
     Member MemberStore r,
     Member NotificationSubsystem r
   ) =>
@@ -388,7 +390,7 @@ acceptOne2One lusr conv conn = do
         when (length mems > 2) $
           throw . BadConvState $
             cid
-        now <- input
+        now <- Now.get
         mm <- createMember lcid lusr
         let e = memberJoinEvent lusr (tUntagged lcid) now mm []
         conv' <- if isJust (find ((tUnqualified lusr /=) . lmId) mems) then promote else pure conv

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -52,7 +52,6 @@ import Data.Id
 import Data.Misc
 import Data.Qualified
 import Data.Range
-import Data.Time.Clock
 import Galley.API.Error
 import Galley.Aws qualified as Aws
 import Galley.Cassandra.Client
@@ -278,7 +277,6 @@ evalGalley e =
     . interpretTinyLog e
     . interpretQueue (e ^. deleteQueue)
     . nowToIO
-    . runInputSem (embed getCurrentTime) -- FUTUREWORK: could we take the time only once instead?
     . runInputConst (e ^. options)
     . runInputConst (toLocalUnsafe (e ^. options . settings . federationDomain) ())
     . interpretTeamFeatureSpecialContext e

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -65,7 +65,6 @@ where
 
 import Data.Id
 import Data.Qualified
-import Data.Time.Clock
 import Galley.Effects.BackendNotificationQueueAccess
 import Galley.Effects.BotAccess
 import Galley.Effects.BrigAccess
@@ -153,7 +152,6 @@ type GalleyEffects1 =
      Input (Maybe [TeamId], FeatureDefaults LegalholdConfig),
      Input (Local ()),
      Input Opts,
-     Input UTCTime, -- TODO: Use 'Now' instead of this
      Now,
      Queue DeleteItem,
      TinyLog,


### PR DESCRIPTION
So we have only one way to get current time across the code.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
