### PR TITLE
nix-hls.sh: Allow limiting memory used by HLS

### DIFF
--- a/hack/bin/nix-hls.sh
+++ b/hack/bin/nix-hls.sh
@@ -7,4 +7,11 @@ TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 direnv="$(nix-build --no-out-link "$TOP_LEVEL/nix" -A pkgs.direnv)/bin/direnv"
 
-"$direnv" exec "$TOP_LEVEL" haskell-language-server-wrapper "$@"
+# shellcheck disable=SC2016
+maxMemory=$("$direnv" exec "$TOP_LEVEL" bash -c 'echo "$HLS_MAX_MEMORY"')
+
+if [[ -z "$maxMemory" ]]; then
+    "$direnv" exec "$TOP_LEVEL" haskell-language-server-wrapper "$@"
+else
+    systemd-run --scope -p MemoryMax="$maxMemory" --user "$direnv" exec "$TOP_LEVEL" haskell-language-server-wrapper "$@"
+fi


### PR DESCRIPTION
To use this set `HLS_MAX_MEMORY` in your global env or in `.envrc.local`.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
