### PR TITLE
 Move PostgresMarshall to wire-api 

### DIFF
--- a/libs/wire-api/src/Wire/API/PostgresMarshall.hs
+++ b/libs/wire-api/src/Wire/API/PostgresMarshall.hs
@@ -1,4 +1,4 @@
-module Wire.PostgresMarshall (PostgresMarshall (..), lmapPG) where
+module Wire.API.PostgresMarshall (PostgresMarshall (..), lmapPG) where
 
 import Data.Aeson
 import Data.Id

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -148,6 +148,7 @@ library
     Wire.API.Password
     Wire.API.Password.Argon2id
     Wire.API.Password.Scrypt
+    Wire.API.PostgresMarshall
     Wire.API.Presence
     Wire.API.Properties
     Wire.API.Provider

--- a/libs/wire-subsystems/src/Wire/AppStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/AppStore/Postgres.hs
@@ -13,9 +13,9 @@ import Imports
 import Polysemy
 import Polysemy.Error (Error)
 import Polysemy.Input
+import Wire.API.PostgresMarshall
 import Wire.AppStore
 import Wire.Postgres
-import Wire.PostgresMarshall
 
 interpretAppStoreToPostgres ::
   ( Member (Embed IO) r,

--- a/libs/wire-subsystems/src/Wire/PostgresMarshall.hs
+++ b/libs/wire-subsystems/src/Wire/PostgresMarshall.hs
@@ -12,10 +12,364 @@ instance (PostgresMarshall a1 b1, PostgresMarshall a2 b2) => PostgresMarshall (a
   postgresMarshall (a1, a2) = (postgresMarshall a1, postgresMarshall a2)
 
 instance
-  (PostgresMarshall a1 b1, PostgresMarshall a2 b2, PostgresMarshall a3 b3) =>
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3
+  ) =>
   PostgresMarshall (a1, a2, a3) (b1, b2, b3)
   where
   postgresMarshall (a1, a2, a3) = (postgresMarshall a1, postgresMarshall a2, postgresMarshall a3)
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4) (b1, b2, b3, b4)
+  where
+  postgresMarshall (a1, a2, a3, a4) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5) (b1, b2, b3, b4, b5)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6) (b1, b2, b3, b4, b5, b6)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7) (b1, b2, b3, b4, b5, b6, b7)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8) (b1, b2, b3, b4, b5, b6, b7, b8)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9) (b1, b2, b3, b4, b5, b6, b7, b8, b9)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11,
+    PostgresMarshall a12 b12
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11,
+      postgresMarshall a12
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11,
+    PostgresMarshall a12 b12,
+    PostgresMarshall a13 b13
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11,
+      postgresMarshall a12,
+      postgresMarshall a13
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11,
+    PostgresMarshall a12 b12,
+    PostgresMarshall a13 b13,
+    PostgresMarshall a14 b14
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11,
+      postgresMarshall a12,
+      postgresMarshall a13,
+      postgresMarshall a14
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11,
+    PostgresMarshall a12 b12,
+    PostgresMarshall a13 b13,
+    PostgresMarshall a14 b14,
+    PostgresMarshall a15 b15
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11,
+      postgresMarshall a12,
+      postgresMarshall a13,
+      postgresMarshall a14,
+      postgresMarshall a15
+    )
+
+instance
+  ( PostgresMarshall a1 b1,
+    PostgresMarshall a2 b2,
+    PostgresMarshall a3 b3,
+    PostgresMarshall a4 b4,
+    PostgresMarshall a5 b5,
+    PostgresMarshall a6 b6,
+    PostgresMarshall a7 b7,
+    PostgresMarshall a8 b8,
+    PostgresMarshall a9 b9,
+    PostgresMarshall a10 b10,
+    PostgresMarshall a11 b11,
+    PostgresMarshall a12 b12,
+    PostgresMarshall a13 b13,
+    PostgresMarshall a14 b14,
+    PostgresMarshall a15 b15,
+    PostgresMarshall a16 b16
+  ) =>
+  PostgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16)
+  where
+  postgresMarshall (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+    ( postgresMarshall a1,
+      postgresMarshall a2,
+      postgresMarshall a3,
+      postgresMarshall a4,
+      postgresMarshall a5,
+      postgresMarshall a6,
+      postgresMarshall a7,
+      postgresMarshall a8,
+      postgresMarshall a9,
+      postgresMarshall a10,
+      postgresMarshall a11,
+      postgresMarshall a12,
+      postgresMarshall a13,
+      postgresMarshall a14,
+      postgresMarshall a15,
+      postgresMarshall a16
+    )
 
 instance PostgresMarshall (Id a) UUID where
   postgresMarshall = toUUID

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -239,7 +239,6 @@ library
     Wire.PasswordStore
     Wire.PasswordStore.Cassandra
     Wire.Postgres
-    Wire.PostgresMarshall
     Wire.PostgresMigrations
     Wire.PropertyStore
     Wire.PropertyStore.Cassandra


### PR DESCRIPTION
Also add instances for tuples of length upto 16.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
