### PR TITLE
quickcheck-fix-generic-shrink

### DIFF
--- a/changelog.d/5-internal/WPB-00000-quickcheck-fix-generic-shrink
+++ b/changelog.d/5-internal/WPB-00000-quickcheck-fix-generic-shrink
@@ -1,1 +1,1 @@
-quickcheck-fix-generic-shrink
+Quickcheck: fix generic shrink.

--- a/changelog.d/5-internal/WPB-00000-quickcheck-fix-generic-shrink
+++ b/changelog.d/5-internal/WPB-00000-quickcheck-fix-generic-shrink
@@ -1,0 +1,1 @@
+quickcheck-fix-generic-shrink

--- a/libs/types-common/src/Wire/Arbitrary.hs
+++ b/libs/types-common/src/Wire/Arbitrary.hs
@@ -70,7 +70,12 @@ instance
   Arbitrary (GenericUniform a)
   where
   arbitrary = GenericUniform <$> Generic.genericArbitraryWith @CustomSizedOpts @a customSizedOpts Generic.uniform
-  shrink = coerce (QC.genericShrink @a)
+  shrink =
+    -- we could define this as `coerce (QC.genericShrink @a)`, but
+    -- that makes for unreasonably large search trees.  if your test
+    -- errors are unhelpful, consider turning this on temporarily, or
+    -- writing your own shrink.
+    const []
 
 -- | We want plug in custom generators for all occurences of '[]' and 'NonEmpty'.
 type CustomSizedOpts =


### PR DESCRIPTION
I've run into non-terminating property tests for the second time now, and it took me again a moment to find that it's non-terminating shrink functions produced by our generic arbitrary machinery.

I can think of two ways of fixing this: (1) truncate the coerce, and (2) do not shrink at all.

This PR implement (2).  The problem I'm having with (1) is that truncate only works on the breadth, not on the depth, of the tree, so I don't know how effective it'll be in practice.  The problem with (3) do nothing is that I will have forgotten again by the next time I'll run into this, it'll annoy me again for a little while.

I like option (2)!  :)  other opinions?

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)