### PR TITLE
Team collaborator: Implicit connection permission

### DIFF
--- a/changelog.d/2-features/WPB-18195
+++ b/changelog.d/2-features/WPB-18195
@@ -1,0 +1,1 @@
+Allow team collaborators with `implicit_connection` permission to create a One2One conversation with a team member.

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -383,6 +383,28 @@ getMLSOne2OneConversation self other = do
       $ joinHttpPath ["one2one-conversations", domain, uid]
   submit "GET" req
 
+postOne2OneConversation ::
+  (HasCallStack, MakesValue self, MakesValue other) =>
+  self ->
+  other ->
+  String ->
+  String ->
+  App Response
+postOne2OneConversation self other tid convName = do
+  qUid <- objQidObject other
+  req <-
+    baseRequest self Galley Versioned
+      $ joinHttpPath ["one2one-conversations"]
+  submit
+    "POST"
+    ( req
+        & addJSONObject
+          [ "name" .= convName,
+            "qualified_users" .= [qUid],
+            "team" .= Aeson.object ["teamid" .= tid, "managed" .= False]
+          ]
+    )
+
 getGroupClients ::
   (HasCallStack, MakesValue user) =>
   user ->

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -96,8 +96,8 @@ testCollaboratorCanCreateTeamConv (TaggedBool collaboratorHasTeam) = do
     resp.status `shouldMatchInt` 201
     resp.json %. "team" `shouldMatch` team
 
-testImplicitConnection :: (HasCallStack) => App ()
-testImplicitConnection = do
+testImplicitConnectionAllowed :: (HasCallStack) => App ()
+testImplicitConnectionAllowed = do
   (owner, team, [alice]) <- createTeam OwnDomain 2
 
   -- At the time of writing, it wasn't clear if this should be a bot instead.
@@ -110,3 +110,18 @@ testImplicitConnection = do
     >>= assertSuccess
 
   postOne2OneConversation bob alice team "chit-chat" >>= assertSuccess
+
+testImplicitConnectionNotConfigured :: (HasCallStack) => App ()
+testImplicitConnectionNotConfigured = do
+  (owner, team, [alice]) <- createTeam OwnDomain 2
+
+  -- At the time of writing, it wasn't clear if this should be a bot instead.
+  bob <- randomUser OwnDomain def
+  addTeamCollaborator
+    owner
+    team
+    bob
+    []
+    >>= assertSuccess
+
+  postOne2OneConversation bob alice team "chit-chat" >>= assertLabel 403 "operation-denied"

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -95,3 +95,18 @@ testCollaboratorCanCreateTeamConv (TaggedBool collaboratorHasTeam) = do
   postConversation collaborator (defMLS {team = Just team}) `bindResponse` \resp -> do
     resp.status `shouldMatchInt` 201
     resp.json %. "team" `shouldMatch` team
+
+testImplicitConnection :: (HasCallStack) => App ()
+testImplicitConnection = do
+  (owner, team, [alice]) <- createTeam OwnDomain 2
+
+  -- At the time of writing, it wasn't clear if this should be a bot instead.
+  bob <- randomUser OwnDomain def
+  addTeamCollaborator
+    owner
+    team
+    bob
+    ["implicit_connection"]
+    >>= assertSuccess
+
+  postOne2OneConversation bob alice team "chit-chat" >>= assertSuccess

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -125,3 +125,19 @@ testImplicitConnectionNotConfigured = do
     >>= assertSuccess
 
   postOne2OneConversation bob alice team "chit-chat" >>= assertLabel 403 "operation-denied"
+
+testImplicitConnectionNoCollaborator :: (HasCallStack) => App ()
+testImplicitConnectionNoCollaborator = do
+  (_owner0, team0, [alice]) <- createTeam OwnDomain 2
+  (owner1, team1, _users1) <- createTeam OwnDomain 2
+
+  -- At the time of writing, it wasn't clear if this should be a bot instead.
+  bob <- randomUser OwnDomain def
+  addTeamCollaborator
+    owner1
+    team1
+    bob
+    ["implicit_connection"]
+    >>= assertSuccess
+
+  postOne2OneConversation bob alice team0 "chit-chat" >>= assertLabel 403 "no-team-member"

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -631,7 +631,7 @@ collaboratorToTeamPermissions =
   foldMap
     ( \case
         Collaborator.CreateTeamConversation -> Set.fromList [CreateConversation, AddRemoveConvMember]
-        Collaborator.ImplicitConnection -> mempty
+        Collaborator.ImplicitConnection -> Set.singleton CreateConversation
     )
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Allow team collaborators to create 1:1 conversations via `POST /one2one-conversations` if they've the `implicit_connection` permission.

Ticket: https://wearezeta.atlassian.net/browse/WPB-18195

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
