### PR TITLE
WPB-20203 backend updating user attributes via SCIM should be possible when E2EID is enabled

### DIFF
--- a/changelog.d/2-features/WPB-20203
+++ b/changelog.d/2-features/WPB-20203
@@ -1,0 +1,1 @@
+Allow updates of SCIM users by SCIM even if E2EID is enabled

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -938,7 +938,7 @@ testAllowUpdatesBySCIMWhenE2EIdEnabled (TaggedBool ssoEnabled) = do
           let cookie = fromJust $ getCookie "zuid" resp
           pure ("zuid=" <> cookie, token)
       newEmail <- randomEmail
-      putSelfEmail user cookie token newEmail `bindResponse` \res -> do
+      updateEmail user newEmail cookie token `bindResponse` \res -> do
         res.status `shouldMatchInt` 403
         res.json %. "label" `shouldMatch` "managed-by-scim"
 

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -812,3 +812,94 @@ testIdpUpdate = do
   -- the SCIM users can still login
   for_ uids $ \(_, email) -> do
     void $ loginWithSamlEmail True tid email idp3
+
+testAllowUpdatesBySCIMWhenE2EIdEnabled :: (HasCallStack) => App ()
+testAllowUpdatesBySCIMWhenE2EIdEnabled  = do
+  (tok, uid, su) <- setup
+
+  su1 <- checkUpdateHandle tok uid su
+  su2 <- checkUpdateDisplayName tok uid su1
+
+  -- the following should not be part of the e2eid certification, but are checked here anyway
+  su3 <- checkUpdateLocale tok uid su2
+  su4 <- checkUpdateEmail tok uid su3
+  void $ checkUpdateExternalId tok uid su4
+  where
+    setup :: App (String, String, Value)
+    setup = do
+      (owner, tid, _) <- createTeam OwnDomain 1
+      setTeamFeatureStatus owner tid "sso" "enabled" >>= assertSuccess
+      setTeamFeatureStatus owner tid "mlsE2EId" "enabled" >>= assertSuccess
+      void $ registerTestIdPWithMeta owner >>= getJSON 201
+      tok <- createScimTokenV6 owner def >>= getJSON 200 >>= (%. "token") >>= asString
+      scimUser <- randomScimUser
+      email <- scimUser %. "emails" >>= asList >>= assertOne >>= (%. "value") >>= asString
+      uid <- createScimUser OwnDomain tok scimUser >>= getJSON 201 >>= (%. "id") >>= asString
+      activateEmail OwnDomain email
+      pure (tok, uid, scimUser)
+
+    checkUpdateHandle :: (HasCallStack) => String -> String -> Value -> App Value
+    checkUpdateHandle tok uid scimUser = do
+      newHandle <- randomHandle
+      su <- setField "userName" newHandle scimUser
+      bindResponse (updateScimUser OwnDomain tok uid su) $ \res -> do
+        res.status `shouldMatchInt` 200
+        res.json %. "userName" `shouldMatch` newHandle
+      bindResponse (getUsersId OwnDomain [uid]) $ \res -> do
+        res.status `shouldMatchInt` 200
+        u <- res.json >>= asList >>= assertOne
+        u %. "handle" `shouldMatch` newHandle
+      pure su
+
+    checkUpdateDisplayName :: (HasCallStack) => String -> String -> Value -> App Value
+    checkUpdateDisplayName tok uid scimUser = do
+      let displayName = "Alice in Wonderland"
+      su <- setField "displayName" displayName scimUser
+      bindResponse (updateScimUser OwnDomain tok uid su) $ \res -> do
+        res.status `shouldMatchInt` 200
+        res.json %. "displayName" `shouldMatch` displayName
+      bindResponse (getUsersId OwnDomain [uid]) $ \res -> do
+        res.status `shouldMatchInt` 200
+        u <- res.json >>= asList >>= assertOne
+        u %. "name" `shouldMatch` displayName
+      pure su
+
+    checkUpdateLocale :: (HasCallStack) => String -> String -> Value -> App Value
+    checkUpdateLocale tok uid scimUser = do
+      su <- setField "preferredLanguage" "fr" scimUser
+      bindResponse (updateScimUser OwnDomain tok uid su) $ \res -> do
+        res.status `shouldMatchInt` 200
+        res.json %. "preferredLanguage" `shouldMatch` "fr"
+      bindResponse (getUsersId OwnDomain [uid]) $ \res -> do
+        res.status `shouldMatchInt` 200
+        u <- res.json >>= asList >>= assertOne
+        u %. "locale" `shouldMatch` "fr"
+      pure su
+
+    checkUpdateEmail :: (HasCallStack) => String -> String -> Value -> App Value
+    checkUpdateEmail tok uid scimUser = do
+      newEmail <- randomEmail
+      su <- setField "emails" [object ["value" .= newEmail]] scimUser
+      bindResponse (updateScimUser OwnDomain tok uid su) $ \res -> do
+        res.status `shouldMatchInt` 200
+        res.json %. "emails" `shouldMatch` [object ["value" .= newEmail]]
+      activateEmail OwnDomain newEmail
+      bindResponse (getUsersId OwnDomain [uid]) $ \res -> do
+        res.status `shouldMatchInt` 200
+        u <- res.json >>= asList >>= assertOne
+        u %. "email" `shouldMatch` newEmail
+      pure su
+
+    checkUpdateExternalId :: (HasCallStack) => String -> String -> Value -> App Value
+    checkUpdateExternalId tok uid scimUser = do
+      newExtId <- randomUUIDString
+      su <- setField "externalId" newExtId scimUser
+      bindResponse (updateScimUser OwnDomain tok uid su) $ \res -> do
+        res.status `shouldMatchInt` 200
+        res.json %. "externalId" `shouldMatch` newExtId
+      bindResponse (getUsersId OwnDomain [uid]) $ \res -> do
+        res.status `shouldMatchInt` 200
+        u <- res.json >>= asList >>= assertOne
+        subject <- u %. "sso_id.subject" >>= asString
+        subject `shouldContainString` newExtId
+      pure su

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -814,7 +814,7 @@ testIdpUpdate = do
     void $ loginWithSamlEmail True tid email idp3
 
 testAllowUpdatesBySCIMWhenE2EIdEnabled :: (HasCallStack) => App ()
-testAllowUpdatesBySCIMWhenE2EIdEnabled  = do
+testAllowUpdatesBySCIMWhenE2EIdEnabled = do
   (tok, uid, su) <- setup
 
   su1 <- checkUpdateHandle tok uid su

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -529,11 +529,12 @@ guardLockedFields ::
 guardLockedFields user updateOrigin (MkUserProfileUpdate {..}) = do
   let idempName = isNothing name || name == Just user.name
       idempLocale = isNothing locale || locale == user.locale
-      scim = updateOrigin == UpdateOriginWireClient && user.managedBy == Just ManagedByScim
+      scimConflict = updateOrigin == UpdateOriginWireClient && user.managedBy == Just ManagedByScim
+      updateByScim = updateOrigin == UpdateOriginScim && user.managedBy == Just ManagedByScim
   e2eid <- hasE2EId user
-  when ((scim || e2eid) && not idempName) do
+  when ((scimConflict || (e2eid && not updateByScim)) && not idempName) do
     throw UserSubsystemDisplayNameManagedByScim
-  when (scim {- e2eid does not matter, it's not part of the e2eid cert! -} && not idempLocale) do
+  when (scimConflict {- e2eid does not matter, it's not part of the e2eid cert! -} && not idempLocale) do
     throw UserSubsystemLocaleManagedByScim
 
 guardLockedHandleField ::
@@ -546,10 +547,11 @@ guardLockedHandleField ::
   Sem r ()
 guardLockedHandleField user updateOrigin handle = do
   let idemp = Just handle == user.handle
-      scim = updateOrigin == UpdateOriginWireClient && user.managedBy == Just ManagedByScim
+      scimConflict = updateOrigin == UpdateOriginWireClient && user.managedBy == Just ManagedByScim
+      updateByScim = updateOrigin == UpdateOriginScim && user.managedBy == Just ManagedByScim
       hasHandle = isJust user.handle
   e2eid <- hasE2EId user
-  when ((scim || (e2eid && hasHandle)) && not idemp) do
+  when ((scimConflict || (e2eid && hasHandle && not updateByScim)) && not idemp) do
     throw UserSubsystemHandleManagedByScim
 
 updateUserProfileImpl ::

--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -654,8 +654,8 @@ spec = describe "UserSubsystem.Interpreter" do
                       getUserProfile lusr (tUntagged lusr)
              in profileErr === Left UserSubsystemLocaleManagedByScim
 
-    prop
-      "if e2e identity is activated, the user name cannot be updated"
+    focus $ prop
+      "if e2e identity is activated, the user name cannot be updated by a wire client"
       \(NotPendingStoredUser alice) localDomain (newName :: Name) config ->
         (alice.name /= newName) ==>
           let lusr = toLocalUnsafe localDomain alice.id
@@ -676,7 +676,7 @@ spec = describe "UserSubsystem.Interpreter" do
                     )
                     config
                     do
-                      updateUserProfile lusr Nothing UpdateOriginScim (def {name = Just newName, supportedProtocols = Nothing})
+                      updateUserProfile lusr Nothing UpdateOriginWireClient (def {name = Just newName, supportedProtocols = Nothing})
                       getUserProfile lusr (tUntagged lusr)
            in profileErr === Left UserSubsystemDisplayNameManagedByScim
 

--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -654,7 +654,7 @@ spec = describe "UserSubsystem.Interpreter" do
                       getUserProfile lusr (tUntagged lusr)
              in profileErr === Left UserSubsystemLocaleManagedByScim
 
-    focus $ prop
+    prop
       "if e2e identity is activated, the user name cannot be updated by a wire client"
       \(NotPendingStoredUser alice) localDomain (newName :: Name) config ->
         (alice.name /= newName) ==>


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
