### PR TITLE
WPB-19482 Add PodDisruptionBudgets to service charts.

### DIFF
--- a/changelog.d/5-internal/WPB-19482-pdbs
+++ b/changelog.d/5-internal/WPB-19482-pdbs
@@ -1,0 +1,1 @@
+Add PodDisruptionBudgets to service charts; render only when replicas > 1

--- a/charts/brig/templates/poddisruptionbudget.yaml
+++ b/charts/brig/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: brig
+  labels:
+    app: brig
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: brig
+{{- end }}

--- a/charts/cannon/templates/poddisruptionbudget.yaml
+++ b/charts/cannon/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cannon
+  labels:
+    app: cannon
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: cannon
+{{- end }}

--- a/charts/cargohold/templates/poddisruptionbudget.yaml
+++ b/charts/cargohold/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cargohold
+  labels:
+    app: cargohold
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: cargohold
+{{- end }}

--- a/charts/federator/templates/poddisruptionbudget.yaml
+++ b/charts/federator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: federator
+  labels:
+    app: federator
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: federator
+{{- end }}

--- a/charts/galley/templates/poddisruptionbudget.yaml
+++ b/charts/galley/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: galley
+  labels:
+    app: galley
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: galley
+{{- end }}

--- a/charts/gundeck/templates/poddisruptionbudget.yaml
+++ b/charts/gundeck/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gundeck
+  labels:
+    app: gundeck
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: gundeck
+{{- end }}

--- a/charts/nginz/templates/poddisruptionbudget.yaml
+++ b/charts/nginz/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginz
+  labels:
+    app: nginz
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: nginz
+{{- end }}

--- a/charts/proxy/templates/poddisruptionbudget.yaml
+++ b/charts/proxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: proxy
+  labels:
+    app: proxy
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: proxy
+{{- end }}

--- a/charts/spar/templates/poddisruptionbudget.yaml
+++ b/charts/spar/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: spar
+  labels:
+    app: spar
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: {{ sub (int .Values.replicaCount) 1 }}
+  selector:
+    matchLabels:
+      app: spar
+{{- end }}


### PR DESCRIPTION
Render only when replicaCount > 1 (so it's inactive in test/demo scenarios); set maxUnavailable to replicaCount-1.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
