### PR TITLE
Some additions to SBOM creation epic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -729,9 +729,9 @@ upload-bombon: sbom.json
 # Targets should be independently executable and creating a Nix env in a Nix
 # env doesn't play well.
 
-# Generate all SBOMs (Helm + Docker Compose + Helmfile)
+# Generate all SBOMs (Helm + Docker Compose + Helmfile + Nix Docker Images)
 .PHONY: sboms
-sboms: sboms-helm sboms-docker-compose sboms-helmfile
+sboms: sboms-helm sboms-docker-compose sboms-helmfile sboms-nix-docker-images
 
 # Generate SBOMs for Helm charts
 .PHONY: sboms-helm
@@ -755,6 +755,16 @@ sboms-helmfile: .local/charts
 		exit 1; \
 	fi
 	./hack/bin/create-helmfile-sboms.sh tmp/sboms/helmfile $(HELM_SEMVER)
+
+# Generate SBOMs for Nix-built Docker images using sbomnix
+# This generates SBOMs from the Nix store paths of executables that go into Docker images
+.PHONY: sboms-nix-docker-images
+sboms-nix-docker-images:
+	@if [ "$(HELM_SEMVER)" = "0.0.42" ]; then \
+		echo "Environment variable HELM_SEMVER not set to non-default value. Re-run with HELM_SEMVER=<version>"; \
+		exit 1; \
+	fi
+	./hack/bin/create-nix-docker-image-sboms.sh tmp/sboms/nix-docker-images $(HELM_SEMVER) imagesUnoptimizedNoDocs
 
 # Validate all SBOM files using cyclonedx
 .PHONY: validate-sboms

--- a/Makefile
+++ b/Makefile
@@ -729,9 +729,9 @@ upload-bombon: sbom.json
 # Targets should be independently executable and creating a Nix env in a Nix
 # env doesn't play well.
 
-# Generate all SBOMs (Helm + Docker Compose + Helmfile + Nix Docker Images)
+# Generate all SBOMs (Helm + Docker Compose + Helmfile + Nix Docker Images + Nix DevShell)
 .PHONY: sboms
-sboms: sboms-helm sboms-docker-compose sboms-helmfile sboms-nix-docker-images
+sboms: sboms-helm sboms-docker-compose sboms-helmfile sboms-nix-docker-images sboms-nix-devshell
 
 # Generate SBOMs for Helm charts
 .PHONY: sboms-helm
@@ -765,6 +765,16 @@ sboms-nix-docker-images:
 		exit 1; \
 	fi
 	./hack/bin/create-nix-docker-image-sboms.sh tmp/sboms/nix-docker-images $(HELM_SEMVER) imagesUnoptimizedNoDocs
+
+# Generate SBOMs for Nix devShells using sbomnix
+# This generates SBOMs from the Nix store paths of packages in the development environments
+.PHONY: sboms-nix-devshell
+sboms-nix-devshell:
+	@if [ "$(HELM_SEMVER)" = "0.0.42" ]; then \
+		echo "Environment variable HELM_SEMVER not set to non-default value. Re-run with HELM_SEMVER=<version>"; \
+		exit 1; \
+	fi
+	./hack/bin/create-nix-devshell-sbom.sh tmp/sboms/nix-devshell $(HELM_SEMVER)
 
 # Validate all SBOM files using cyclonedx
 .PHONY: validate-sboms

--- a/changelog.d/5-internal/sbomnix
+++ b/changelog.d/5-internal/sbomnix
@@ -1,0 +1,1 @@
+Use sbomnix to generate SBOMs for Nix-built Docker images and devShells. Adjust Helm chart values for inlined wire-server chart.

--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,55 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746162366,
+        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -83,6 +132,54 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "sbomnix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "sbomnix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "sbomnix",
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -153,6 +250,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1772963539,
@@ -216,6 +328,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs_24_11": "nixpkgs_24_11",
         "postie": "postie",
+        "sbomnix": "sbomnix",
         "servant-openapi3": "servant-openapi3",
         "tasty": "tasty",
         "tasty-ant-xml": "tasty-ant-xml",
@@ -223,6 +336,32 @@
         "tinylog": "tinylog",
         "tom-bombadil": "tom-bombadil",
         "wai-predicates": "wai-predicates"
+      }
+    },
+    "sbomnix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1760339225,
+        "narHash": "sha256-pYZax5cxBHa+jcxTsQKEVHhXMtmvLGD1ISUyli2ZreU=",
+        "owner": "tiiuae",
+        "repo": "sbomnix",
+        "rev": "fe2a608c000127092b3d27c9cfd65c26f325bb28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "ref": "v1.7.4",
+        "repo": "sbomnix",
+        "type": "github"
       }
     },
     "servant-openapi3": {
@@ -345,6 +484,27 @@
       "original": {
         "owner": "wireapp",
         "repo": "tom-bombadil",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "sbomnix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    sbomnix = {
+      url = "github:tiiuae/sbomnix/v1.7.4";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     bloodhound = {
       url = "github:wireapp/bloodhound?ref=wire-fork";
@@ -83,7 +87,7 @@
     };
   };
 
-  outputs = inputs@{ nixpkgs, nixpkgs_24_11, nixpkgs-unstable, flake-utils, tom-bombadil, ... }:
+  outputs = inputs@{ nixpkgs, nixpkgs_24_11, nixpkgs-unstable, flake-utils, tom-bombadil, sbomnix, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -134,6 +138,7 @@
             pkgs_unstable.syft
             pkgs.kubernetes-helm
             pkgs.helmfile
+            sbomnix.packages.${system}.default
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             # Linux-only container tools
             pkgs.skopeo

--- a/hack/bin/create-helm-sboms.sh
+++ b/hack/bin/create-helm-sboms.sh
@@ -33,10 +33,35 @@ extract_images_from_chart() {
   fi
 
   # Template the chart and extract image references
-  # We use a dummy release name and set a global placeholder to be more lenient
+  # For wire-server and wire-server-enterprise, provide minimal values to pass required checks
   # (we don't want to check the Helm chart, only extract its images)
   local output
-  output=$(helm template test-release "$chart_path" --set-string 'global.placeholder=placeholder' 2>/dev/null) || true
+  if [[ "$chart_name" == "wire-server" ]]; then
+    local tmpval=$(mktemp --suffix=.yaml)
+    cat > "$tmpval" <<'EOF'
+nginz: {secrets: {zAuth: {publicKeys: placeholder}, basicAuth: placeholder}}
+brig:
+  secrets: {zAuth: {privateKeys: placeholder, publicKeys: placeholder}, turn: {secret: placeholder}, rabbitmq: {username: placeholder, password: placeholder}}
+  config:
+    aws: {sesQueue: placeholder}
+    externalUrls: {nginz: 'https://placeholder'}
+cargohold: {secrets: {placeholder: placeholder}}
+background-worker: {secrets: {rabbitmq: {username: placeholder, password: placeholder}}}
+proxy: {secrets: {proxy_config: placeholder}}
+cannon: {secrets: {rabbitmq: {username: placeholder, password: placeholder}}}
+gundeck: {secrets: {rabbitmq: {username: placeholder, password: placeholder}}}
+cassandra-migrations: {cassandra: {host: placeholder}}
+elasticsearch-index: {elasticsearch: {host: placeholder}, cassandra: {host: placeholder}}
+spar: {config: {appUri: 'https://placeholder', ssoUri: 'https://placeholder', contacts: [placeholder]}}
+galley: {config: {settings: {conversationCodeURI: 'https://placeholder'}}, secrets: {rabbitmq: {username: placeholder, password: placeholder}}}
+EOF
+    output=$(helm template test-release "$chart_path" -f "$tmpval")
+    rm -f "$tmpval"
+  elif [[ "$chart_name" == "wire-server-enterprise" ]]; then
+    output=$(helm template test-release "$chart_path" --set 'secrets.placeholder=placeholder')
+  else
+    output=$(helm template test-release "$chart_path")
+  fi
 
   # Extract image values from the output using yq (jq wrapper)
   # Recursively find all .image fields in objects and output unique values

--- a/hack/bin/create-helm-sboms.sh
+++ b/hack/bin/create-helm-sboms.sh
@@ -37,7 +37,8 @@ extract_images_from_chart() {
   # (we don't want to check the Helm chart, only extract its images)
   local output
   if [[ "$chart_name" == "wire-server" ]]; then
-    local tmpval=$(mktemp --suffix=.yaml)
+    local tmpval
+    tmpval=$(mktemp --suffix=.yaml)
     cat > "$tmpval" <<'EOF'
 nginz: {secrets: {zAuth: {publicKeys: placeholder}, basicAuth: placeholder}}
 brig:

--- a/hack/bin/create-nix-devshell-sbom.sh
+++ b/hack/bin/create-nix-devshell-sbom.sh
@@ -7,19 +7,12 @@ GIT_ROOT="$(git rev-parse --show-toplevel)"
 
 OUTPUT_DIR_BASE="${1:-.}"
 VERSION="${2:-}"
-IMAGES_ATTR="${3:-imagesNoDocs}"
 
 if [[ -z "$VERSION" ]]; then
-  echo "Usage: $0 <output-dir-base> <version> [images-attr]"
+  echo "Usage: $0 <output-dir-base> <version>"
   echo "  output-dir-base: Base directory to write SBOM files"
   echo "                   Will create subdirectories: runtime/ and buildtime/"
   echo "  version:         Version to use for SBOMs (e.g., 5.28.22)"
-  echo "  images-attr:     Nix attribute for images (default: imagesNoDocs)"
-  echo ""
-  echo "Available image attributes:"
-  echo "  - imagesNoDocs (production images, optimized)"
-  echo "  - imagesUnoptimizedNoDocs (dev images, faster builds)"
-  echo "  - images (full images with docs)"
   exit 1
 fi
 
@@ -31,18 +24,21 @@ mkdir -p "$OUTPUT_DIR_RUNTIME" "$OUTPUT_DIR_BUILDTIME"
 # Get current git commit hash for linking to source
 GIT_COMMIT=$(git rev-parse HEAD)
 
+# Get system architecture for the flake reference
+SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+
 # Track errors during processing
 error_count=0
 
-# Function to generate SBOM with metadata and conversion
-# Parameters: flake_ref, output_file, docker_image, oci_purl, sbom_type
+# Function to generate SBOM with metadata and convert it
+# Parameters: flake_ref, output_file, component_name, purl, sbom_type
 #   sbom_type must be either "runtime" or "buildtime"
 # Uses global variables: VERSION, GIT_COMMIT
 generate_sbom() {
   local flake_ref="$1"
   local output_file="$2"
-  local docker_image="$3"
-  local oci_purl="$4"
+  local component_name="$3"
+  local purl="$4"
   local sbom_type="$5"
 
   # Validate sbom_type parameter
@@ -69,8 +65,8 @@ generate_sbom() {
     local source_url="https://github.com/wireapp/wire-server/tree/${GIT_COMMIT}"
 
     # Remove invalid CPEs (those with empty version fields) and add our metadata
-    jq --arg docker_image "$docker_image" \
-       --arg oci_purl "$oci_purl" \
+    jq --arg component_name "$component_name" \
+       --arg purl "$purl" \
        --arg source_url "$source_url" \
        --arg version "$VERSION" \
        '# Remove CPE from metadata.component if it has empty version (::)
@@ -78,10 +74,10 @@ generate_sbom() {
           .metadata.component |= del(.cpe)
         else . end |
         # Add our metadata
+        .metadata.component.name = $component_name |
         .metadata.component.version = $version |
-        .metadata.component.purl = $oci_purl |
+        .metadata.component.purl = $purl |
         .metadata.component.externalReferences += [
-          {"type": "distribution", "url": ("docker://" + $docker_image), "comment": "Docker image"},
           {"type": "vcs", "url": $source_url, "comment": "Source repository"}
         ]' \
        "$output_file" > "$temp_file"
@@ -101,44 +97,44 @@ generate_sbom() {
   return 1
 }
 
-echo "Generating SBOMs for Nix-built Docker images..."
-echo "Images attribute: $IMAGES_ATTR"
+echo "Generating SBOMs for Nix devShells..."
 echo "Version: $VERSION"
+echo "System: $SYSTEM"
 echo "Output directory (runtime): $OUTPUT_DIR_RUNTIME"
 echo "Output directory (buildtime): $OUTPUT_DIR_BUILDTIME"
 echo ""
 
-# Get list of image names from the imagesNoDocs attrset (excluding 'all')
-echo "Discovering images from $IMAGES_ATTR..."
-mapfile -t image_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#wireServer.${IMAGES_ATTR}" --apply 'images: builtins.concatStringsSep "\n" (builtins.filter (name: name != "all") (builtins.attrNames images))' --raw 2>&1 | grep -v warning)
+# Get list of devShell names from the devShells attrset
+echo "Discovering devShells..."
+mapfile -t devshell_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#devShells.${SYSTEM}" --apply 'shells: builtins.concatStringsSep "\n" (builtins.attrNames shells)' --raw 2>&1 | grep -v warning)
 
-echo "Found ${#image_names[@]} images to process"
+echo "Found ${#devshell_names[@]} devShells to process"
 echo ""
 
-# Process each image
-for image_name in "${image_names[@]}"; do
+# Process each devShell
+for devshell_name in "${devshell_names[@]}"; do
   # Skip empty lines
-  [[ -z "$image_name" ]] && continue
+  [[ -z "$devshell_name" ]] && continue
 
-  echo "Processing image: $image_name"
+  echo "Processing devShell: $devshell_name"
 
-  # Create flake reference for the image
-  flake_ref="$GIT_ROOT#wireServer.${IMAGES_ATTR}.${image_name}"
+  # Create flake reference for the devShell
+  flake_ref="$GIT_ROOT#devShells.${SYSTEM}.${devshell_name}"
   echo "  Flake reference: $flake_ref"
 
-  # Create docker image reference and metadata
-  docker_image="quay.io/wire/${image_name}:${VERSION}"
-  oci_purl="pkg:oci/wire-${image_name}@${VERSION}?repository_url=quay.io/wire"
+  # Create component metadata
+  component_name="wire-server-devshell-${devshell_name}"
+  purl="pkg:nix/wire-server/${devshell_name}@${VERSION}"
 
   # Generate runtime-only SBOM
-  runtime_output_file="$OUTPUT_DIR_RUNTIME/sbom-nix-docker-${image_name}.${VERSION}.cyclonedx.json"
-  if ! generate_sbom "$flake_ref" "$runtime_output_file" "$docker_image" "$oci_purl" "runtime"; then
+  runtime_output_file="$OUTPUT_DIR_RUNTIME/sbom-nix-devshell-${devshell_name}.${VERSION}.cyclonedx.json"
+  if ! generate_sbom "$flake_ref" "$runtime_output_file" "$component_name" "$purl" "runtime"; then
     ((error_count++))
   fi
 
   # Generate buildtime SBOM (includes build dependencies)
-  buildtime_output_file="$OUTPUT_DIR_BUILDTIME/sbom-nix-docker-${image_name}.${VERSION}.cyclonedx.json"
-  if ! generate_sbom "$flake_ref" "$buildtime_output_file" "$docker_image" "$oci_purl" "buildtime"; then
+  buildtime_output_file="$OUTPUT_DIR_BUILDTIME/sbom-nix-devshell-${devshell_name}.${VERSION}.cyclonedx.json"
+  if ! generate_sbom "$flake_ref" "$buildtime_output_file" "$component_name" "$purl" "buildtime"; then
     ((error_count++))
   fi
 
@@ -148,7 +144,7 @@ done
 echo "SBOM generation complete."
 echo "Runtime SBOMs:   $OUTPUT_DIR_RUNTIME"
 echo "Buildtime SBOMs: $OUTPUT_DIR_BUILDTIME"
-echo "Total images processed: ${#image_names[@]}"
+echo "Total devShells processed: ${#devshell_names[@]}"
 
 if [[ $error_count -gt 0 ]]; then
   echo "WARNING: $error_count error(s) occurred during SBOM generation" >&2

--- a/hack/bin/create-nix-docker-image-sboms.sh
+++ b/hack/bin/create-nix-docker-image-sboms.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Find git repository root to ensure paths work regardless of where script is executed
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+
+OUTPUT_DIR_BASE="${1:-.}"
+VERSION="${2:-}"
+IMAGES_ATTR="${3:-imagesNoDocs}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <output-dir-base> <version> [images-attr]"
+  echo "  output-dir-base: Base directory to write SBOM files"
+  echo "                   Will create subdirectories: runtime/ and buildtime/"
+  echo "  version:         Version to use for SBOMs (e.g., 5.28.22)"
+  echo "  images-attr:     Nix attribute for images (default: imagesNoDocs)"
+  echo ""
+  echo "Available image attributes:"
+  echo "  - imagesNoDocs (production images, optimized)"
+  echo "  - imagesUnoptimizedNoDocs (dev images, faster builds)"
+  echo "  - images (full images with docs)"
+  exit 1
+fi
+
+# Create separate directories for runtime and buildtime SBOMs
+OUTPUT_DIR_RUNTIME="$OUTPUT_DIR_BASE/runtime"
+OUTPUT_DIR_BUILDTIME="$OUTPUT_DIR_BASE/buildtime"
+mkdir -p "$OUTPUT_DIR_RUNTIME" "$OUTPUT_DIR_BUILDTIME"
+
+# Get current git commit hash for linking to source
+GIT_COMMIT=$(git rev-parse HEAD)
+
+# Track errors during processing
+error_count=0
+
+# Function to generate SBOM with metadata and conversion
+# Parameters: flake_ref, output_file, docker_image, oci_purl, sbom_type
+#   sbom_type must be either "runtime" or "buildtime"
+# Uses global variables: VERSION, GIT_COMMIT
+generate_sbom() {
+  local flake_ref="$1"
+  local output_file="$2"
+  local docker_image="$3"
+  local oci_purl="$4"
+  local sbom_type="$5"
+
+  # Validate sbom_type parameter
+  if [[ "$sbom_type" != "runtime" && "$sbom_type" != "buildtime" ]]; then
+    echo "  ERROR: Invalid sbom_type '$sbom_type'. Must be 'runtime' or 'buildtime'" >&2
+    return 1
+  fi
+
+  echo "  Generating $sbom_type SBOM..."
+
+  # Build sbomnix command with buildtime flag if needed
+  local sbomnix_cmd="sbomnix \"$flake_ref\" --verbose 1"
+  [[ "$sbom_type" == "buildtime" ]] && sbomnix_cmd="$sbomnix_cmd --buildtime"
+  sbomnix_cmd="$sbomnix_cmd --cdx=\"$output_file\""
+
+  if ! eval "$sbomnix_cmd" 2>&1; then
+    echo "  ERROR: sbomnix ($sbom_type) failed" >&2
+    return 1
+  fi
+
+  # Add metadata and convert to v1.6
+  if [[ -f "$output_file" ]]; then
+    local temp_file="${output_file}.tmp"
+    local source_url="https://github.com/wireapp/wire-server/tree/${GIT_COMMIT}"
+
+    # Remove invalid CPEs (those with empty version fields) and add our metadata
+    jq --arg docker_image "$docker_image" \
+       --arg oci_purl "$oci_purl" \
+       --arg source_url "$source_url" \
+       --arg version "$VERSION" \
+       '# Remove CPE from metadata.component if it has empty version (::)
+        if .metadata.component.cpe and (.metadata.component.cpe | contains("::")) then
+          .metadata.component |= del(.cpe)
+        else . end |
+        # Add our metadata
+        .metadata.component.version = $version |
+        .metadata.component.purl = $oci_purl |
+        .metadata.component.externalReferences += [
+          {"type": "distribution", "url": ("docker://" + $docker_image), "comment": "Docker image"},
+          {"type": "vcs", "url": $source_url, "comment": "Source repository"}
+        ]' \
+       "$output_file" > "$temp_file"
+    mv "$temp_file" "$output_file"
+
+    # Convert to CycloneDX 1.6
+    cyclonedx convert --input-file "$output_file" --output-file "$temp_file" --output-format json --output-version v1_6 2>&1 | grep -v "^$" || true
+    if [[ -f "$temp_file" ]]; then
+      mv "$temp_file" "$output_file"
+    fi
+
+    echo "  ✓ $sbom_type SBOM created: $output_file"
+    return 0
+  fi
+
+  return 1
+}
+
+echo "Generating SBOMs for Nix-built Docker images..."
+echo "Images attribute: $IMAGES_ATTR"
+echo "Version: $VERSION"
+echo "Output directory (runtime): $OUTPUT_DIR_RUNTIME"
+echo "Output directory (buildtime): $OUTPUT_DIR_BUILDTIME"
+echo ""
+
+# Get list of image names from the imagesNoDocs attrset (excluding 'all')
+echo "Discovering images from $IMAGES_ATTR..."
+mapfile -t image_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#wireServer.${IMAGES_ATTR}" --apply 'images: builtins.concatStringsSep "\n" (builtins.filter (name: name != "all") (builtins.attrNames images))' --raw 2>&1 | grep -v warning)
+
+echo "Found ${#image_names[@]} images to process"
+echo ""
+
+# Process each image
+for image_name in "${image_names[@]}"; do
+  # Skip empty lines
+  [[ -z "$image_name" ]] && continue
+
+  echo "Processing image: $image_name"
+
+  # Create flake reference for the image
+  flake_ref="$GIT_ROOT#wireServer.${IMAGES_ATTR}.${image_name}"
+  echo "  Flake reference: $flake_ref"
+
+  # Create docker image reference and metadata
+  docker_image="quay.io/wire/${image_name}:${VERSION}"
+  oci_purl="pkg:oci/wire-${image_name}@${VERSION}?repository_url=quay.io/wire"
+
+  # Generate runtime-only SBOM
+  runtime_output_file="$OUTPUT_DIR_RUNTIME/sbom-nix-docker-${image_name}.${VERSION}.cyclonedx.json"
+  if ! generate_sbom "$flake_ref" "$runtime_output_file" "$docker_image" "$oci_purl" "runtime"; then
+    ((error_count++))
+  fi
+
+  # Generate buildtime SBOM (includes build dependencies)
+  buildtime_output_file="$OUTPUT_DIR_BUILDTIME/sbom-nix-docker-${image_name}.${VERSION}.cyclonedx.json"
+  if ! generate_sbom "$flake_ref" "$buildtime_output_file" "$docker_image" "$oci_purl" "buildtime"; then
+    ((error_count++))
+  fi
+
+  echo ""
+done
+
+echo "SBOM generation complete."
+echo "Runtime SBOMs:   $OUTPUT_DIR_RUNTIME"
+echo "Buildtime SBOMs: $OUTPUT_DIR_BUILDTIME"
+echo "Total images processed: ${#image_names[@]}"
+
+if [[ $error_count -gt 0 ]]; then
+  echo "WARNING: $error_count error(s) occurred during SBOM generation" >&2
+  exit 1
+fi

--- a/hack/bin/upload-all-sboms.sh
+++ b/hack/bin/upload-all-sboms.sh
@@ -83,4 +83,30 @@ else
   echo "Skipping Nix Docker Images SBOMs (buildtime) (directory not found)"
 fi
 
+if [[ -d "$SBOMS_DIR/nix-devshell/runtime" ]]; then
+  echo "Uploading Nix devShell SBOMs (runtime dependencies)..."
+  find "$SBOMS_DIR/nix-devshell/runtime" -name '*.json' -type f 2>/dev/null | while read -r sbom; do
+    # Extract devShell name from filename: sbom-nix-devshell-{name}.{version}.cyclonedx.json
+    devshell_name=$(basename "$sbom" | sed 's/sbom-nix-devshell-//' | sed 's/\.[0-9].*//' | sed 's/\.cyclonedx\.json$//')
+    # Add [runtime] to make project name unique
+    project_prefix="devshell-$devshell_name [runtime]"
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "nix-devshell-runtime" "$PROJECT_NAME" "$VERSION" "$project_prefix" || exit 1
+  done
+else
+  echo "Skipping Nix devShell SBOMs (runtime) (directory not found)"
+fi
+
+if [[ -d "$SBOMS_DIR/nix-devshell/buildtime" ]]; then
+  echo "Uploading Nix devShell SBOMs (buildtime dependencies)..."
+  find "$SBOMS_DIR/nix-devshell/buildtime" -name '*.json' -type f 2>/dev/null | while read -r sbom; do
+    # Extract devShell name from filename: sbom-nix-devshell-{name}.{version}.cyclonedx.json
+    devshell_name=$(basename "$sbom" | sed 's/sbom-nix-devshell-//' | sed 's/\.[0-9].*//' | sed 's/\.cyclonedx\.json$//')
+    # Add [buildtime] to make project name unique
+    project_prefix="devshell-$devshell_name [buildtime]"
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "nix-devshell-buildtime" "$PROJECT_NAME" "$VERSION" "$project_prefix" || exit 1
+  done
+else
+  echo "Skipping Nix devShell SBOMs (buildtime) (directory not found)"
+fi
+
 echo "✓ All SBOMs uploaded successfully"

--- a/hack/bin/upload-all-sboms.sh
+++ b/hack/bin/upload-all-sboms.sh
@@ -28,21 +28,59 @@ SBOMS_DIR="$GIT_ROOT/tmp/sboms"
 
 SCRIPT_DIR="$(dirname "$0")"
 
-echo "Uploading Helm SBOMs..."
-find "$SBOMS_DIR/helm" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
-  chart_purl=$(jq -r '.metadata.component.externalReferences[] | select(.comment == "Helm chart") | .url' "$sbom")
-  chart_name=$(echo "$chart_purl" | sed 's|pkg:helm/||' | cut -d'@' -f1)
-  "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "Helm charts" "$PROJECT_NAME" "$VERSION" "$chart_name" || exit 1
-done
+if [[ -d "$SBOMS_DIR/helm" ]]; then
+  echo "Uploading Helm SBOMs..."
+  find "$SBOMS_DIR/helm" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
+    chart_purl=$(jq -r '.metadata.component.externalReferences[] | select(.comment == "Helm chart") | .url' "$sbom")
+    chart_name=$(echo "$chart_purl" | sed 's|pkg:helm/||' | cut -d'@' -f1)
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "Helm charts" "$PROJECT_NAME" "$VERSION" "$chart_name" || exit 1
+  done
+else
+  echo "Skipping Helm SBOMs (directory not found)"
+fi
 
-echo "Uploading Helmfile SBOMs..."
-find "$SBOMS_DIR/helmfile" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
-  "$SCRIPT_DIR/upload-sbom.sh" "$sbom" helmfile "$PROJECT_NAME" "$VERSION" || exit 1
-done
+if [[ -d "$SBOMS_DIR/helmfile" ]]; then
+  echo "Uploading Helmfile SBOMs..."
+  find "$SBOMS_DIR/helmfile" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" helmfile "$PROJECT_NAME" "$VERSION" || exit 1
+  done
+else
+  echo "Skipping Helmfile SBOMs (directory not found)"
+fi
 
-echo "Uploading Docker Compose SBOMs..."
-find "$SBOMS_DIR/docker-compose" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
-  "$SCRIPT_DIR/upload-sbom.sh" "$sbom" docker-compose "$PROJECT_NAME" "$VERSION" || exit 1
-done
+if [[ -d "$SBOMS_DIR/docker-compose" ]]; then
+  echo "Uploading Docker Compose SBOMs..."
+  find "$SBOMS_DIR/docker-compose" -name '*.json' -type f -not -path '*/.oci-cache/*' 2>/dev/null | while read -r sbom; do
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" docker-compose "$PROJECT_NAME" "$VERSION" || exit 1
+  done
+else
+  echo "Skipping Docker Compose SBOMs (directory not found)"
+fi
+
+if [[ -d "$SBOMS_DIR/nix-docker-images/runtime" ]]; then
+  echo "Uploading Nix Docker Images SBOMs (runtime dependencies)..."
+  find "$SBOMS_DIR/nix-docker-images/runtime" -name '*.json' -type f 2>/dev/null | while read -r sbom; do
+    # Extract image name from filename: sbom-nix-docker-{name}.{version}.cyclonedx.json
+    image_name=$(basename "$sbom" | sed 's/sbom-nix-docker-//' | sed 's/\.[0-9].*//' | sed 's/\.cyclonedx\.json$//')
+    # Add [runtime] to make project name unique
+    project_prefix="$image_name [runtime]"
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "nix-docker-runtime" "$PROJECT_NAME" "$VERSION" "$project_prefix" || exit 1
+  done
+else
+  echo "Skipping Nix Docker Images SBOMs (runtime) (directory not found)"
+fi
+
+if [[ -d "$SBOMS_DIR/nix-docker-images/buildtime" ]]; then
+  echo "Uploading Nix Docker Images SBOMs (buildtime dependencies)..."
+  find "$SBOMS_DIR/nix-docker-images/buildtime" -name '*.json' -type f 2>/dev/null | while read -r sbom; do
+    # Extract image name from filename: sbom-nix-docker-{name}.{version}.cyclonedx.json
+    image_name=$(basename "$sbom" | sed 's/sbom-nix-docker-//' | sed 's/\.[0-9].*//' | sed 's/\.cyclonedx\.json$//')
+    # Add [buildtime] to make project name unique
+    project_prefix="$image_name [buildtime]"
+    "$SCRIPT_DIR/upload-sbom.sh" "$sbom" "nix-docker-buildtime" "$PROJECT_NAME" "$VERSION" "$project_prefix" || exit 1
+  done
+else
+  echo "Skipping Nix Docker Images SBOMs (buildtime) (directory not found)"
+fi
 
 echo "✓ All SBOMs uploaded successfully"


### PR DESCRIPTION
Use `sbomnix` to create SBOMs for Nix-generated docker images and flake `devShell`s. (It's much better than tom-bombadil regarding speed and completeness.)

Also, adjust the Helm template-ing after inlining other charts into `wire-server`.

The result of the whole workflow can be seen here: https://deptrack.wire.link/projects/1ac04e80-0376-413c-a26b-5ac0dd857338/collectionprojects

Ticket: https://wearezeta.atlassian.net/browse/WPB-20616

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
