### PR TITLE
Fixes to `make devtest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ ifeq ("$(package)", "all")
 	ghcid --command 'cabal repl lib:integration' --test='Testlib.Run.mainI []'
 else
 	@ghcid --command 'cabal repl $(package):${package}-tests lib:$(package)' --test='Main.main' \
-	  || echo -e "\n\n\n*** usage: make devtest-package package=<package>.\n*** this works for wire-subsystems; for other packages, you may need to edit the cabal file.\n\n"
+	  || echo -e "\n\n\n*** usage: make devtest package=<package>.\n*** this works for wire-subsystems; for other packages, you may need to edit the cabal file.\n\n"
 endif
 
 .PHONY: devtest-package

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ devtest:
 ifeq ("$(package)", "all")
 	ghcid --command 'cabal repl lib:integration' --test='Testlib.Run.mainI []'
 else
-	@ghcid --command 'cabal repl $(package):${package}-tests lib:$(package)' --test='Main.main' \
+	@ghcid --command 'cabal repl $(package):${package}-tests lib:$(package) --enable-multi-repl' --test='Main.main' \
 	  || echo -e "\n\n\n*** usage: make devtest package=<package>.\n*** this works for wire-subsystems; for other packages, you may need to edit the cabal file.\n\n"
 endif
 


### PR DESCRIPTION
This fixes a help message and might fix the cabal repl used by ghcid. _Might_ in the sense that when I run `make devtest package=wire-subsystems` I get the following error:
```
Error: [Cabal-7076]
Cannot open a repl for multiple components at onnce. The targets 'wire-subsystems' and 'wire-subsystems-tests' refer to different components..

Your compiler supports a multiple component repl but support is not enabled.
The experimental multi repl can be enabled by
  * Globally: Setting multi-repl: True in your .cabal/config
  * Project Wide: Setting multi-repl: True in your cabal.project file
  * Per Invocation: By passing --enable-multi-repl when starting the repl

Command "cabal repl wire-subsystems:wire-subsystems-tests lib:wire-subsystems" exited unexpectedly with error message: 



*** usage: make devtest package=<package>.
*** this works for wire-subsystems; for other packages, you may need to edit the cabal file.
```

This is on cabal version 3.14.1.1. This seems to be provided by the nix environment, so I don't really understand how the command did run for @fisx, but not for me. Adding ` --enable-multi-repl` as suggested makes it work.
