### PR TITLE
WPB-21359 fix: Inconsistent notifications are sent to local and remote members when they're removed from MLS conversations

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-21359
+++ b/changelog.d/3-bug-fixes/WPB-21359
@@ -1,0 +1,1 @@
+Fix: Inconsistent removal messages across local and federated conversation members

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -682,7 +682,8 @@ consumingMessages mlsProtocol mp = Codensity $ \k -> do
 
     -- at this point we know that every new user has been added to the
     -- conversation
-    for_ (zip clients wss) $ \((cid, t), ws) -> case t of
+    let clients' = filter (\(ci, _) -> ci `Set.notMember` conv.membersToBeRemoved) clients
+    for_ (zip clients' wss) $ \((cid, t), ws) -> case t of
       MLSNotificationMessageTag ->
         when (conv.epoch > 0) $
           void $

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -682,8 +682,8 @@ consumingMessages mlsProtocol mp = Codensity $ \k -> do
 
     -- at this point we know that every new user has been added to the
     -- conversation
-    let clients' = filter (\(ci, _) -> ci `Set.notMember` conv.membersToBeRemoved) clients
-    for_ (zip clients' wss) $ \((cid, t), ws) -> case t of
+    let cssNoToBeRemoved = filter (\((ci, _), _) -> ci `Set.notMember` conv.membersToBeRemoved) (zip clients wss)
+    for_ cssNoToBeRemoved $ \((cid, t), ws) -> case t of
       MLSNotificationMessageTag ->
         when (conv.epoch > 0) $
           void $
@@ -718,7 +718,7 @@ consumeMessageNoExternal cs cid mp = consumeMessageWithPredicate isNewMLSMessage
   where
     -- the backend (correctly) reacts to a commit removing someone from a parent conversation with a
     -- remove proposal, however, we don't want to consume this here
-    isNewMLSMessageNotifButNoProposal :: Value -> App Bool
+    isNewMLSMessageNotifButNoProposal :: (HasCallStack) => Value -> App Bool
     isNewMLSMessageNotifButNoProposal n = do
       isRelevantNotif <- isNewMLSMessageNotif n &&~ isNotifConvId mp.convId n
       if isRelevantNotif

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -1209,3 +1209,13 @@ testGroupIdParseError = do
     resp.json %. "label" `shouldMatch` "mls-protocol-error"
     msg <- resp.json %. "message" & asString
     assertBool "unexpected error message" $ "Could not parse group ID:" `isPrefixOf` msg
+
+testFederatedRemove :: (HasCallStack) => App ()
+testFederatedRemove = do
+  [alice, amy, bob] <- createAndConnectUsers [OwnDomain, OwnDomain, OtherDomain]
+  [alice1, amy1, bob1] <- traverse (createMLSClient def) [alice, amy, bob]
+  traverse_ (uploadNewKeyPackage def) [amy1, bob1]
+  convId <- createNewGroup def alice1
+
+  void $ createAddCommit alice1 convId [amy, bob] >>= sendAndConsumeCommitBundle
+  void $ createRemoveCommit alice1 convId [amy1, bob1] >>= sendAndConsumeCommitBundle

--- a/libs/wire-subsystems/src/Wire/ConversationStore/MLS/Types.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/MLS/Types.hs
@@ -174,6 +174,10 @@ cmSingleton cid idx =
       (cidQualifiedUser cid)
       (Map.singleton (ciClient cid) idx)
 
+-- | Construct the subset of the first client map consisting of users that are present in the second.
+cmIntersect :: ClientMap a -> ClientMap b -> ClientMap a
+cmIntersect (ClientMap m1) (ClientMap m2) = ClientMap (Map.intersection m1 m2)
+
 -- | Inform a handler for 'POST /conversations/list-ids' if the MLS global team
 -- conversation and the MLS self-conversation should be included in the
 -- response.

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
@@ -35,7 +35,6 @@ import Data.Set qualified as Set
 import Data.Tagged
 import Data.Text.Lazy qualified as LT
 import Data.Tuple.Extra
-import Debug.Trace
 import Galley.Types.Error
 import Imports
 import Polysemy
@@ -349,8 +348,6 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
       lConvOrSub' <- fetchConvOrSub qusr bundle.groupId ctype lConvOrSubId
       let convOrSub' = tUnqualified lConvOrSub'
           mems = cmIntersect (void convOrSub.members) convOrSub'.members
-      traceM $ "original: " <> show convOrSub.members
-      traceM $ "intersected: " <> show mems
       propagateMessage qusr (Just c) lConvOrSub conn bundle.rawMessage mems
       pure lConvOrSub'
     pure (events, newClients, lConvOrSub')

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
@@ -35,6 +35,7 @@ import Data.Set qualified as Set
 import Data.Tagged
 import Data.Text.Lazy qualified as LT
 import Data.Tuple.Extra
+import Debug.Trace
 import Galley.Types.Error
 import Imports
 import Polysemy
@@ -297,7 +298,7 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
 
   senderIdentity <- getSenderIdentity qusr c bundle.sender lConvOrSub
 
-  (events, newClients) <- handleGroupInfoMismatch lConvOrSubId bundle $ lowerCodensity $ do
+  (events, newClients, lConvOrSub') <- handleGroupInfoMismatch lConvOrSubId bundle $ lowerCodensity $ do
     (events, newClients) <- case senderIdentity.index of
       Just _ -> do
         -- extract added/removed clients from bundle
@@ -341,11 +342,18 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
           action
           bundle.commit.value.path
         pure ([], mempty)
-    lift $ do
+    lConvOrSub' <- lift $ do
       updateOutOfSyncFlag senderIdentity.client lConvOrSub
       storeGroupInfo convOrSub.id (GroupInfoData bundle.groupInfo.raw)
-      propagateMessage qusr (Just c) lConvOrSub conn bundle.rawMessage convOrSub.members
-    pure (events, newClients)
+      -- reload conversation from db to make sure we have an up-to-date list of members
+      lConvOrSub' <- fetchConvOrSub qusr bundle.groupId ctype lConvOrSubId
+      let convOrSub' = tUnqualified lConvOrSub'
+          mems = cmIntersect (void convOrSub.members) convOrSub'.members
+      traceM $ "original: " <> show convOrSub.members
+      traceM $ "intersected: " <> show mems
+      propagateMessage qusr (Just c) lConvOrSub conn bundle.rawMessage mems
+      pure lConvOrSub'
+    pure (events, newClients, lConvOrSub')
 
   -- send welcome messages
   for_ bundle.welcome $ \welcome ->
@@ -353,11 +361,8 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
 
   -- send application message
   for_ bundle.appMessage $ \msg -> do
-    -- reload conversation from db to make sure we have an up-to-date list of members
-    lConvOrSub' <- fetchConvOrSub qusr bundle.groupId ctype lConvOrSubId
     let convOrSub' = tUnqualified lConvOrSub'
-    propagateMessage qusr (Just c) lConvOrSub' conn msg.rawMessage $
-      void convOrSub'.members
+    propagateMessage qusr (Just c) lConvOrSub' conn msg.rawMessage convOrSub'.members
 
   pure events
 


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
