### PR TITLE
PostgresMigrations: Don't block on migration lock

### DIFF
--- a/changelog.d/3-bug-fixes/parent-conv-index
+++ b/changelog.d/3-bug-fixes/parent-conv-index
@@ -1,1 +1,1 @@
-Postgres: Index the parent_conv column in the conversation table (#5205, ##)
+Postgres: Index the parent_conv column in the conversation table (#5205, #5209, ##)

--- a/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
+++ b/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
@@ -29,11 +29,12 @@ import Hasql.Pool
 import Hasql.Session
 import Hasql.Session qualified as Session
 import Hasql.Statement qualified as Hasql
-import Hasql.TH (resultlessStatement)
+import Hasql.TH
 import Hasql.Transaction.Sessions
 import Imports
 import System.Logger (Logger)
 import System.Logger qualified as Log
+import UnliftIO.Retry
 
 allMigrations :: [MigrationCommand]
 allMigrations = map (uncurry MigrationScript) $(makeRelativeToProject "postgres-migrations" >>= embedDir)
@@ -55,16 +56,12 @@ runAllMigrations pool logger = do
           mErr <-
             case migrationScriptName migrationCmd of
               (Just name)
-                | name `Set.member` nonTransactionMigrations -> do
+                | name `Set.member` nonTransactionMigrations ->
                     -- Locking the migration makes sure that only one process is
                     -- running this migration at a time. Without this `CREATE
                     -- INDEX CONCURRENTLY` can deadlock with other processes
                     -- causing a silent failure.
-                    let lockId = fromIntegral $ Hashable.hash name
-                    Session.statement lockId lockNonTransactionMigration
-                    migRes <- runMigrationWithoutTransactions migrationCmd
-                    Session.statement lockId unlockNonTransactionMigration
-                    pure migRes
+                    withLock name $ runMigrationWithoutTransactions migrationCmd
               _ ->
                 transaction Serializable Write $ runMigration migrationCmd
 
@@ -75,13 +72,33 @@ runAllMigrations pool logger = do
 
   either throwIO pure =<< use pool session
   where
-    lockNonTransactionMigration :: Hasql.Statement Int64 ()
-    lockNonTransactionMigration =
-      [resultlessStatement|SELECT (1 :: integer) FROM (SELECT pg_advisory_lock($1 :: bigint))|]
+    -- We must use `try` instead of blocking on the lock because running `CREATE
+    -- INDEX CONCURRENTLY` requires all transactions to be complete and blocking
+    -- on the lock causes an implicit transaction to be blocked, which means we
+    -- would end up in a deadlock.
+    tryLockNonTransactionMigration :: Hasql.Statement Int64 Bool
+    tryLockNonTransactionMigration =
+      [singletonStatement|SELECT (pg_try_advisory_lock($1 :: bigint) :: bool)|]
 
     unlockNonTransactionMigration :: Hasql.Statement Int64 ()
     unlockNonTransactionMigration =
       [resultlessStatement|SELECT (1 :: integer) FROM (SELECT pg_advisory_unlock($1 :: bigint))|]
+
+    -- We don't have to use 'bracket' here becasue failing in the session should
+    -- cause the session to drop and any acquired locks get automatically
+    -- released.
+    withLock :: ScriptName -> Session a -> Session a
+    withLock name migration = do
+      let lockId = fromIntegral $ Hashable.hash name
+
+      void . retrying (constantDelay 1_000_000) (const pure) $ \_ ->
+        Session.statement lockId tryLockNonTransactionMigration
+
+      migRes <- migration
+
+      Session.statement lockId unlockNonTransactionMigration
+
+      pure migRes
 
 migrationName :: MigrationCommand -> (Log.Msg -> Log.Msg)
 migrationName = \case

--- a/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
+++ b/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
@@ -91,7 +91,7 @@ runAllMigrations pool logger = do
     withLock name migration = do
       let lockId = fromIntegral $ Hashable.hash name
 
-      void . retrying (constantDelay 1_000_000) (const pure) $ \_ ->
+      void . retrying (constantDelay 1_000_000) (const $ pure . not) $ \_ ->
         Session.statement lockId tryLockNonTransactionMigration
 
       migRes <- migration

--- a/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
+++ b/libs/wire-subsystems/src/Wire/PostgresMigrations.hs
@@ -84,7 +84,7 @@ runAllMigrations pool logger = do
     unlockNonTransactionMigration =
       [resultlessStatement|SELECT (1 :: integer) FROM (SELECT pg_advisory_unlock($1 :: bigint))|]
 
-    -- We don't have to use 'bracket' here becasue failing in the session should
+    -- We don't have to use 'bracket' here because failing in the session should
     -- cause the session to drop and any acquired locks get automatically
     -- released.
     withLock :: ScriptName -> Session a -> Session a


### PR DESCRIPTION
This causes deadlocks with another process running the same migration of `CREATE INDEX CONCURRENTLY` because this query waits on all transactions to be complete.

https://wearezeta.atlassian.net/browse/WPB-22832

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
