### PR TITLE
redis-ephemeral: use docker.io registry by default

### DIFF
--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -1,5 +1,6 @@
 redis-ephemeral:
   image:
+    registry: docker.io
     repository: bitnamilegacy/redis
     tag: 7.2.5
   # We use a single node redis for now.


### PR DESCRIPTION
another follow-up to #4792

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
