### PR TITLE
nginx-ingress-services: fix ingress class check

### DIFF
--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "nginx-ingress-services.getIngressName" . | quote }}
   {{- if .Values.config.renderCSPInIngress }}
   annotations:
-    {{- if not (contains .Values.config.ingressClass "nginx") }}
+    {{- if not (hasPrefix "nginx" .Values.config.ingressClass) }}
         {{ fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}
     {{- end }}
     {{/* We need to add CSP headers here for webapp, team-settings and


### PR DESCRIPTION
we want to check substrings the right way round (does the ingressClass contain 'nginx' - function arguments were given the wrong way around)

Related to https://wearezeta.atlassian.net/browse/WPB-22002 (bug occurs when trying to configure multi-ingress)

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
