### PR TITLE
 fix(charts-nginz): Make k8s dns resolver service configurable for nginz

### DIFF
--- a/changelog.d/5-internal/fix-ngniz-dns-resolver
+++ b/changelog.d/5-internal/fix-ngniz-dns-resolver
@@ -1,0 +1,1 @@
+charts/nginz: Make k8s dns resolver service configurable for nginz

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -191,7 +191,7 @@ http {
   #
 {{- $clusterDomain := .Values.nginx_conf.cluster_domain }}
 
-  resolver kube-dns.kube-system.svc.{{ $clusterDomain }} valid=30s ipv6=off;
+  resolver {{ .Values.nginx_conf.dns_resolver }}.kube-system.svc.{{ $clusterDomain }} valid=30s ipv6=off;
   resolver_timeout 5s;
 
 {{- $validUpstreams := include "valid_upstreams" . | fromJson }}

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -21,6 +21,7 @@ config:
     useProxyProtocol: true
 terminationGracePeriodSeconds: 90
 nginx_conf:
+  dns_resolver: kube-dns
   cluster_domain: cluster.local
   zauth_keystore: /etc/wire/nginz/secrets/zauth.conf
   zauth_acl: /etc/wire/nginz/conf/zauth.acl


### PR DESCRIPTION


## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
