### PR TITLE
Fix conversation type check for reset action

### DIFF
--- a/changelog.d/3-bug-fixes/reset-non-group
+++ b/changelog.d/3-bug-fixes/reset-non-group
@@ -1,0 +1,1 @@
+Fix bug where reset action was returning "invalid-op" for non-group conversations

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -936,9 +936,7 @@ updateLocalConversationUnchecked lconv qusr con action = do
           -- TeamMember is a special case, which will be handled in ensureAllowed
           TeamMember _ -> pure ()
 
-      -- check if it is a group conversation (except for rename actions)
-      when (fromSing tag /= ConversationRenameTag) $
-        ensureGroupConversation conv
+      checkConversationType (fromSing tag) conv
 
       -- extra action-specific checks
       ensureAllowed tag loc action conv self

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -254,6 +254,18 @@ ensureGroupConversation conv = do
   let ty = Data.convType conv
   when (ty /= RegularConv) $ throwS @'InvalidOperation
 
+-- | Ensure that the conversation is of the right type for the action
+checkConversationType ::
+  (Member (ErrorS 'InvalidOperation) r) =>
+  ConversationActionTag ->
+  Data.Conversation ->
+  Sem r ()
+checkConversationType ConversationRenameTag _conv = pure ()
+checkConversationType ConversationResetTag _conv = pure ()
+checkConversationType _ conv = do
+  let ty = Data.convType conv
+  when (ty /= RegularConv) $ throwS @'InvalidOperation
+
 -- | Ensure that the set of actions provided are not "greater" than the user's
 --   own. This is used to ensure users cannot "elevate" allowed actions
 --   This function needs to be review when custom roles are introduced since only


### PR DESCRIPTION
This fixes a bug where the backend was incorrectly checking that a conversation being reset is a group conversation, and throwing "invalid-op" if not.

https://wearezeta.atlassian.net/browse/WPB-19296

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
