### PR TITLE
fix(nginz): also include namespace in upstream name when `upstream_namespace` is set

### DIFF
--- a/changelog.d/5-internal/nginz-disco-fix
+++ b/changelog.d/5-internal/nginz-disco-fix
@@ -1,0 +1,1 @@
+Fixed 504 errors when trying to reach services in other namespaces.

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -196,7 +196,7 @@ http {
 
 {{- $validUpstreams := include "valid_upstreams" . | fromJson }}
 {{- range $name, $_ := $validUpstreams }}
-  upstream {{ $name }} {
+  upstream {{ $name }}{{ if hasKey $.Values.nginx_conf.upstream_namespace $name }}.{{ get $.Values.nginx_conf.upstream_namespace $name }}{{end}} { 
       zone {{ $name }} 64k; # needed for dynamic DNS updates
       least_conn;
       keepalive 32;


### PR DESCRIPTION
If `upstream_name` is set, we're including it in the proxy_pass directive. However, the actual upstreams never included the namespace name.
This PR adds the namespace to the upstream name in the upstream declaration, so that proxy_pass is not running into a 504 error for such services.

related to WPB-19292


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
