### PR TITLE
renovate: security updates only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
This PR configures renovate bot to perform security udpates only. Link to docs: https://docs.renovatebot.com/presets-security/#securityonly-security-updates

