### PR TITLE
WPB-24549: fix older AMD CPU support

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,11 @@
 self: super: {
 
+  stdenv = super.overrideCC super.stdenv (super.gcc.override {
+    targetPlatform = super.targetPlatform // {
+      platform.gcc.arch = "x86-64-v3";
+    };
+  });
+
   zauth = self.callPackage ./pkgs/zauth { };
   mls-test-cli = self.callPackage ./pkgs/mls-test-cli { };
 


### PR DESCRIPTION
Following v5.5.0 -> v5.25.0 upgrade, brig crashed on `AMD EPYC 7282` CPU (exposed on `kubernetes2`/`kubernetes3`, see [JIRA
 Ticket](https://wearezeta.atlassian.net/browse/WPB-24549)).

It seems that, since GHC 9.8.1, GHC is more aggressively optimizing for the underlying CPU architecture, the CI build machines being more recent, it prevents older CPUs to run the generated binaries.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
