### PR TITLE
Do not overwrite groupId when recreating a one2one

### DIFF
--- a/changelog.d/3-bug-fixes/reset-one2one
+++ b/changelog.d/3-bug-fixes/reset-one2one
@@ -1,0 +1,1 @@
+Fix bug in reset logic for one2one conversations

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -654,7 +654,10 @@ consumingMessages mlsProtocol mp = Codensity $ \k -> do
     -- at this point we know that every new user has been added to the
     -- conversation
     for_ (zip clients wss) $ \((cid, t), ws) -> case t of
-      MLSNotificationMessageTag -> void $ consumeMessageNoExternal conv.ciphersuite cid mp ws
+      MLSNotificationMessageTag ->
+        when (conv.epoch > 0) $
+          void $
+            consumeMessageNoExternal conv.ciphersuite cid mp ws
       MLSNotificationWelcomeTag -> consumeWelcome cid mp ws
     pure r
 

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -323,10 +323,20 @@ data ConvId = ConvId
   deriving (Show, Eq, Ord)
 
 convIdToQidObject :: ConvId -> Value
-convIdToQidObject convId = object [fromString "id" .= convId.id_, fromString "domain" .= convId.domain]
+convIdToQidObject convId =
+  object
+    [ fromString "id" .= convId.id_,
+      fromString "domain" .= convId.domain
+    ]
 
 instance ToJSON ConvId where
-  toJSON = convIdToQidObject
+  toJSON convId =
+    object
+      [ fromString "id" .= convId.id_,
+        fromString "domain" .= convId.domain,
+        fromString "group_id" .= convId.groupId,
+        fromString "subconv_id" .= convId.subconvId
+      ]
 
 data MLSState = MLSState
   { baseDir :: FilePath,
@@ -334,15 +344,6 @@ data MLSState = MLSState
     clientGroupState :: Map ClientIdentity ClientGroupState
   }
   deriving (Show)
-
-printMLSState :: MLSState -> String
-printMLSState MLSState {convs, clientGroupState} =
-  "MLSState {"
-    <> "convs = "
-    <> show convs
-    <> ", clientGroupState = "
-    <> show (Map.keys clientGroupState)
-    <> "}"
 
 data MLSConv = MLSConv
   { members :: Set ClientIdentity,

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra.hs
@@ -70,7 +70,8 @@ createMLSSelfConversation lusr = do
           { metadata =
               (defConversationMetadata (Just usr)) {cnvmType = SelfConv},
             users = ulFromLocals [toUserRole usr],
-            protocol = BaseProtocolMLSTag
+            protocol = BaseProtocolMLSTag,
+            groupId = Nothing
           }
       meta = nc.metadata
       gid =
@@ -119,9 +120,10 @@ createConversation lcnv nc = do
       (proto, mgid) = case nc.protocol of
         BaseProtocolProteusTag -> (ProtocolProteus, Nothing)
         BaseProtocolMLSTag ->
-          let gid =
+          let newGid =
                 newGroupId meta.cnvmType $
                   Conv <$> tUntagged lcnv
+              gid = fromMaybe newGid nc.groupId
            in ( ProtocolMLS
                   ConversationMLSData
                     { cnvmlsGroupId = gid,

--- a/libs/wire-subsystems/src/Wire/StoredConversation.hs
+++ b/libs/wire-subsystems/src/Wire/StoredConversation.hs
@@ -89,7 +89,8 @@ convReceiptMode c = c.metadata.cnvmReceiptMode
 data NewConversation = NewConversation
   { metadata :: ConversationMetadata,
     users :: UserList (UserId, RoleName),
-    protocol :: BaseProtocolTag
+    protocol :: BaseProtocolTag,
+    groupId :: Maybe GroupId
   }
 
 data MLSMigrationState

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -466,7 +466,8 @@ createProteusSelfConversation lusr = do
             NewConversation
               { metadata = (defConversationMetadata (Just (tUnqualified lusr))) {cnvmType = SelfConv},
                 users = ulFromLocals [toUserRole (tUnqualified lusr)],
-                protocol = BaseProtocolProteusTag
+                protocol = BaseProtocolProteusTag,
+                groupId = Nothing
               }
       c <- E.createConversation lcnv nc
       conversationCreated lusr c
@@ -594,7 +595,8 @@ createLegacyOne2OneConversationUnchecked self zcon name mtid other = do
         NewConversation
           { users = ulFromLocals (map (toUserRole . tUnqualified) [self, other]),
             protocol = BaseProtocolProteusTag,
-            metadata = meta
+            metadata = meta,
+            groupId = Nothing
           }
   mc <- E.getConversation (tUnqualified lcnv)
   case mc of
@@ -666,7 +668,8 @@ createOne2OneConversationLocally lcnv self zcon name mtid other = do
             NewConversation
               { metadata = meta,
                 users = fmap toUserRole (toUserList lcnv [tUntagged self, other]),
-                protocol = BaseProtocolProteusTag
+                protocol = BaseProtocolProteusTag,
+                groupId = Nothing
               }
       c <- E.createConversation lcnv nc
       notifyCreatedConversation self (Just zcon) c def
@@ -718,7 +721,8 @@ createConnectConversation lusr conn j = do
             -- when the other user accepts the connection request.
             users = ulFromLocals ([(toUserRole . tUnqualified) lusr]),
             protocol = BaseProtocolProteusTag,
-            metadata = meta
+            metadata = meta,
+            groupId = Nothing
           }
   E.getConversation (tUnqualified lcnv)
     >>= maybe (create lcnv nc) (update n)
@@ -832,7 +836,8 @@ newRegularConversation lusr newConv = do
                       else CellsDisabled
                 },
             users = newConvUsersRoles,
-            protocol = newConvProtocol newConv
+            protocol = newConvProtocol newConv,
+            groupId = Nothing
           }
   pure (nc, users)
 

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -130,10 +130,12 @@ createMLSOne2OneConversation ::
   Local MLSConversation ->
   Sem r StoredConversation
 createMLSOne2OneConversation self other lconv = do
+  let conv = tUnqualified lconv
   createConversation
     (fmap mcId lconv)
     NewConversation
-      { metadata = mcMetadata (tUnqualified lconv),
+      { metadata = mcMetadata conv,
         users = fmap (,roleNameWireMember) (toUserList lconv [self, other]),
-        protocol = BaseProtocolMLSTag
+        protocol = BaseProtocolMLSTag,
+        groupId = Just conv.mcMLSData.cnvmlsGroupId
       }

--- a/services/galley/src/Galley/API/One2One.hs
+++ b/services/galley/src/Galley/API/One2One.hs
@@ -48,7 +48,8 @@ newConnectConversationWithRemote creator users =
           { cnvmType = One2OneConv
           },
       users = fmap toUserRole users,
-      protocol = BaseProtocolProteusTag
+      protocol = BaseProtocolProteusTag,
+      groupId = Nothing
     }
 
 iUpsertOne2OneConversation ::


### PR DESCRIPTION
Fix bug in reset logic for MLS one2one conversations. The conversation groupId was being regenerated on the first commit after reset.

https://wearezeta.atlassian.net/browse/WPB-19643

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
