### PR TITLE
team collaborators with implicit connection to team can get mls one2one

### DIFF
--- a/changelog.d/2-features/WPB-18195
+++ b/changelog.d/2-features/WPB-18195
@@ -1,1 +1,1 @@
-Allow team collaborators with `implicit_connection` permission to create a One2One conversation with a team member.
+Allow team collaborators with `implicit_connection` permission to create and query a One2One conversation with a team member.

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -111,6 +111,8 @@ testImplicitConnectionAllowed = do
 
   postOne2OneConversation bob alice team "chit-chat" >>= assertSuccess
 
+  getMLSOne2OneConversation bob alice >>= assertSuccess
+
 testImplicitConnectionNotConfigured :: (HasCallStack) => App ()
 testImplicitConnectionNotConfigured = do
   (owner, team, [alice]) <- createTeam OwnDomain 2

--- a/libs/wire-subsystems/postgres-migrations/20250729181800-create-collaborators-uid.sql
+++ b/libs/wire-subsystems/postgres-migrations/20250729181800-create-collaborators-uid.sql
@@ -1,0 +1,1 @@
+CREATE INDEX collaborators_user_id_idx ON collaborators (user_id);

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore.hs
@@ -11,5 +11,6 @@ data TeamCollaboratorsStore m a where
   CreateTeamCollaborator :: UserId -> TeamId -> Set CollaboratorPermission -> TeamCollaboratorsStore m ()
   GetAllTeamCollaborators :: TeamId -> TeamCollaboratorsStore m [TeamCollaborator]
   GetTeamCollaborator :: TeamId -> UserId -> TeamCollaboratorsStore m (Maybe TeamCollaborator)
+  GetTeamCollaborations :: UserId -> TeamCollaboratorsStore m ([TeamCollaborator])
 
 makeSem ''TeamCollaboratorsStore

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
@@ -158,10 +158,10 @@ getTeamCollaborationsImpl teamId = do
   either throw pure eitherTeamCollaborators
   where
     session :: Session [TeamCollaborator]
-    session = statement teamId getAllUserCollaborationsStatement
+    session = statement teamId getAllCollaborationsByUserStatement
 
-    getAllUserCollaborationsStatement :: Statement UserId [TeamCollaborator]
-    getAllUserCollaborationsStatement =
+    getAllCollaborationsByUserStatement :: Statement UserId [TeamCollaborator]
+    getAllCollaborationsByUserStatement =
       dimap toUUID (Data.Vector.toList . (toTeamCollaborator <$>)) $
         [vectorStatement|
           select user_id :: uuid, team_id :: uuid, permissions :: int2[] from collaborators where user_id = ($1 :: uuid)

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsStore/Postgres.hs
@@ -36,6 +36,7 @@ interpretTeamCollaboratorsStoreToPostgres =
     CreateTeamCollaborator userId teamId permissions -> createTeamCollaboratorImpl userId teamId permissions
     GetAllTeamCollaborators teamId -> getAllTeamCollaboratorsImpl teamId
     GetTeamCollaborator teamId userId -> getTeamCollaboratorImpl teamId userId
+    GetTeamCollaborations userId -> getTeamCollaborationsImpl userId
 
 getTeamCollaboratorImpl ::
   ( Member (Input Pool) r,
@@ -143,3 +144,25 @@ collaboratorPermissionToPostgreslRep =
 postgreslRepToCollaboratorPermission :: Int16 -> CollaboratorPermission
 postgreslRepToCollaboratorPermission =
   (collaboratorPermissionMap Bimap.! {- `!` throws if the element isn't found -})
+
+getTeamCollaborationsImpl ::
+  ( Member (Input Pool) r,
+    Member (Embed IO) r,
+    Member (Error UsageError) r
+  ) =>
+  UserId ->
+  Sem r [TeamCollaborator]
+getTeamCollaborationsImpl teamId = do
+  pool <- input
+  eitherTeamCollaborators <- liftIO $ use pool session
+  either throw pure eitherTeamCollaborators
+  where
+    session :: Session [TeamCollaborator]
+    session = statement teamId getAllUserCollaborationsStatement
+
+    getAllUserCollaborationsStatement :: Statement UserId [TeamCollaborator]
+    getAllUserCollaborationsStatement =
+      dimap toUUID (Data.Vector.toList . (toTeamCollaborator <$>)) $
+        [vectorStatement|
+          select user_id :: uuid, team_id :: uuid, permissions :: int2[] from collaborators where user_id = ($1 :: uuid)
+          |]

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem.hs
@@ -12,5 +12,6 @@ data TeamCollaboratorsSubsystem m a where
   CreateTeamCollaborator :: Local UserId -> UserId -> TeamId -> Set CollaboratorPermission -> TeamCollaboratorsSubsystem m ()
   GetAllTeamCollaborators :: Local UserId -> TeamId -> TeamCollaboratorsSubsystem m [TeamCollaborator]
   InternalGetTeamCollaborator :: TeamId -> UserId -> TeamCollaboratorsSubsystem m (Maybe TeamCollaborator)
+  InternalGetTeamCollaborations :: UserId -> TeamCollaboratorsSubsystem m [TeamCollaborator]
 
 makeSem ''TeamCollaboratorsSubsystem

--- a/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/TeamCollaboratorsSubsystem/Interpreter.hs
@@ -35,6 +35,7 @@ interpretTeamCollaboratorsSubsystem = interpret $ \case
   CreateTeamCollaborator zUser user team perms -> createTeamCollaboratorImpl zUser user team perms
   GetAllTeamCollaborators zUser team -> getAllTeamCollaboratorsImpl zUser team
   InternalGetTeamCollaborator team user -> internalGetTeamCollaboratorImpl team user
+  InternalGetTeamCollaborations userId -> internalGetTeamCollaborationsImpl userId
 
 internalGetTeamCollaboratorImpl ::
   (Member Store.TeamCollaboratorsStore r) =>
@@ -43,6 +44,13 @@ internalGetTeamCollaboratorImpl ::
   Sem r (Maybe TeamCollaborator)
 internalGetTeamCollaboratorImpl teamId userId = do
   Store.getTeamCollaborator teamId userId
+
+internalGetTeamCollaborationsImpl ::
+  (Member Store.TeamCollaboratorsStore r) =>
+  UserId ->
+  Sem r [TeamCollaborator]
+internalGetTeamCollaborationsImpl userId = do
+  Store.getTeamCollaborations userId
 
 createTeamCollaboratorImpl ::
   ( Member TeamSubsystem r,

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/TeamCollaboratorsStore.hs
@@ -22,3 +22,5 @@ inMemoryTeamCollaboratorsStoreInterpreter =
       gets $ \(s :: Map TeamId [TeamCollaborator]) -> (fromMaybe []) (Map.lookup teamId s)
     GetTeamCollaborator teamId userId ->
       gets $ \(s :: Map TeamId [TeamCollaborator]) -> find (\tc -> tc.gUser == userId) =<< Map.lookup teamId s
+    GetTeamCollaborations userId ->
+      gets $ \(s :: Map TeamId [TeamCollaborator]) -> concatMap (filter (\tc -> tc.gUser == userId)) (Map.elems s)

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -130,6 +130,7 @@ import Wire.API.User as User
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
+import Wire.TeamCollaboratorsSubsystem
 
 type family HasConversationActionEffects (tag :: ConversationActionTag) r :: Constraint where
   HasConversationActionEffects 'ConversationJoinTag r =
@@ -509,6 +510,7 @@ performAction ::
   forall tag r.
   ( HasConversationActionEffects tag r,
     Member BackendNotificationQueueAccess r,
+    Member TeamCollaboratorsSubsystem r,
     Member (Error FederationError) r
   ) =>
   Sing tag ->
@@ -622,7 +624,8 @@ performAction tag origUser lconv action = do
 performConversationJoin ::
   forall r.
   ( HasConversationActionEffects 'ConversationJoinTag r,
-    Member BackendNotificationQueueAccess r
+    Member BackendNotificationQueueAccess r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Qualified UserId ->
   Local Conversation ->
@@ -857,7 +860,8 @@ updateLocalConversation ::
     Member Now r,
     HasConversationActionEffects tag r,
     SingI tag,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local ConvId ->
   Qualified UserId ->
@@ -892,7 +896,8 @@ updateLocalConversationUnchecked ::
     Member NotificationSubsystem r,
     Member Now r,
     HasConversationActionEffects tag r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local Conversation ->
   Qualified UserId ->

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -50,6 +50,7 @@ import Wire.API.Routes.MultiTablePaging
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
 import Wire.Sem.Paging.Cassandra (CassandraPaging)
+import Wire.TeamCollaboratorsSubsystem
 
 getClients ::
   ( Member BrigAccess r,
@@ -81,7 +82,8 @@ rmClient ::
     Member ProposalStore r,
     Member Random r,
     Member SubConversationStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   UserId ->
   ClientId ->

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -279,7 +279,8 @@ leaveConversation ::
     Member Random r,
     Member SubConversationStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Domain ->
   LeaveConversationRequest ->
@@ -500,7 +501,8 @@ updateConversation ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamFeatureStore r,
-    Member (Input (Local ())) r
+    Member (Input (Local ())) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Domain ->
   ConversationUpdateRequest ->

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -101,6 +101,7 @@ import Wire.API.User (BaseProtocolTag (..))
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
+import Wire.TeamCollaboratorsSubsystem
 
 type FederationAPI = "federation" :> FedApi 'Galley
 
@@ -628,7 +629,8 @@ sendMLSCommitBundle ::
     Member P.TinyLog r,
     Member Random r,
     Member SubConversationStore r,
-    Member ProposalStore r
+    Member ProposalStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Domain ->
   MLSMessageSendRequest ->
@@ -682,7 +684,8 @@ sendMLSMessage ::
     Member TeamStore r,
     Member P.TinyLog r,
     Member ProposalStore r,
-    Member SubConversationStore r
+    Member SubConversationStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Domain ->
   MLSMessageSendRequest ->

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -103,6 +103,7 @@ import Wire.Sem.Now qualified as Now
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
 import Wire.TeamSubsystem qualified as TeamSubsystem
+import Wire.TeamCollaboratorsSubsystem
 
 internalAPI :: API InternalAPI GalleyEffects
 internalAPI =
@@ -137,7 +138,8 @@ ejpdGetConvInfo ::
     Member (Input Env) r,
     Member (ListItems p ConvId) r,
     Member (ListItems p (Remote ConvId)) r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   UserId ->
   Sem r [EJPDConvInfo]
@@ -331,7 +333,8 @@ rmUser ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamFeatureStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   Maybe ConnId ->

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -102,8 +102,8 @@ import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
-import Wire.TeamSubsystem qualified as TeamSubsystem
 import Wire.TeamCollaboratorsSubsystem
+import Wire.TeamSubsystem qualified as TeamSubsystem
 
 internalAPI :: API InternalAPI GalleyEffects
 internalAPI =

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -84,6 +84,7 @@ import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+import Wire.TeamCollaboratorsSubsystem
 
 createSettings ::
   forall r.
@@ -172,7 +173,8 @@ removeSettingsInternalPaging ::
     Member TeamFeatureStore r,
     Member (TeamMemberStore InternalPaging) r,
     Member TeamStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -215,7 +217,8 @@ removeSettings ::
     Member P.TinyLog r,
     Member Random r,
     Member SubConversationStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   UserId ->
   TeamId ->
@@ -271,7 +274,8 @@ removeSettings' ::
     Member Random r,
     Member P.TinyLog r,
     Member SubConversationStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   TeamId ->
   Sem r ()
@@ -320,7 +324,8 @@ grantConsent ::
     Member P.TinyLog r,
     Member Random r,
     Member SubConversationStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -371,7 +376,8 @@ requestDevice ::
     Member SubConversationStore r,
     Member TeamFeatureStore r,
     Member TeamStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -465,7 +471,8 @@ approveDevice ::
     Member SubConversationStore r,
     Member TeamFeatureStore r,
     Member TeamStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -542,7 +549,8 @@ disableForUser ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamStore r,
-    Member (Embed IO) r
+    Member (Embed IO) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -606,7 +614,8 @@ changeLegalholdStatusAndHandlePolicyConflicts ::
     Member ProposalStore r,
     Member Random r,
     Member P.TinyLog r,
-    Member SubConversationStore r
+    Member SubConversationStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   TeamId ->
   Local UserId ->
@@ -722,7 +731,8 @@ handleGroupConvPolicyConflicts ::
     Member P.TinyLog r,
     Member Random r,
     Member SubConversationStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   UserLegalHoldStatus ->

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -70,6 +70,7 @@ import Wire.API.MLS.Validation.Error (toText)
 import Wire.API.User.Client
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
+import Wire.TeamCollaboratorsSubsystem
 
 type HasProposalActionEffects r =
   ( Member BackendNotificationQueueAccess r,
@@ -98,7 +99,8 @@ type HasProposalActionEffects r =
     Member TeamStore r,
     Member TinyLog r,
     Member NotificationSubsystem r,
-    Member Random r
+    Member Random r,
+    Member TeamCollaboratorsSubsystem r
   )
 
 getCommitData ::

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -66,7 +66,6 @@ import Wire.API.MLS.Proposal qualified as Proposal
 import Wire.API.MLS.SubConversation
 import Wire.API.Unreachable
 import Wire.API.User.Client
-import Wire.TeamCollaboratorsSubsystem
 
 processInternalCommit ::
   forall r.
@@ -81,8 +80,7 @@ processInternalCommit ::
     Member SubConversationStore r,
     Member Resource r,
     Member Random r,
-    Member (ErrorS MLSInvalidLeafNodeSignature) r,
-    Member TeamCollaboratorsSubsystem r
+    Member (ErrorS MLSInvalidLeafNodeSignature) r
   ) =>
   SenderIdentity ->
   Maybe ConnId ->

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -66,6 +66,7 @@ import Wire.API.MLS.Proposal qualified as Proposal
 import Wire.API.MLS.SubConversation
 import Wire.API.Unreachable
 import Wire.API.User.Client
+import Wire.TeamCollaboratorsSubsystem
 
 processInternalCommit ::
   forall r.
@@ -80,7 +81,8 @@ processInternalCommit ::
     Member SubConversationStore r,
     Member Resource r,
     Member Random r,
-    Member (ErrorS MLSInvalidLeafNodeSignature) r
+    Member (ErrorS MLSInvalidLeafNodeSignature) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   SenderIdentity ->
   Maybe ConnId ->

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -71,6 +71,7 @@ import Wire.API.MLS.Validation.Error (toText)
 import Wire.API.Message
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
+import Wire.TeamCollaboratorsSubsystem
 
 data ProposalAction = ProposalAction
   { paAdd :: ClientMap (LeafIndex, Maybe KeyPackage),
@@ -138,7 +139,8 @@ type HasProposalEffects r =
     Member ProposalStore r,
     Member TeamStore r,
     Member TeamStore r,
-    Member TinyLog r
+    Member TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   )
 
 derefOrCheckProposal ::

--- a/services/galley/src/Galley/API/MLS/Reset.hs
+++ b/services/galley/src/Galley/API/MLS/Reset.hs
@@ -40,6 +40,7 @@ import Wire.API.MLS.SubConversation
 import Wire.API.Routes.Public.Galley.MLS
 import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
+import Wire.TeamCollaboratorsSubsystem
 
 resetMLSConversation ::
   ( Member (Input Env) r,
@@ -67,7 +68,8 @@ resetMLSConversation ::
     Member Resource r,
     Member SubConversationStore r,
     Member TeamStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   MLSReset ->

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -117,6 +117,7 @@ import Wire.API.User
 import Wire.HashPassword (HashPassword)
 import Wire.RateLimit
 import Wire.Sem.Paging.Cassandra
+import Wire.TeamCollaboratorsSubsystem
 
 getBotConversation ::
   ( Member ConversationStore r,
@@ -893,7 +894,8 @@ getMLSOne2OneConversationV6 ::
     Member (ErrorS 'NotConnected) r,
     Member FederatorAccess r,
     Member TeamStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   Qualified UserId ->

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -404,7 +404,8 @@ conversationIdsPageFromV2 ::
       Member (Input Env) r,
       Member (ListItems p ConvId) r,
       Member (ListItems p (Remote ConvId)) r,
-      Member P.TinyLog r
+      Member P.TinyLog r,
+      Member TeamCollaboratorsSubsystem r
     )
   ) =>
   ListGlobalSelfConvs ->
@@ -501,7 +502,8 @@ conversationIdsPageFrom ::
       Member (Input Env) r,
       Member (ListItems p ConvId) r,
       Member (ListItems p (Remote ConvId)) r,
-      Member P.TinyLog r
+      Member P.TinyLog r,
+      Member TeamCollaboratorsSubsystem r
     )
   ) =>
   Local UserId ->
@@ -856,7 +858,8 @@ getMLSOne2OneConversationV5 ::
     Member (ErrorS 'MLSFederatedOne2OneNotSupported) r,
     Member FederatorAccess r,
     Member TeamStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   Qualified UserId ->
@@ -876,7 +879,8 @@ getMLSOne2OneConversationInternal ::
     Member (ErrorS 'NotConnected) r,
     Member FederatorAccess r,
     Member TeamStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   Qualified UserId ->
@@ -920,7 +924,8 @@ getMLSOne2OneConversation ::
     Member (ErrorS 'NotConnected) r,
     Member FederatorAccess r,
     Member TeamStore r,
-    Member P.TinyLog r
+    Member P.TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   Qualified UserId ->

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -137,6 +137,7 @@ import Wire.NotificationSubsystem
 import Wire.Sem.Now
 import Wire.Sem.Now qualified as Now
 import Wire.Sem.Paging.Cassandra
+import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem qualified as TeamSubsystem
 
@@ -1011,7 +1012,8 @@ deleteTeamConversation ::
     Member NotificationSubsystem r,
     Member Now r,
     Member SubConversationStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -70,6 +70,7 @@ import Wire.NotificationSubsystem
 import Wire.Sem.Now (Now)
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+import Wire.TeamCollaboratorsSubsystem
 
 patchFeatureInternal ::
   forall cfg r.
@@ -338,7 +339,8 @@ instance SetFeatureConfig LegalholdConfig where
         Member (TeamMemberStore InternalPaging) r,
         Member P.TinyLog r,
         Member Random r,
-        Member (Embed IO) r
+        Member (Embed IO) r,
+        Member TeamCollaboratorsSubsystem r
       )
 
   prepareFeature tid feat = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -144,6 +144,7 @@ import Wire.NotificationSubsystem
 import Wire.RateLimit
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
+import Wire.TeamCollaboratorsSubsystem
 
 acceptConv ::
   ( Member ConversationStore r,
@@ -291,7 +292,8 @@ type UpdateConversationAccessEffects =
 
 updateConversationAccess ::
   ( Members UpdateConversationAccessEffects r,
-    Member Now r
+    Member Now r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -305,7 +307,8 @@ updateConversationAccess lusr con qcnv update = do
 
 updateConversationAccessUnqualified ::
   ( Members UpdateConversationAccessEffects r,
-    Member Now r
+    Member Now r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -337,7 +340,8 @@ updateConversationReceiptMode ::
     Member Now r,
     Member MemberStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -417,7 +421,8 @@ updateConversationReceiptModeUnqualified ::
     Member Now r,
     Member MemberStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+      Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -436,7 +441,8 @@ updateConversationMessageTimer ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -469,7 +475,8 @@ updateConversationMessageTimerUnqualified ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -495,7 +502,8 @@ deleteLocalConversation ::
     Member MemberStore r,
     Member ProposalStore r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -738,7 +746,8 @@ updateConversationProtocolWithLocalUser ::
     Member ProposalStore r,
     Member SubConversationStore r,
     Member TeamFeatureStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -783,7 +792,8 @@ updateChannelAddPermission ::
     Member BrigAccess r,
     Member FederatorAccess r,
     Member MemberStore r,
-    Member (ErrorS 'InvalidTargetAccess) r
+    Member (ErrorS 'InvalidTargetAccess) r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -943,7 +953,8 @@ addMembers ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamStore r,
-    Member TinyLog r
+    Member TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -988,7 +999,8 @@ addMembersUnqualifiedV2 ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamStore r,
-    Member TinyLog r
+    Member TinyLog r,
+      Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1031,7 +1043,8 @@ addMembersUnqualified ::
     Member Random r,
     Member SubConversationStore r,
     Member TeamStore r,
-    Member TinyLog r
+    Member TinyLog r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1119,7 +1132,8 @@ updateOtherMemberLocalConv ::
     Member NotificationSubsystem r,
     Member Now r,
     Member MemberStore r,
-    Member TeamStore r
+    Member TeamStore r,
+      Member TeamCollaboratorsSubsystem r
   ) =>
   Local ConvId ->
   Local UserId ->
@@ -1146,7 +1160,8 @@ updateOtherMemberUnqualified ::
     Member NotificationSubsystem r,
     Member Now r,
     Member MemberStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1172,7 +1187,8 @@ updateOtherMember ::
     Member NotificationSubsystem r,
     Member Now r,
     Member MemberStore r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1212,7 +1228,8 @@ removeMemberUnqualified ::
     Member Random r,
     Member SubConversationStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1242,7 +1259,8 @@ removeMemberQualified ::
     Member Random r,
     Member SubConversationStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1319,7 +1337,8 @@ removeMemberFromLocalConv ::
     Member Random r,
     Member SubConversationStore r,
     Member TinyLog r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local ConvId ->
   Local UserId ->
@@ -1550,7 +1569,8 @@ updateConversationName ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1576,7 +1596,8 @@ updateUnqualifiedConversationName ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1598,7 +1619,8 @@ updateLocalConversationName ::
     Member ExternalAccess r,
     Member NotificationSubsystem r,
     Member Now r,
-    Member TeamStore r
+    Member TeamStore r,
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -422,7 +422,7 @@ updateConversationReceiptModeUnqualified ::
     Member MemberStore r,
     Member TinyLog r,
     Member TeamStore r,
-      Member TeamCollaboratorsSubsystem r
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1000,7 +1000,7 @@ addMembersUnqualifiedV2 ::
     Member SubConversationStore r,
     Member TeamStore r,
     Member TinyLog r,
-      Member TeamCollaboratorsSubsystem r
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local UserId ->
   ConnId ->
@@ -1133,7 +1133,7 @@ updateOtherMemberLocalConv ::
     Member Now r,
     Member MemberStore r,
     Member TeamStore r,
-      Member TeamCollaboratorsSubsystem r
+    Member TeamCollaboratorsSubsystem r
   ) =>
   Local ConvId ->
   Local UserId ->

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -90,6 +90,7 @@ import Wire.API.Team.Collaborator
 import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.API.Team.Member qualified as Mem
+import Wire.API.Team.Permission qualified as Perm
 import Wire.API.Team.Role
 import Wire.API.User hiding (userId)
 import Wire.API.User.Auth.ReAuth
@@ -159,7 +160,7 @@ ensureConnectedToLocalsOrSameTeam (tUnqualified -> u) uids = do
   uTeams <- getUserTeams u
   colls :: [TeamId] <-
     gTeam
-      <$$> (filter (Set.member ImplicitConnection . gPermissions) <$> internalGetTeamCollaborations u)
+      <$$> (filter (flip hasPermission Perm.CreateConversation) <$> internalGetTeamCollaborations u)
   -- We collect all the relevant uids from same teams as the origin user
   sameTeamUids <- forM (uTeams `union` colls) $ \team ->
     fmap (view Mem.userId) <$> selectTeamMembers team uids

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -161,7 +161,7 @@ ensureConnectedToLocalsOrSameTeam (tUnqualified -> u) uids = do
     gTeam
       <$$> (filter (Set.member ImplicitConnection . gPermissions) <$> internalGetTeamCollaborations u)
   -- We collect all the relevant uids from same teams as the origin user
-  sameTeamUids <- forM (uTeams ++ colls) $ \team ->
+  sameTeamUids <- forM (uTeams `union` colls) $ \team ->
     fmap (view Mem.userId) <$> selectTeamMembers team uids
   -- Do not check connections for users that are on the same team
   ensureConnectedToLocals u (uids \\ join sameTeamUids)


### PR DESCRIPTION
Allow team collaborators with `impicit_connection` permission to get a MLS 1:1 where the collaborator is involved.

The affected endpoint is `GET /one2one-conversations/{usr_domain}/{usr}`.

The other affected bit is `performConversationJoin`. Which (hopefully) should be fine, as team collaborators would be able to join conversations.

Ticket: https://wearezeta.atlassian.net/browse/WPB-18195

# Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
