### PR TITLE
WPB-24490 users can escape sso via password reset

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-24490
+++ b/changelog.d/3-bug-fixes/WPB-24490
@@ -1,0 +1,1 @@
+Prevent password reset for SAML users

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -23,6 +23,7 @@ import API.Brig as Brig
 import API.BrigInternal as BrigInternal
 import API.Common (defPassword, randomDomain, randomEmail, randomExternalId, randomHandle)
 import API.GalleyInternal (setTeamFeatureStatus)
+import qualified API.Nginz as Nginz
 import API.Spar
 import API.SparInternal
 import Control.Lens (to, (^.))
@@ -1400,3 +1401,26 @@ testAllowUpdatesBySCIMWhenE2EIdEnabled (TaggedBool ssoEnabled) = do
       pure su
 
 -- @END
+
+testNoPasswordResetForSAMLUSer :: (HasCallStack) => App ()
+testNoPasswordResetForSAMLUSer = do
+  (owner, tid, _) <- createTeam OwnDomain 1
+  void $ setTeamFeatureStatus owner tid "sso" "enabled"
+  void $ setTeamFeatureStatus owner tid "validateSAMLemails" "enabled"
+  (idp, _) <- registerTestIdPWithMetaWithPrivateCreds owner
+  idpId <- asString $ idp.json %. "id"
+  tok <- createScimToken owner def {idp = Just idpId} >>= getJSON 200 >>= (%. "token") >>= asString
+  scimUser <- randomScimUser
+  email <- scimUser %. "emails" >>= asList >>= assertOne >>= (%. "value") >>= asString
+  _uid <- createScimUser OwnDomain tok scimUser >>= getJSON 201 >>= (%. "id") >>= asString
+  activateEmail OwnDomain email
+  -- login with password should fail
+  Nginz.login OwnDomain email defPassword `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 403
+  -- password reset returns 201 always to not leak any account information
+  passwordReset OwnDomain email `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 201
+  -- however no password reset code and key should be generated
+  getPasswordResetCode OwnDomain email `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 400
+    resp.json %. "label" `shouldMatch` "invalid-key"

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -1402,8 +1402,8 @@ testAllowUpdatesBySCIMWhenE2EIdEnabled (TaggedBool ssoEnabled) = do
 
 -- @END
 
-testNoPasswordResetForSAMLUSer :: (HasCallStack) => App ()
-testNoPasswordResetForSAMLUSer = do
+testNoPasswordResetForSAMLUser :: (HasCallStack) => App ()
+testNoPasswordResetForSAMLUser = do
   (owner, tid, _) <- createTeam OwnDomain 1
   void $ setTeamFeatureStatus owner tid "sso" "enabled"
   void $ setTeamFeatureStatus owner tid "validateSAMLemails" "enabled"

--- a/libs/wire-subsystems/src/Wire/AuthenticationSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/AuthenticationSubsystem/Interpreter.hs
@@ -325,6 +325,10 @@ resetPasswordImpl ident code pw = do
   case muid of
     Nothing -> throw AuthenticationSubsystemInvalidPasswordResetCode
     Just uid -> do
+      localUnit <- inputs (.local)
+      mUser <- User.getAccountNoFilter (qualifyAs localUnit uid)
+      when (maybe False isSamlUser mUser) $
+        throw AuthenticationSubsystemInvalidPasswordResetCode
       let rateLimitKey = RateLimitUser uid
       Log.debug $ field "user" (toByteString uid) . field "action" (val "User.completePasswordReset")
       checkNewIsDifferent uid pw

--- a/libs/wire-subsystems/src/Wire/AuthenticationSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/AuthenticationSubsystem/Interpreter.hs
@@ -123,12 +123,14 @@ data PasswordResetError
   = AllowListError
   | InvalidResetKey
   | InProgress
+  | SAMLUserNotAllowed
   deriving (Show)
 
 instance Exception PasswordResetError where
   displayException AllowListError = "email domain is not allowed for password reset"
   displayException InvalidResetKey = "invalid reset key for password reset"
   displayException InProgress = "password reset already in progress"
+  displayException SAMLUserNotAllowed = "SAML users are not allowed to reset password"
 
 authenticateEitherImpl ::
   ( Member UserStore r,
@@ -216,7 +218,7 @@ createPasswordResetCodeImpl target =
     user <- lookupActiveUserByUserKey target >>= maybe (throw InvalidResetKey) pure
     let uid = userId user
     Log.debug $ field "user" (toByteString uid) . field "action" (val "User.beginPasswordReset")
-
+    when (isSamlUser user) $ throw SAMLUserNotAllowed
     mExistingCode <- lookupPasswordResetCode uid
     when (isJust mExistingCode) $
       throw InProgress

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -414,7 +414,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             Right newPasswordVerification =

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -412,6 +412,31 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               Left err ->
                 counterexample ("expected Right Nothing, got Left: " <> show err) False
 
+    prop "issued reset code is rejected if user becomes SAML before completion" $
+      \email userNoEmail samlUserRef oldPassword newPassword ->
+        let user =
+              userNoEmail
+                { email = Just email,
+                  emailUnvalidated = Nothing,
+                  status = Just Active,
+                  ssoId = Nothing,
+                  activated = True
+                }
+            uid = user.id
+            passwords = Map.singleton uid $ hashPassword oldPassword
+            Right (oldPasswordVerification, newPasswordVerification, resetPasswordResult) =
+              runAllEffects testDomain [user] passwords Nothing $ do
+                createPasswordResetCode (mkEmailKey email)
+                (_, resetCode) <- expect1ResetPasswordEmail email
+                void $ updateSSOId uid (Just (UserSSOId samlUserRef))
+                mCaughtExc <- catchExpectedError $ resetPassword (PasswordResetEmailIdentity email) resetCode newPassword
+                (,,mCaughtExc)
+                  <$> verifyUserPassword uid (toInputPassword oldPassword)
+                  <*> verifyUserPassword uid (toInputPassword newPassword)
+         in resetPasswordResult === Just AuthenticationSubsystemInvalidPasswordResetCode
+              .&&. fst oldPasswordVerification === True
+              .&&. fst newPasswordVerification === False
+
   describe "internalLookupPasswordResetCode" do
     prop "should find password reset code by email" $
       \email userNoEmail newPassword ->

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -161,14 +161,15 @@ toInputPassword pw8 =
 
 spec :: Spec
 spec = describe "AuthenticationSubsystem.Interpreter" do
-  describe "password reset" do
+  focus $ describe "password reset" do
     prop "password reset should work with the email being used as password reset key" $
       \email userNoEmail (cookiesWithTTL :: [(Cookie (), Maybe TTL)]) mPreviousPassword newPassword ->
         let user =
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             passwords = foldMap (Map.singleton uid . hashPassword) mPreviousPassword
@@ -196,7 +197,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             passwords = foldMap (Map.singleton uid . hashPassword) mPreviousPassword
@@ -228,7 +230,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             createPasswordResetCodeResult =
               runAllEffects testDomain [user] mempty (Just [decodeUtf8 $ domainPart email]) $
@@ -264,7 +267,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             Right (newPasswordVerification, mCaughtException) =
@@ -287,7 +291,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             passwords = Map.singleton uid $ hashPassword oldPassword
@@ -332,7 +337,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             passwords = Map.singleton uid $ hashPassword oldPassword
@@ -353,7 +359,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               userNoEmail
                 { email = Just email,
                   emailUnvalidated = Nothing,
-                  status = Just Active
+                  status = Just Active,
+                  ssoId = Nothing
                 }
             uid = user.id
             passwords = Map.singleton uid $ hashPassword oldPassword
@@ -383,6 +390,22 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               wrongResetErrors == replicate wrongResetAttempts (Just AuthenticationSubsystemInvalidPasswordResetCode)
                 .&&. resetPassworedWithCorectCodeResult === expectedFinalResetResult
                 .&&. assertPasswordVerification
+    prop "reset code not generated for SAML user" $
+      \email userNoEmail samlUserRef ->
+        let user =
+              userNoEmail
+                { email = Just email,
+                  emailUnvalidated = Nothing,
+                  status = Just Active,
+                  ssoId = Just (UserSSOId samlUserRef),
+                  activated = True
+                }
+            createPasswordResetCodeResult =
+              runAllEffects testDomain [user] mempty Nothing $
+                createPasswordResetCode (mkEmailKey email)
+                  <* expectNoEmailSent
+         in counterexample ("expected Right, got: " <> show createPasswordResetCodeResult) $
+              isRight createPasswordResetCodeResult
 
   describe "internalLookupPasswordResetCode" do
     prop "should find password reset code by email" $

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -409,8 +409,8 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
               Right Nothing -> property True
               Right mResetCode ->
                 counterexample ("expected no stored password reset code, got: " <> show mResetCode) False
-              Left err ->
-                counterexample ("expected Right Nothing, got Left: " <> show err) False
+              Left e ->
+                counterexample ("expected Right Nothing, got Left: " <> show e) False
 
     prop "issued reset code is rejected if user becomes SAML before completion" $
       \email userNoEmail samlUserRef oldPassword newPassword ->

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -161,7 +161,7 @@ toInputPassword pw8 =
 
 spec :: Spec
 spec = describe "AuthenticationSubsystem.Interpreter" do
-  focus $ describe "password reset" do
+  describe "password reset" do
     prop "password reset should work with the email being used as password reset key" $
       \email userNoEmail (cookiesWithTTL :: [(Cookie (), Maybe TTL)]) mPreviousPassword newPassword ->
         let user =

--- a/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AuthenticationSubsystem/InterpreterSpec.hs
@@ -401,11 +401,16 @@ spec = describe "AuthenticationSubsystem.Interpreter" do
                   activated = True
                 }
             createPasswordResetCodeResult =
-              runAllEffects testDomain [user] mempty Nothing $
+              runAllEffects testDomain [user] mempty Nothing $ do
                 createPasswordResetCode (mkEmailKey email)
-                  <* expectNoEmailSent
-         in counterexample ("expected Right, got: " <> show createPasswordResetCodeResult) $
-              isRight createPasswordResetCodeResult
+                expectNoEmailSent
+                internalLookupPasswordResetCode (mkEmailKey email)
+         in case createPasswordResetCodeResult of
+              Right Nothing -> property True
+              Right mResetCode ->
+                counterexample ("expected no stored password reset code, got: " <> show mResetCode) False
+              Left err ->
+                counterexample ("expected Right Nothing, got Left: " <> show err) False
 
   describe "internalLookupPasswordResetCode" do
     prop "should find password reset code by email" $


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
