### PR TITLE
WPB-19263 feature flag to enable iOS chat bubbles

### DIFF
--- a/changelog.d/2-features/WPB-19263
+++ b/changelog.d/2-features/WPB-19263
@@ -1,0 +1,1 @@
+New team feature config for chat bubbles

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -191,5 +191,9 @@ data:
         consumableNotifications:
           {{- toYaml .settings.featureFlags.consumableNotifications | nindent 10 }}
         {{- end }}
+        {{- if .settings.featureFlags.chatBubbles }}
+        chatBubbles:
+          {{- toYaml .settings.featureFlags.chatBubbles | nindent 10 }}
+        {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -217,7 +217,7 @@ config:
       chatBubbles:
         defaults:
           status: disabled
-          lockStatus: unlocked
+          lockStatus: locked
 
   aws:
     region: "eu-west-1"

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -214,6 +214,10 @@ config:
         defaults:
           status: disabled
           lockStatus: locked
+      chatBubbles:
+        defaults:
+          status: disabled
+          lockStatus: unlocked
 
   aws:
     region: "eu-west-1"

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -614,7 +614,7 @@ config:
       chatBubbles:
         defaults:
           status: disabled
-          lockStatus: unlocked
+          lockStatus: locked
 ```
 
 ## Settings in brig

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -600,6 +600,23 @@ config:
           mlsConversationReset: true
 ```
 
+### Chat Bubbles
+
+Feature toggle for `chatBubbles`.
+
+Example default configuration:
+
+```yaml
+# galley.yaml
+config:
+  settings:
+    featureFlags:
+      chatBubbles:
+        defaults:
+          status: disabled
+          lockStatus: unlocked
+```
+
 ## Settings in brig
 
 Some features (as of the time of writing this: only

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -371,7 +371,7 @@ galley:
         chatBubbles:
           defaults:
             status: disabled
-            lockStatus: unlocked
+            lockStatus: locked
     journal:
       endpoint: http://fake-aws-sqs:4568
       queueName: integration-team-events.fifo

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -368,6 +368,10 @@ galley:
           status: enabled
           config:
             mlsConversationReset: false
+        chatBubbles:
+          defaults:
+            status: disabled
+            lockStatus: unlocked
     journal:
       endpoint: http://fake-aws-sqs:4568
       queueName: integration-team-events.fifo

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -137,6 +137,7 @@ library
     Test.FeatureFlags.AppLock
     Test.FeatureFlags.Cells
     Test.FeatureFlags.Channels
+    Test.FeatureFlags.ChatBubbles
     Test.FeatureFlags.ClassifiedDomains
     Test.FeatureFlags.ConferenceCalling
     Test.FeatureFlags.ConsumableNotifications

--- a/integration/test/Test/FeatureFlags/ChatBubbles.hs
+++ b/integration/test/Test/FeatureFlags/ChatBubbles.hs
@@ -1,0 +1,14 @@
+module Test.FeatureFlags.ChatBubbles where
+
+import Test.FeatureFlags.Util
+import Testlib.Prelude
+
+testConversationChatBubbles :: (HasCallStack) => APIAccess -> App ()
+testConversationChatBubbles access =
+  mkFeatureTests "chatBubbles"
+    & addUpdate enabled
+    & addUpdate disabled
+    & runFeatureTests OwnDomain access
+
+testPatchChatBubbles :: (HasCallStack) => App ()
+testPatchChatBubbles = checkPatch OwnDomain "chatBubbles" disabled

--- a/integration/test/Test/FeatureFlags/ChatBubbles.hs
+++ b/integration/test/Test/FeatureFlags/ChatBubbles.hs
@@ -1,14 +1,25 @@
 module Test.FeatureFlags.ChatBubbles where
 
+import qualified API.GalleyInternal as Internal
+import SetupHelpers
 import Test.FeatureFlags.Util
 import Testlib.Prelude
 
-testConversationChatBubbles :: (HasCallStack) => APIAccess -> App ()
-testConversationChatBubbles access =
-  mkFeatureTests "chatBubbles"
-    & addUpdate enabled
-    & addUpdate disabled
-    & runFeatureTests OwnDomain access
+testChatBubblesInternal :: (HasCallStack) => App ()
+testChatBubblesInternal = do
+  (alice, tid, _) <- createTeam OwnDomain 0
+  Internal.setTeamFeatureLockStatus alice tid "chatBubbles" "unlocked"
+  withWebSocket alice $ \ws -> do
+    setFlag InternalAPI ws tid "chatBubbles" enabled
+    setFlag InternalAPI ws tid "chatBubbles" disabled
+  Internal.setTeamFeatureLockStatus alice tid "chatBubbles" "locked"
+  setFeature InternalAPI alice tid "chatBubbles" enabled `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 409
+    resp.json %. "label" `shouldMatch` "feature-locked"
+  -- the feature does not have a public PUT endpoint
+  setFeature PublicAPI alice tid "chatBubbles" enabled `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 404
+    resp.json %. "label" `shouldMatch` "no-endpoint"
 
 testPatchChatBubbles :: (HasCallStack) => App ()
 testPatchChatBubbles = checkPatch OwnDomain "chatBubbles" disabled

--- a/integration/test/Test/FeatureFlags/Util.hs
+++ b/integration/test/Test/FeatureFlags/Util.hs
@@ -159,7 +159,8 @@ defAllFeatures =
                 [ "mlsConversationReset" .= False
                 ]
           ],
-      "consumableNotifications" .= disabledLocked
+      "consumableNotifications" .= disabledLocked,
+      "chatBubbles" .= disabled
     ]
 
 hasExplicitLockStatus :: String -> Bool

--- a/integration/test/Test/FeatureFlags/Util.hs
+++ b/integration/test/Test/FeatureFlags/Util.hs
@@ -160,7 +160,7 @@ defAllFeatures =
                 ]
           ],
       "consumableNotifications" .= disabledLocked,
-      "chatBubbles" .= disabled
+      "chatBubbles" .= disabledLocked
     ]
 
 hasExplicitLockStatus :: String -> Bool

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -299,6 +299,13 @@ newtype instance FeatureDefaults ConsumableNotificationsConfig
   deriving (FromJSON) via Defaults (LockableFeature ConsumableNotificationsConfig)
   deriving (ParseFeatureDefaults) via OptionalField ConsumableNotificationsConfig
 
+newtype instance FeatureDefaults ChatBubblesConfig
+  = ChatBubblesDefaults (LockableFeature ChatBubblesConfig)
+  deriving stock (Eq, Show)
+  deriving newtype (Default, GetFeatureDefaults)
+  deriving (FromJSON) via Defaults (LockableFeature ChatBubblesConfig)
+  deriving (ParseFeatureDefaults) via OptionalField ChatBubblesConfig
+
 featureKey :: forall cfg. (IsFeatureConfig cfg) => Key.Key
 featureKey = Key.fromText $ featureName @cfg
 

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -87,6 +87,7 @@ type IFeatureAPI =
     :<|> IFeatureStatusLockStatusPut ChannelsConfig
     :<|> IFeatureStatusLockStatusPut CellsConfig
     :<|> IFeatureStatusLockStatusPut ConsumableNotificationsConfig
+    :<|> IFeatureStatusLockStatusPut ChatBubblesConfig
     -- all feature configs
     :<|> Named
            "feature-configs-internal"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -69,6 +69,7 @@ type FeatureAPI =
     :<|> FeatureAPIGetPut CellsConfig
     :<|> FeatureAPIGet AllowedGlobalOperationsConfig
     :<|> FeatureAPIGet ConsumableNotificationsConfig
+    :<|> FeatureAPIGetPut ChatBubblesConfig
 
 type DeprecationNotice1 = "This endpoint is potentially used by the old Android client. It is not used by iOS, team management, or webapp as of June 2022"
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -69,7 +69,7 @@ type FeatureAPI =
     :<|> FeatureAPIGetPut CellsConfig
     :<|> FeatureAPIGet AllowedGlobalOperationsConfig
     :<|> FeatureAPIGet ConsumableNotificationsConfig
-    :<|> FeatureAPIGetPut ChatBubblesConfig
+    :<|> FeatureAPIGet ChatBubblesConfig
 
 type DeprecationNotice1 = "This endpoint is potentially used by the old Android client. It is not used by iOS, team management, or webapp as of June 2022"
 

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -1505,7 +1505,7 @@ instance ToSchema ChatBubblesConfig where
   schema = object "ChatBubblesConfig" objectSchema
 
 instance Default (LockableFeature ChatBubblesConfig) where
-  def = defUnlockedFeature {status = FeatureStatusDisabled}
+  def = defLockedFeature
 
 instance IsFeatureConfig ChatBubblesConfig where
   type FeatureSymbol ChatBubblesConfig = "chatBubbles"

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -88,6 +88,7 @@ module Wire.API.Team.Feature
     CellsConfig (..),
     AllowedGlobalOperationsConfig (..),
     ConsumableNotificationsConfig (..),
+    ChatBubblesConfig (..),
     Features,
     AllFeatures,
     NpProject (..),
@@ -246,6 +247,7 @@ data FeatureSingleton cfg where
   FeatureSingletonCellsConfig :: FeatureSingleton CellsConfig
   FeatureSingletonAllowedGlobalOperationsConfig :: FeatureSingleton AllowedGlobalOperationsConfig
   FeatureSingletonConsumableNotificationsConfig :: FeatureSingleton ConsumableNotificationsConfig
+  FeatureSingletonChatBubblesConfig :: FeatureSingleton ChatBubblesConfig
 
 type family DeprecatedFeatureName (v :: Version) (cfg :: Type) :: Symbol
 
@@ -1490,6 +1492,27 @@ instance IsFeatureConfig ConsumableNotificationsConfig where
   featureSingleton = FeatureSingletonConsumableNotificationsConfig
   objectSchema = pure ConsumableNotificationsConfig
 
+--------------------------------------------------------------------------------
+-- Chat Bubbles Feature
+
+data ChatBubblesConfig = ChatBubblesConfig
+  deriving (Eq, Show, Generic, GSOP.Generic)
+  deriving (Arbitrary) via (GenericUniform ChatBubblesConfig)
+  deriving (RenderableSymbol) via (RenderableTypeName ChatBubblesConfig)
+  deriving (ParseDbFeature, Default) via TrivialFeature ChatBubblesConfig
+
+instance ToSchema ChatBubblesConfig where
+  schema = object "ChatBubblesConfig" objectSchema
+
+instance Default (LockableFeature ChatBubblesConfig) where
+  def = defUnlockedFeature {status = FeatureStatusDisabled}
+
+instance IsFeatureConfig ChatBubblesConfig where
+  type FeatureSymbol ChatBubblesConfig = "chatBubbles"
+  featureSingleton = FeatureSingletonChatBubblesConfig
+
+  objectSchema = pure ChatBubblesConfig
+
 ----------------------------------------------------------------------
 -- FeatureStatus
 
@@ -1577,7 +1600,8 @@ type Features =
     ChannelsConfig,
     CellsConfig,
     AllowedGlobalOperationsConfig,
-    ConsumableNotificationsConfig
+    ConsumableNotificationsConfig,
+    ChatBubblesConfig
   ]
 
 -- | list of available features as a record

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -165,6 +165,10 @@ settings:
       defaults:
         status: disabled
         lockStatus: locked
+    chatBubbles:
+      defaults:
+        status: disabled
+        lockStatus: unlocked
 
 logLevel: Warn
 logNetStrings: false

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -168,7 +168,7 @@ settings:
     chatBubbles:
       defaults:
         status: disabled
-        lockStatus: unlocked
+        lockStatus: locked
 
 logLevel: Warn
 logNetStrings: false

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -283,6 +283,7 @@ allFeaturesAPI =
     <@> featureAPI1Full
     <@> featureAPI1Get
     <@> featureAPI1Full
+    <@> featureAPI1Full
 
 featureAPI :: API IFeatureAPI GalleyEffects
 featureAPI =
@@ -302,6 +303,7 @@ featureAPI =
     <@> mkNamedAPI @'("ilock", ChannelsConfig) (updateLockStatus @ChannelsConfig)
     <@> mkNamedAPI @'("ilock", CellsConfig) (updateLockStatus @CellsConfig)
     <@> mkNamedAPI @'("ilock", ConsumableNotificationsConfig) (updateLockStatus @ConsumableNotificationsConfig)
+    <@> mkNamedAPI @'("ilock", ChatBubblesConfig) (updateLockStatus @ChatBubblesConfig)
     -- all features
     <@> mkNamedAPI @"feature-configs-internal" (maybe getAllTeamFeaturesForServer getAllTeamFeaturesForUser)
 

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -70,7 +70,7 @@ featureAPI =
     <@> featureAPIGetPut
     <@> mkNamedAPI @'("get", AllowedGlobalOperationsConfig) getFeature
     <@> mkNamedAPI @'("get", ConsumableNotificationsConfig) getFeature
-    <@> featureAPIGetPut
+    <@> mkNamedAPI @'("get", ChatBubblesConfig) getFeature
 
 deprecatedFeatureConfigAPI :: API DeprecatedFeatureAPI GalleyEffects
 deprecatedFeatureConfigAPI =

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -70,6 +70,7 @@ featureAPI =
     <@> featureAPIGetPut
     <@> mkNamedAPI @'("get", AllowedGlobalOperationsConfig) getFeature
     <@> mkNamedAPI @'("get", ConsumableNotificationsConfig) getFeature
+    <@> featureAPIGetPut
 
 deprecatedFeatureConfigAPI :: API DeprecatedFeatureAPI GalleyEffects
 deprecatedFeatureConfigAPI =

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -452,3 +452,5 @@ instance SetFeatureConfig DomainRegistrationConfig
 instance SetFeatureConfig CellsConfig
 
 instance SetFeatureConfig ConsumableNotificationsConfig
+
+instance SetFeatureConfig ChatBubblesConfig

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -403,6 +403,8 @@ instance GetFeatureConfig AllowedGlobalOperationsConfig
 
 instance GetFeatureConfig ConsumableNotificationsConfig
 
+instance GetFeatureConfig ChatBubblesConfig
+
 -- | If second factor auth is enabled, make sure that end-points that don't support it, but
 -- should, are blocked completely.  (This is a workaround until we have 2FA for those
 -- end-points as well.)

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -184,6 +184,8 @@ sitemap' =
     :<|> Named @"put-route-limited-event-fanout" (mkFeatureStatusPutRoute @LimitedEventFanoutConfig)
     :<|> Named @"get-route-consumable-notifications" (mkFeatureGetRoute @ConsumableNotificationsConfig)
     :<|> Named @"put-route-consumable-notifications" (mkFeatureStatusPutRoute @ConsumableNotificationsConfig)
+    :<|> Named @"get-route-chat-bubbles-config" (mkFeatureGetRoute @ChatBubblesConfig)
+    :<|> Named @"put-route-chat-bubbles-config" (mkFeatureStatusPutRoute @ChatBubblesConfig)
     :<|> Named @"get-team-invoice" getTeamInvoice
     :<|> Named @"get-team-billing-info" getTeamBillingInfo
     :<|> Named @"put-team-billing-info" updateTeamBillingInfo
@@ -216,6 +218,7 @@ sitemap' =
     :<|> Named @"lock-unlock-route-limited-event-fanout-config" (mkFeatureLockUnlockRoute @LimitedEventFanoutConfig)
     :<|> Named @"lock-unlock-route-cells-config" (mkFeatureLockUnlockRoute @CellsConfig)
     :<|> Named @"lock-unlock-route-consumable-notifications-config" (mkFeatureLockUnlockRoute @ConsumableNotificationsConfig)
+    :<|> Named @"lock-unlock-route-chat-bubbles-config" (mkFeatureLockUnlockRoute @ChatBubblesConfig)
 
 sitemapInternal :: Servant.Server SternAPIInternal
 sitemapInternal =

--- a/tools/stern/src/Stern/API/Routes.hs
+++ b/tools/stern/src/Stern/API/Routes.hs
@@ -319,6 +319,8 @@ type SternAPI =
     :<|> Named "put-route-limited-event-fanout" (MkFeatureStatusPutRoute LimitedEventFanoutConfig)
     :<|> Named "get-route-consumable-notifications" (MkFeatureGetRoute ConsumableNotificationsConfig)
     :<|> Named "put-route-consumable-notifications" (MkFeatureStatusPutRoute ConsumableNotificationsConfig)
+    :<|> Named "get-route-chat-bubbles-config" (MkFeatureGetRoute ChatBubblesConfig)
+    :<|> Named "put-route-chat-bubbles-config" (MkFeatureStatusPutRoute ChatBubblesConfig)
     :<|> Named
            "get-team-invoice"
            ( Summary "Get a specific invoice by Number"
@@ -468,6 +470,7 @@ type SternAPI =
     :<|> Named "lock-unlock-route-limited-event-fanout-config" (MkFeatureLockUnlockRoute LimitedEventFanoutConfig)
     :<|> Named "lock-unlock-route-cells-config" (MkFeatureLockUnlockRoute CellsConfig)
     :<|> Named "lock-unlock-route-consumable-notifications-config" (MkFeatureLockUnlockRoute ConsumableNotificationsConfig)
+    :<|> Named "lock-unlock-route-chat-bubbles-config" (MkFeatureLockUnlockRoute ChatBubblesConfig)
 
 -------------------------------------------------------------------------------
 -- Swagger

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -116,7 +116,9 @@ tests s =
       test s "PUT /teams/:tid/features/sndFactorPasswordChallenge{,'?lockOrUnlock'}" $ testLockStatus @SndFactorPasswordChallengeConfig,
       test s "PUT /teams/:tid/features/limitedEventFanout{,'?lockOrUnlock'}" $ testLockStatus @LimitedEventFanoutConfig,
       test s "PUT /teams/:tid/features/cells{,'?lockOrUnlock'}" $ testLockStatus @CellsConfig,
-      test s "PUT /teams/:tid/features/consumableNotifications{,'?lockOrUnlock'}" $ testLockStatus @ConsumableNotificationsConfig
+      test s "PUT /teams/:tid/features/consumableNotifications{,'?lockOrUnlock'}" $ testLockStatus @ConsumableNotificationsConfig,
+      test s "PUT /teams/:tid/features/chatBubbles{,'?lockOrUnlock'}" $ testLockStatus @ChatBubblesConfig,
+      test s "/teams/:tid/features/chatBubbles" $ testFeatureStatus @ChatBubblesConfig
       -- The following endpoints can not be tested here because they require ibis:
       -- - `GET /teams/:tid/billing`
       -- - `GET /teams/:tid/invoice/:inr`


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
