### PR TITLE
charts/gundeck: add prestop hook

### DIFF
--- a/changelog.d/5-internal/graceful-shutdown-gundeck
+++ b/changelog.d/5-internal/graceful-shutdown-gundeck
@@ -1,0 +1,1 @@
+Add a preStopHook to gundeck helm chart to avoid spurious 500s on gundeck restarts.

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       topologySpreadConstraints:
         - maxSkew: 1
@@ -171,5 +172,9 @@ spec:
               scheme: HTTP
               path: /i/status
               port: {{ .Values.service.internalPort }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -14,6 +14,9 @@ resources:
     cpu: "100m"
   limits:
     memory: "1Gi"
+
+# Should be greater than Warp's graceful shutdown (default 30s).
+terminationGracePeriodSeconds: 40
 config:
   logLevel: Info
   logFormat: StructuredJSON


### PR DESCRIPTION
We currently get a few 500s sometime when gundeck restarts, where some current requests seem to get aborted mid-request. This is possibly due to terminating pods still getting some traffic.

https://wearezeta.atlassian.net/browse/WPB-19694

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
