### PR TITLE
update nixpkgs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,7 +27,7 @@ if [[ ! -d "$env_dir" || ! -f "$layout_dir/nix-rebuild" || "$store_paths" != $(<
     fi
   fi
   echo "🔧 Building environment"
-  $bcmd build -f nix wireServer.devEnv -Lv --out-link ./.env
+  $bcmd build -f nix wireServer.devEnv -Lv --out-link ./.env --fallback
   echo "$store_paths" >"$layout_dir/nix-rebuild"
 fi
 

--- a/changelog.d/5-internal/update-nixpkgs
+++ b/changelog.d/5-internal/update-nixpkgs
@@ -1,0 +1,3 @@
+Update `nixpkgs` (source of dependencies) to [latest of `unstable`
+channel](https://github.com/NixOS/nixpkgs/commits/c53baa6685261e5253a1c355a1b322f82674a824).
+This has no specific reason other than preventing tech-debt.

--- a/hack/bin/upload-images.sh
+++ b/hack/bin/upload-images.sh
@@ -23,10 +23,10 @@ readonly SCRIPT_DIR ROOT_DIR
 
 tmp_link_store=$(mktemp -d)
 image_list_file="$tmp_link_store/image-list"
-nix -v --show-trace -L build -f "$ROOT_DIR/nix" wireServer.imagesList -o "$image_list_file"
+nix -v --show-trace -L build -f "$ROOT_DIR/nix" wireServer.imagesList -o "$image_list_file" --fallback
 
 # Build everything first so we can benefit the most from having many cores.
-nix -v --show-trace -L build -f "$ROOT_DIR/nix" "wireServer.$IMAGES_ATTR" --no-link
+nix -v --show-trace -L build -f "$ROOT_DIR/nix" "wireServer.$IMAGES_ATTR" --no-link --fallback
 
 xargs -I {} -P 10 "$SCRIPT_DIR/upload-image.sh" "wireServer.$IMAGES_ATTR.{}" < "$image_list_file"
 

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -821,15 +821,6 @@ fromSomeResponse (SomeResponse Response {..}) = do
         ..
       }
 
-class HasAcceptCheck cs where
-  acceptCheck' :: Proxy cs -> AcceptHeader -> DelayedIO ()
-
-instance (AllMime cs) => HasAcceptCheck cs where
-  acceptCheck' = acceptCheck
-
-instance HasAcceptCheck '() where
-  acceptCheck' _ _ = pure ()
-
 instance
   ( HasAcceptCheck cs,
     IsResponseList cs as,

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -177,19 +177,6 @@ let
       };
     };
 
-    # Replace this with upstream once > 0.20.2 has been released.
-    servant = {
-      src = fetchgit {
-        url = "https://github.com/wireapp/servant";
-        rev = "fa8271564ebd9dff22de84aa77a687c89398a612";
-        hash = "sha256-9g3tEfHCtGyA+w4HAy6H36IyIUnDPmfJHAxCswJEVSQ=";
-      };
-      packages = {
-        servant = "servant";
-        servant-server = "servant-server";
-      };
-    };
-
     # we need HEAD, the latest release is too old
     postie = {
       src = fetchgit {

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -326,16 +326,6 @@ let
       sha256 = "sha256-afC4lQUPUL5cHe+7vTG1lFZ4wWyQzdh9MEhMT/TtP5c=";
     };
 
-    text-builder-core = {
-      version = "0.1.1.1";
-      sha256 = "sha256-BX6JRG+K1PnS3GLvpakG7rTsARfVmGLl1gTW0a4UyDo=";
-    };
-
-    text-builder = {
-      version = "1.0.0.3";
-      sha256 = "sha256-9VCOzwebs89KosOouJjFUcAgY6PF97yJnnIp4HZOK20=";
-    };
-
     network-control = {
       version = "0.1.0";
       sha256 = "sha256-D6pKb6+0Pr08FnObGbXBVMv04ys3N731p7U+GYH1oEg=";

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -272,8 +272,8 @@ let
     amazonka = {
       src = fetchgit {
         url = "https://github.com/wireapp/amazonka";
-        rev = "b482e255d1fe8f33ceced7b55aa1f6e93081dea8";
-        hash = "sha256-p/07Hge/QwMldpnqV7Ic5GRiQFoaTxzrAjhmu554J4U=";
+        rev = "d98cefc04bcc7076a915076a322ab5905c6a4945";
+        hash = "sha256-8HNHoTUaLi5lyOrKYybacZsDSHrju9/oo+Lf/YulbIo=";
       };
       packages = {
         amazonka = "lib/amazonka";

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -17,7 +17,7 @@ hself: hsuper: {
   quickcheck-state-machine = hlib.dontCheck hsuper.quickcheck-state-machine;
 
   # Tests require a running redis
-  hedis = hlib.dontCheck (hlib.doJailbreak hsuper.hedis);
+  hedis = hlib.dontCheck hsuper.hedis;
 
   HaskellNet = hlib.dontCheck hsuper.HaskellNet;
 
@@ -37,12 +37,6 @@ hself: hsuper: {
   bytestring-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.bytestring-arbitrary);
   lens-datetime = hlib.markUnbroken (hlib.doJailbreak hsuper.lens-datetime);
   postie = hlib.doJailbreak hsuper.postie;
-  polysemy-time = hlib.doJailbreak (hsuper.polysemy-time);
-  polysemy-resume = hlib.doJailbreak (hsuper.polysemy-resume);
-  polysemy-conc = hlib.doJailbreak (hsuper.polysemy-conc);
-  text-builder-core = hlib.doJailbreak hsuper.text-builder-core;
-  text-builder = hlib.doJailbreak hsuper.text-builder;
-  bitvec = hlib.doJailbreak hsuper.bitvec;
 
   # the libsodium haskell library is incompatible with the new version of the libsodium c library
   # that nixpkgs has - this downgrades libsodium from 1.0.19 to 1.0.18
@@ -76,7 +70,7 @@ hself: hsuper: {
 
   # cabal multirepl requires Cabal 3.12
   Cabal = hsuper.Cabal_3_12_1_0;
-  Cabal-syntax = hsuper.Cabal-syntax_3_12_1_0;
+  Cabal-syntax = hsuper.Cabal-syntax_3_14_2_0;
 
   text-builder = hlib.doJailbreak (hsuper.text-builder_1_0_0_4);
 
@@ -87,7 +81,7 @@ hself: hsuper: {
   cryptostore = hlib.addBuildDepends (hlib.dontCheck (hlib.appendConfigureFlags hsuper.cryptostore [ "-fuse_crypton" ]))
     [ hself.crypton hself.crypton-x509 hself.crypton-x509-validation ];
   # doJailbreak because upstreams requires a specific crypton-connection version we don't have
-  hoogle = hlib.justStaticExecutables (hlib.doJailbreak (hlib.dontCheck (hsuper.hoogle)));
+  hoogle = hlib.justStaticExecutables (hlib.dontCheck (hsuper.hoogle));
 
   # Extra dependencies/flags for local packages
   http2-manager = hlib.enableCabalFlag hsuper.http2-manager "-f-test-trailing-dot";

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -78,6 +78,7 @@ hself: hsuper: {
   Cabal = hsuper.Cabal_3_12_1_0;
   Cabal-syntax = hsuper.Cabal-syntax_3_12_1_0;
 
+  text-builder = hlib.doJailbreak (hsuper.text-builder_1_0_0_4);
 
   # -----------------
   # flags and patches

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
-        "sha256": "1vf26scmz0826g49mqclmm4pblk5gzw5d4bk9bwql0psz916ij0n",
+        "rev": "c53baa6685261e5253a1c355a1b322f82674a824",
+        "sha256": "07iy9la8yc56477q0rh6bmkcgnm57n267g19i2si5yb2j320gpj7",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b3582c75c7f21ce0b429898980eddbbf05c68e55.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c53baa6685261e5253a1c355a1b322f82674a824.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
The most exciting change is probably that we're using Servant upstream again. Servant version `0.20.3.0` contains:
- A fix to the lazy-streaming issue
- Upstreamed `MultiVerb`

(See https://hackage.haskell.org/package/servant-0.20.3.0/changelog)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
