### PR TITLE
multi-ingress: cross-IdP SSO

### DIFF
--- a/changelog.d/2-features/multi-ingress-cross-IdP-SSO
+++ b/changelog.d/2-features/multi-ingress-cross-IdP-SSO
@@ -1,0 +1,10 @@
+When a team uses multiple SAML IdPs (one per ingress domain) in a multi-ingress
+setup, users can now authenticate via any of the team's IdPs even if their
+account was originally provisioned under a different one. Spar resolves the
+correct account by email-based NameID lookup across all team IdPs and migrates
+the user's SSO identity to the authenticating IdP transparently.
+
+**Important:** Email addresses (`NameID`s) must be unique across configured
+IdPs! Otherwise, users may be logged into wrong accounts!
+
+Please refer to the documentation for further information.

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -858,7 +858,7 @@ spar:
 
     # Optional SHA-1 certificate fingerprint allowlist for IdP descriptor
     # certificates. Empty list (the default) disables the check. Any non-empty
-    # list enforces that every cert in an IdP descriptor  is present in this
+    # list enforces that every cert in an IdP descriptor is present in this
     # list (on create/update and on AuthnResponse). Entries are hex strings;
     # canonical form is uppercase pairs separated by ':' (e.g. "AA:BB:CC:..."),
     # but the parser accepts lowercase and omitted separators.

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -865,6 +865,11 @@ spar:
     # Example:
     # idpCertFingerprintAllowlist:
     #   - "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+    #
+    # WARNING - In a multi-ingress setup, this enables the multi-ingress
+    # cross-IdP fallback with severe security implications. Refer to the
+    # documentation of this feature ('Multi-ingress cross-IdP SSO (fallback)')
+    # to understand what this means.
     idpCertFingerprintAllowlist: []
 
     logLevel: Info

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1368,7 +1368,8 @@ Given an email address, the SSO code is looked up by these criteria:
 - The mapping must be unambiguous (there must be exactly one matching IdP).
   In multi-ingress mode, IdPs are always bound to one domain; the request domain
   must match the IdP's configured domain.
-- The user was created via SCIM
+- The user is a SSO user. So it was created via SCIM with SSO enabled (any IdP
+  configured in SCIM token) OR created via SSO (no SCIM involved).
 
 The last condition ensures that team admins cannot get into locked-out
 situations due to misconfigured IdPs.
@@ -1651,6 +1652,59 @@ Putting it differently: We require an unambiguous mapping `(team, domain) -> IdP
 
 For multi-ingress setups, the [`idpCertFingerprintAllowlist`](#idp-certificate-fingerprint-allowlist)
 must be configured to restrict which X.509 certificates can be used in IdP metadata.
+This restriction was introduced to mitigate risks of
+[Multi-ingress cross-IdP SSO (fallback)](#multi-ingress-cross-idp-sso-fallback).
+
+#### Multi-ingress cross-IdP SSO (fallback)
+
+Terms used below:
+
+- _Authenticating IdP_ — the external identity provider that issued the SAML
+  assertion, identified by the `Issuer` URI inside it.
+- _IdP configuration_ — backend's IdP representation registered via
+  `/identity-providers`, storing the issuer URI, the associated multi-ingress
+  domain, and the team.
+
+In the normal SSO flow spar looks up the authenticating user by their `(issuer,
+NameID)` pair — matching the assertion's issuer against the IdP configuration
+the user was provisioned under.
+
+In a multi-ingress setup each domain has its own IdP configuration with its own
+issuer URI. A user provisioned under domain _A_ has their SSO identity tied to
+issuer _A_'s URI. When that user later authenticates via domain _B_, the IdP
+authentication response's assertion carries issuer _B_'s URI, so the primary
+`(issuer, NameID)` lookup finds nothing. Two IdPs can't have the same Issuer
+ID because those must be globally unique, and each external identity provider
+controls its own issuer URI (spar can't override it).
+
+When this primary lookup finds no user, spar therefore attempts a cross-IdP
+migration when multi-ingress is configured:
+
+1. **NameID must be an email address.** Username-based `NameID`s are rejected
+   to avoid ambiguity across authenticating IdPs.
+2. **The matching IdP configuration is resolved.** Spar looks for an IdP
+   configuration in the team whose issuer URI and configured domain both match
+   the assertion's issuer and the incoming `Z-Host` header (exact match).
+   If this condition is unmet, the login is rejected.
+3. **Team-wide user search.** The authenticating IdP is now known (step 2), but
+   the user may still be registered under a *different* team IdP from an
+   earlier login. Spar therefore searches every IdP configuration in the team,
+   pairing each one's issuer with the assertion's email NameID, and tries the
+   primary `(issuer, NameID)` lookup for each pairing until one matches.
+4. **Migrate or provision:**
+   - _Exactly one match found:_ The user's SSO identity is updated to point to
+     the IdP configuration for the authenticating IdP's issuer, so subsequent
+     logins hit the primary lookup directly. This saves the complexity of the IdP
+     configuration lookup and keeps the backend's representations of the user's
+     SSO data sound.
+   - _No match found:_ A new user account is auto-provisioned under the
+     authenticating IdP's configuration.
+   - _No matching IdP configuration can be resolved:_ Login is rejected.
+
+##### Security considerations
+
+It must be ensured that email `NameID`s are unique across IdPs by IdP
+administrators. Otherwise, users may be logged into other users' accounts!
 
 ### Webapp
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1429,6 +1429,13 @@ All formats must be exactly 40 hex digits (20 bytes).
 Invalid hex or wrong length (anything not exactly 20 bytes / 40 hex digits) causes
 the configuration to fail at startup with a clear error message.
 
+!!! danger Multi-ingress cross-IdP SSO fallback
+
+  This feature enables multi-ingress cross-IdP authentication in multi-ingress
+  scenarios. I.e. multiple IdPs can be used to authenticate the same account.
+  This can be a security issue if IdPs are not configured for this! See
+  [Multi-ingress cross-IdP SSO(fallback)](#multi-ingress-cross-idp-sso-fallback).
+
 ### SCIM
 
 In Helm:
@@ -1705,6 +1712,15 @@ migration when multi-ingress is configured:
 
 It must be ensured that email `NameID`s are unique across IdPs by IdP
 administrators. Otherwise, users may be logged into other users' accounts!
+
+!!! danger
+  This fallback feature breaks the 1:1 relationship between users and IdPs. To
+  use it safely, all user accounts must be consistent across all IdPs. Also note,
+  that this increases the attack surface as you have to secure and maintain
+  multiple IdPs; while a successful attack on one of them breaks security for all
+  accounts of a team with that IdP configured.
+
+  **If in doubt, please contact customer support!**
 
 ### Webapp
 

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -211,6 +211,7 @@ library
     Test.Spar
     Test.Spar.CertFingerprintAllowlist
     Test.Spar.GetByEmail
+    Test.Spar.MultiIngressCrossIdpSso
     Test.Spar.MultiIngressIdp
     Test.Spar.MultiIngressSSO
     Test.Spar.STM

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -31,12 +31,15 @@ import Crypto.Random (getRandomBytes)
 import Data.Aeson hiding ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Base64.Lazy as EL
 import qualified Data.ByteString.Base64.URL as B64Url
 import Data.ByteString.Char8 (unpack)
 import qualified Data.CaseInsensitive as CI
 import Data.Default
+import Data.Either.Extra (fromRight')
 import Data.Function
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
@@ -44,6 +47,7 @@ import qualified Data.UUID as UUID
 import Data.UUID.V1 (nextUUID)
 import Data.UUID.V4 (nextRandom)
 import Data.Vector (fromList)
+import qualified Data.X509 as X509
 import GHC.Stack
 import qualified SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.API.Example as SAML
@@ -687,6 +691,35 @@ nextSubject = do
       0 -> either (error . show) id . SAML.mkUNameIDEmail . cs <$> randomEmail
       1 -> liftIO $ SAML.mkUNameIDUnspecified . UUID.toText <$> nextRandom
   either (error . show) pure $ SAML.mkNameID unameId Nothing Nothing Nothing
+
+-- | Generate a random email address and the corresponding email-based `SAML.NameID`.
+randomEmailNameId :: (HasCallStack) => App (String, SAML.NameID)
+randomEmailNameId = do
+  email <- randomEmail
+  let nameId = fromRight (error "could not create name id") $ SAML.emailNameID (Text.pack email)
+  pure (email, nameId)
+
+-- | Extract and decode base64 content from HTML error page <pre> tag.
+--
+-- This is meant to decode SAML errors embedded in HTML pages; e.g. from
+-- @/sso/finalize-login@.
+extractSAMLErrorPageContent :: (HasCallStack) => ByteString -> String
+extractSAMLErrorPageContent body =
+  let bdy = unpack body
+   in case bdy =~ ("<pre>([A-Za-z0-9+/=]+)</pre>" :: String) :: (String, String, String, [String]) of
+        (_, _, _, [b64Content]) -> cs $ Base64.decodeLenient (cs b64Content)
+        _ -> error "Could not extract base64 content from <pre> tag"
+
+-- | Helper to create IdP metadata with a fixed issuer suffix
+makeSampleIdPMetadataWithIssuer ::
+  (HasCallStack) =>
+  (SAML.SignPrivCreds, SAML.SignCreds, X509.SignedCertificate) -> String -> App SampleIdP
+makeSampleIdPMetadataWithIssuer (privcreds, creds, cert) suffix = do
+  let issuerUri = Text.pack $ "https://issuer.net/_" <> suffix
+      requriUri = Text.pack $ "https://requri.net/_req_" <> suffix
+      issuer = SAML.Issuer . fromRight' $ SAML.parseURI' issuerUri
+      requri = fromRight' $ SAML.parseURI' requriUri
+  pure $ SampleIdP (SAML.IdPMetadata issuer requri (cert NonEmpty.:| [])) privcreds creds cert
 
 -- helpers
 

--- a/integration/test/Test/Spar/GetByEmail.hs
+++ b/integration/test/Test/Spar/GetByEmail.hs
@@ -99,10 +99,10 @@ testGetSsoCodeByEmailWithMultiIngress (TaggedBool requireExternalEmailVerificati
           [] -> assertFailure "Expected at least one email"
 
       let idpTokenConfig = if isIdPScimToken then (def {idp = Just idpIdErnie}) else def
-      scimTok <- createScimToken owner idpTokenConfig
-      scimToken <- scimTok.json %. "token" & asString
+      scimToken <- createScimToken owner idpTokenConfig
+      scimTokenStr <- scimToken.json %. "token" & asString
 
-      createScimUser domain scimToken scimUser >>= assertSuccess
+      createScimUser domain scimTokenStr scimUser >>= assertSuccess
 
       if isIdPScimToken
         then when requireExternalEmailVerification $ do
@@ -157,10 +157,10 @@ testGetSsoCodeByEmailRegular (TaggedBool requireExternalEmailVerification) (Tagg
           [] -> assertFailure "Expected at least one email"
 
       let idpTokenConfig = if isIdPScimToken then (def {idp = Just idpId}) else def
-      scimTok <- createScimToken owner idpTokenConfig
-      scimToken <- scimTok.json %. "token" & asString
+      scimToken <- createScimToken owner idpTokenConfig
+      scimTokenStr <- scimToken.json %. "token" & asString
 
-      createScimUser domain scimToken scimUser >>= assertSuccess
+      createScimUser domain scimTokenStr scimUser >>= assertSuccess
 
       if isIdPScimToken
         then when requireExternalEmailVerification $ do
@@ -222,10 +222,10 @@ testGetSsoCodeByEmailDisabledRegular = do
           (e : _) -> e %. "value" >>= asString
           [] -> assertFailure "Expected at least one email"
 
-      scimTok <- createScimToken owner def {idp = Just idpId}
-      scimToken <- scimTok.json %. "token" & asString
+      scimToken <- createScimToken owner def {idp = Just idpId}
+      scimTokenStr <- scimToken.json %. "token" & asString
 
-      createScimUser domain scimToken scimUser >>= assertSuccess
+      createScimUser domain scimTokenStr scimUser >>= assertSuccess
 
       -- Activate the email so the user can be found by email
       activateEmail domain userEmail
@@ -288,10 +288,10 @@ testGetSsoCodeByEmailDisabledMultiIngress = do
           (e : _) -> e %. "value" >>= asString
           [] -> assertFailure "Expected at least one email"
 
-      scimTok <- createScimToken owner def {idp = Just idpIdErnie}
-      scimToken <- scimTok.json %. "token" & asString
+      scimToken <- createScimToken owner def {idp = Just idpIdErnie}
+      scimTokenStr <- scimToken.json %. "token" & asString
 
-      createScimUser domain scimToken scimUser >>= assertSuccess
+      createScimUser domain scimTokenStr scimUser >>= assertSuccess
 
       -- Activate the email so the user can be found by email
       activateEmail domain userEmail

--- a/integration/test/Test/Spar/MultiIngressCrossIdpSso.hs
+++ b/integration/test/Test/Spar/MultiIngressCrossIdpSso.hs
@@ -1,0 +1,548 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2026 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Spar.MultiIngressCrossIdpSso where
+
+import API.BrigInternal (getUsersId)
+import API.Common (randomHandle)
+import API.Spar
+  ( CreateScimToken (..),
+    createIdpWithZHostV2,
+    createScimToken,
+    createScimUser,
+    finalizeSamlLoginWithZHost,
+    getSPMetadataWithZHost,
+    getSsoCodeByEmailWithZHost,
+    initiateSamlLoginWithZHostAndLabel,
+  )
+import Control.Lens ((.~), (^.))
+import Data.ByteString.Char8 (unpack)
+import Data.Either.Extra
+import Data.String.Conversions (cs)
+import Data.Text (pack)
+import qualified Data.UUID as UUID
+import qualified Data.X509 as X509
+import GHC.Stack
+import qualified SAML2.WebSSO as SAML
+import qualified SAML2.WebSSO.Test.MockResponse as SAML
+import SAML2.WebSSO.Test.Util
+import SetupHelpers
+import Testlib.Certs (fingerprintHex)
+import Testlib.Prelude
+import qualified Text.XML.DSig as SAML
+
+ernieDomain, bertDomain, ernieZHost, bertZHost :: String
+ernieDomain = "ernie.example.com"
+bertDomain = "bert.example.com"
+ernieZHost = "nginz-https." <> ernieDomain
+bertZHost = "nginz-https." <> bertDomain
+
+-- | Test that - in a multi-ingress scenario -  a user provisioned under one
+-- IdP can log in via another IdP, with their SSO identity migrating to the new
+-- IdP transparently.
+--
+-- Covers both SCIM-provisioned and auto-provisioned users, and verifies
+-- back-and-forth migration between IdPs.
+testCrossIdpSsoMigration :: (HasCallStack) => TaggedBool "useScim" -> App ()
+testCrossIdpSsoMigration (TaggedBool useSCIM) = do
+  ernieCredsWithCert@(_, _, ernieCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [ernieCert, bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    -- Register IdP for Ernie's domain
+    SampleIdP idpMetaErnie pCredsErnie _ _ <- makeSampleIdPMetadataWithIssuer ernieCredsWithCert "ernie"
+    idpErnie <- createIdpWithZHostV2 owner (Just ernieZHost) idpMetaErnie
+    idpIdErnie <- asString $ idpErnie.json %. "id"
+
+    -- Register IdP for Bert's domain
+    SampleIdP idpMetaBert pCredsBert _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    idpBert <- createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+    idpIdBert <- asString $ idpBert.json %. "id"
+
+    ernieIssuer <- idpErnie.json %. "metadata.issuer" >>= asString
+    bertIssuer <- idpBert.json %. "metadata.issuer" >>= asString
+
+    (biboEmail, biboNameId) <- randomEmailNameId
+
+    -- Optionally create the user via SCIM (and not automatically)
+    mScimUserId <-
+      if useSCIM
+        then do
+          -- Create SCIM token associated with Ernie's IdP
+          scimToken <- createScimToken owner (def {idp = Just idpIdErnie})
+          scimTokenStr <- scimToken.json %. "token" & asString
+
+          -- Create SCIM user with the email
+          scimUser <- randomScimUserWithEmail biboEmail biboEmail
+          scimUid <- bindResponse (createScimUser domain scimTokenStr scimUser) $ \resp -> do
+            resp.status `shouldMatchInt` 201
+            resp.json %. "id" >>= asString
+
+          activateEmail domain biboEmail
+
+          pure (Just scimUid)
+        else pure Nothing
+
+    -- Bibo logs in on Ernie ingress (should succeed)
+    userIdErnie <-
+      loginWithSamlWithZHost
+        (Just ernieZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdErnie, (idpMetaErnie, pCredsErnie))
+        >>= maybe (error "Expected user ID from SSO login on Ernie domain") pure
+        . fst
+
+    case mScimUserId of
+      Just scimUid ->
+        -- Validate that SCIM-created user matches SSO login user
+        scimUid `shouldMatch` userIdErnie
+      Nothing ->
+        -- Non-SCIM user was auto-provisioned. Activate them.
+        activateEmail domain biboEmail
+
+    -- Verify user's SSO ID has Ernie's issuer (not Bert's)
+    getUsersId domain [userIdErnie] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` ernieIssuer
+      ssoIdTenant `shouldNotMatch` bertIssuer
+
+    -- Verify sso/get-by-email returns Ernie's IdP
+    getSsoCodeByEmailWithZHost domain (Just ernieZHost) biboEmail `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoCodeStr <- resp.json %. "sso_code" >>= asString
+      ssoCodeStr `shouldMatch` idpIdErnie
+
+    -- Bibo re-logs in on Ernie (should succeed - proves SSO works on same ingress)
+    (mUserIdErnieAgain, _) <-
+      loginWithSamlWithZHost
+        (Just ernieZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdErnie, (idpMetaErnie, pCredsErnie))
+
+    userIdErnieAgain <- assertJust "Expected user ID from re-login on Ernie domain" mUserIdErnieAgain
+    userIdErnieAgain `shouldMatch` userIdErnie
+
+    -- Same Bibo logs in on Bert ingress with SAME email
+    -- This should SUCCEED because of cross-IdP SSO migration.
+    (mUserIdBert, _) <-
+      loginWithSamlWithZHost
+        (Just bertZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdBert, (idpMetaBert, pCredsBert))
+
+    -- Verify the same user ID is returned (cross-IdP SSO migration worked)
+    userIdBert <- assertJust "Expected user ID from cross-IdP SSO login on Bert domain" mUserIdBert
+    userIdBert `shouldMatch` userIdErnie
+
+    -- Verify user's SSO ID was migrated to Bert's issuer (not Ernie's anymore)
+    getUsersId domain [userIdErnie] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` bertIssuer
+      ssoIdTenant `shouldNotMatch` ernieIssuer
+
+    -- Verify sso/get-by-email returns Bert's IdP for Bert's ingress after migration
+    getSsoCodeByEmailWithZHost domain (Just bertZHost) biboEmail `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoCodeStr <- resp.json %. "sso_code" >>= asString
+      ssoCodeStr `shouldMatch` idpIdBert
+
+    -- Verify sso/get-by-email returns Ernie's IdP for Ernie's ingress after migration
+    getSsoCodeByEmailWithZHost domain (Just ernieZHost) biboEmail `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoCodeStr <- resp.json %. "sso_code" >>= asString
+      ssoCodeStr `shouldMatch` idpIdErnie
+
+    -- Login on Ernie again to show back-and-forth migration works
+    (mUserIdErnieFinal, _) <-
+      loginWithSamlWithZHost
+        (Just ernieZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdErnie, (idpMetaErnie, pCredsErnie))
+
+    userIdErnieFinal <- assertJust "Expected user ID from final login on Ernie domain" mUserIdErnieFinal
+    userIdErnieFinal `shouldMatch` userIdErnie
+
+    -- Verify user's SSO ID was migrated back to Ernie's IdP
+    getUsersId domain [userIdErnie] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` ernieIssuer
+      ssoIdTenant `shouldNotMatch` bertIssuer
+
+    -- Verify sso/get-by-email returns correct IdP by ingress
+    getSsoCodeByEmailWithZHost domain (Just ernieZHost) biboEmail `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoCodeStr <- resp.json %. "sso_code" >>= asString
+      ssoCodeStr `shouldMatch` idpIdErnie
+
+    getSsoCodeByEmailWithZHost domain (Just bertZHost) biboEmail `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoCodeStr <- resp.json %. "sso_code" >>= asString
+      ssoCodeStr `shouldMatch` idpIdBert
+
+-- | Cross-IdP migration works even when the user's first SSO login is on a different IdP
+-- than the one they were SCIM-provisioned under.
+testScimUserLoginsDifferentIdP :: (HasCallStack) => App ()
+testScimUserLoginsDifferentIdP = do
+  ernieCredsWithCert@(_, _, ernieCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [ernieCert, bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    -- Register IdP for Ernie's domain
+    SampleIdP idpMetaErnie pCredsErnie _ _ <- makeSampleIdPMetadataWithIssuer ernieCredsWithCert "ernie"
+    idpErnie <- createIdpWithZHostV2 owner (Just ernieZHost) idpMetaErnie
+    idpIdErnie <- asString $ idpErnie.json %. "id"
+
+    -- Register IdP for Bert's domain
+    SampleIdP idpMetaBert pCredsBert _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    idpBert <- createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+    idpIdBert <- asString $ idpBert.json %. "id"
+
+    ernieIssuer <- idpErnie.json %. "metadata.issuer" >>= asString
+    bertIssuer <- idpBert.json %. "metadata.issuer" >>= asString
+
+    (biboEmail, biboNameId) <- randomEmailNameId
+
+    -- Provision SCIM user for Ernie's IdP
+    scimToken <- createScimToken owner (def {idp = Just idpIdErnie})
+    scimTokenStr <- scimToken.json %. "token" & asString
+
+    scimUser <- randomScimUserWithEmail biboEmail biboEmail
+    biboUid <- bindResponse (createScimUser domain scimTokenStr scimUser) $ \resp -> do
+      resp.status `shouldMatchInt` 201
+      resp.json %. "id" >>= asString
+
+    activateEmail domain biboEmail
+
+    -- Verify user was created with Ernie's SSO ID
+    getUsersId domain [biboUid] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` ernieIssuer
+
+    -- Bibo logs in for the FIRST time on Bert's IdP (NOT Ernie!)
+    -- This tests cross-IdP migration when user has never logged in before (only SCIM provisioned)
+    userIdBert <-
+      loginWithSamlWithZHost
+        (Just bertZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdBert, (idpMetaBert, pCredsBert))
+        >>= maybe (error "Expected user ID from cross-IdP SSO login on Bert domain") pure
+        . fst
+
+    -- Verify the same user ID is returned (cross-IdP SSO migration worked)
+    userIdBert `shouldMatch` biboUid
+
+    -- Verify user's SSO ID was migrated to Bert's issuer
+    getUsersId domain [userIdBert] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` bertIssuer
+      ssoIdTenant `shouldNotMatch` ernieIssuer
+
+    -- Login on Ernie to verify back-migration also works
+    (mUserIdErnie, _) <-
+      loginWithSamlWithZHost
+        (Just ernieZHost)
+        domain
+        True -- expect success
+        tid
+        biboNameId
+        (idpIdErnie, (idpMetaErnie, pCredsErnie))
+
+    userIdErnie <- assertJust "Expected user ID from login on Ernie domain" mUserIdErnie
+    userIdErnie `shouldMatch` biboUid
+
+    -- Verify user's SSO ID was migrated back to Ernie's issuer
+    getUsersId domain [biboUid] `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 200
+      ssoId <- resp.json %. "0.sso_id"
+      ssoIdTenant <- ssoId %. "tenant" >>= asString
+      ssoIdTenant `shouldContain` ernieIssuer
+      ssoIdTenant `shouldNotMatch` bertIssuer
+
+-- | Login fails when the authenticating IdP's issuer is not registered for the target domain.
+testIdpNotFoundError :: (HasCallStack) => App ()
+testIdpNotFoundError = do
+  ernieCredsWithCert@(_, _, ernieCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [ernieCert, bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    -- Register TWO IdPs: one for Ernie domain, one for Bert domain
+    SampleIdP idpMetaErnie pCredsErnie _ _ <- makeSampleIdPMetadataWithIssuer ernieCredsWithCert "ernie"
+    idpErnie <- createIdpWithZHostV2 owner (Just ernieZHost) idpMetaErnie
+    idpIdErnie <- asString $ idpErnie.json %. "id"
+    ernieIssuer <- idpErnie.json %. "metadata.issuer" >>= asString
+
+    SampleIdP idpMetaBert _ _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    _idpBert <- createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+
+    (_biboEmail, biboNameId) <- randomEmailNameId
+
+    -- Initiate on ernie, then replay the response against bert's endpoint (cross-domain).
+    -- Spar rejects: ernie's issuer is not configured for bert's domain.
+    spmetaBert <- getSPMetadataWithZHost domain (Just bertZHost) tid
+    authnReqRaw <- initiateSamlLoginWithZHostAndLabel domain (Just ernieZHost) Nothing idpIdErnie
+    let spMetaDataBert = fromRight (error "could not decode spmetadata") $ SAML.decode $ cs spmetaBert.body
+        -- Manipulate: redirect the ernie authn request to bert's SP issuer so the audience
+        -- restriction in the SAML response targets bert's ACS URL, not ernie's.
+        parsedAuthnReqErnie =
+          parseAuthnReqResp authnReqRaw.body
+            & SAML.rqIssuer .~ SAML.Issuer (spMetaDataBert ^. SAML.spResponseURL)
+        idpConfigErnie =
+          SAML.IdPConfig
+            (SAML.IdPId (fromMaybe (error "invalid idp id") (UUID.fromString idpIdErnie)))
+            idpMetaErnie
+            ()
+    authnReqResp <-
+      runSimpleSP
+        $ SAML.mkAuthnResponseWithSubj
+          biboNameId
+          pCredsErnie
+          idpConfigErnie
+          spMetaDataBert
+          (Just parsedAuthnReqErnie)
+          True
+
+    bindResponse (finalizeSamlLoginWithZHost domain (Just bertZHost) tid authnReqResp) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      let bdy = unpack resp.body
+      bdy `shouldContain` "wire:sso:error:"
+      bdy `shouldContain` "\"type\":\"AUTH_ERROR\""
+      bdy `shouldContain` "wire:sso:error:not-found"
+      bdy `shouldContain` "\"label\":\"forbidden\""
+      let expectedErrorMsg =
+            "Could not find IdP: IdP with issuer '"
+              <> ernieIssuer
+              <> "' for domain '"
+              <> bertZHost
+              <> "' is not configured for this team"
+      bdy `shouldContain` expectedErrorMsg
+
+-- | Test that a user of one team cannot log in using the IdP of a different team.
+--
+-- Team B's IdP must not grant access to Team A, even when the SAML response is otherwise
+-- well-formed.
+testCrossTeamIdpLoginRejected :: (HasCallStack) => App ()
+testCrossTeamIdpLoginRejected = do
+  credsA@(_, _, certA) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  credsB@(_, _, certB) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [certA, certB] $ \domain -> do
+    -- Team A with IdP A on bert domain
+    (ownerA, tidA, _) <- createTeam domain 1
+    SampleIdP idpMetaA pCredsA _ _ <- makeSampleIdPMetadataWithIssuer credsA "team-a"
+    idpA <- createIdpWithZHostV2 ownerA (Just bertZHost) idpMetaA
+    idpIdA <- asString $ idpA.json %. "id"
+
+    -- Team B with IdP B on ernie domain
+    (ownerB, _, _) <- createTeam domain 1
+    SampleIdP idpMetaB pCredsB _ _ <- makeSampleIdPMetadataWithIssuer credsB "team-b"
+    idpB <- createIdpWithZHostV2 ownerB (Just ernieZHost) idpMetaB
+    idpIdB <- asString $ idpB.json %. "id"
+
+    -- Create Bibo as a user of Team A
+    (biboEmail, biboNameId) <- randomEmailNameId
+    _ <- loginWithSamlWithZHost (Just bertZHost) domain True tidA biboNameId (idpIdA, (idpMetaA, pCredsA))
+    activateEmail domain biboEmail
+
+    -- IdP B lives on ernie and can be initiated there, but finalization fails because IdP B
+    -- belongs to Team B, not Team A.
+    authnReqRespErnie <- buildSamlAuthnResponse domain ernieZHost tidA idpIdB idpMetaB pCredsB biboNameId
+    bindResponse (finalizeSamlLoginWithZHost domain (Just ernieZHost) tidA authnReqRespErnie) $ \resp -> do
+      resp.status `shouldMatchInt` 404
+      extractSAMLErrorPageContent resp.body `shouldContain` "IdpNotFound"
+
+    -- IdP B lives on ernie, not bert: initiation on bert is rejected
+    -- immediately independent of the team (domain mismatch).
+    bindResponse (initiateSamlLoginWithZHostAndLabel domain (Just bertZHost) Nothing idpIdB) $ \resp ->
+      resp.status `shouldMatchInt` 404
+
+-- | Test that non-email NameIDs are rejected in multi-ingress mode.
+--
+-- Multi-ingress cross-IdP SSO requires email-based NameIDs to prevent ambiguities.
+testNonEmailNameIdRejectedInMultiIngress :: (HasCallStack) => App ()
+testNonEmailNameIdRejectedInMultiIngress = do
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [bertDomain] [bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    -- Register IdP
+    SampleIdP idpMetaBert pCredsBert _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    idpBert <- createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+    idpIdBert <- asString $ idpBert.json %. "id"
+
+    randomUsername <- randomHandle
+    let usernameNameId =
+          fromRight (error "could not create name id")
+            $ SAML.mkNameID (SAML.mkUNameIDUnspecified (pack randomUsername)) Nothing Nothing Nothing
+
+    authnReqResp <- buildSamlAuthnResponse domain bertZHost tid idpIdBert idpMetaBert pCredsBert usernameNameId
+    bindResponse (finalizeSamlLoginWithZHost domain (Just bertZHost) tid authnReqResp) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      let bdy = unpack resp.body
+      bdy `shouldContain` "wire:sso:error:multi-ingress-config-error"
+      bdy `shouldContain` "Multi-ingress SSO only supports email-based NameIDs for cross-IdP migration. Username-based NameIDs are not allowed."
+
+-- | Test that SAML responses without a prior authentication request are rejected.
+--
+-- A response referencing a request Spar never stored results in a "bad InResponseTo" error.
+testUnsolicitedSamlResponseRejected :: (HasCallStack) => App ()
+testUnsolicitedSamlResponseRejected = do
+  ernieCredsWithCert@(_, _, ernieCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [ernieCert, bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    SampleIdP idpMetaErnie _ _ _ <- makeSampleIdPMetadataWithIssuer ernieCredsWithCert "ernie"
+    void $ createIdpWithZHostV2 owner (Just ernieZHost) idpMetaErnie
+
+    SampleIdP idpMetaBert pCredsBert _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    idpBert <- createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+    idpIdBert <- asString $ idpBert.json %. "id"
+
+    (_biboEmail, biboNameId) <- randomEmailNameId
+
+    spmeta <- getSPMetadataWithZHost domain (Just bertZHost) tid
+    let spMetaData = fromRight (error "could not decode spmetadata") $ SAML.decode $ cs spmeta.body
+        idpConfig = SAML.IdPConfig (SAML.IdPId (fromMaybe (error "invalid idp id") (UUID.fromString idpIdBert))) idpMetaBert ()
+    -- Create a local authn request (stored in SimpleSP's in-memory store, not in Spar's database)
+    localReq <- runSimpleSP $ SAML.createAuthnRequest 300 (idpMetaBert ^. SAML.edIssuer) (idpMetaBert ^. SAML.edIssuer)
+    authnReqResp <- makeAuthnResponse biboNameId pCredsBert idpConfig spMetaData localReq
+
+    -- Spar cannot find the request (no verdict format stored), so it rejects with server error.
+    -- This is not a user flow, so we can accept any error - even 500 - here.
+    bindResponse (finalizeSamlLoginWithZHost domain (Just bertZHost) tid authnReqResp) $ \resp -> do
+      resp.status `shouldMatchInt` 500
+      resp.json %. "label" `shouldMatch` "server-error"
+
+-- | Test that SAML responses for one ingress are rejected when submitted to a
+-- different ingress.
+--
+-- A login request on the ernie ingress must be finalized on the ernie ingress.
+-- Finalizing on the bert ingress should fail with a bad recipient error.
+testCrossIngressRequestResponseMismatch :: (HasCallStack) => App ()
+testCrossIngressRequestResponseMismatch = do
+  ernieCredsWithCert@(_, _, ernieCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+  bertCredsWithCert@(_, _, bertCert) <- liftIO $ SAML.mkSignCredsWithCert Nothing 96
+
+  withMultiIngressBackend [ernieDomain, bertDomain] [ernieCert, bertCert] $ \domain -> do
+    (owner, tid, _) <- createTeam domain 1
+
+    SampleIdP idpMetaErnie pCredsErnie _ _ <- makeSampleIdPMetadataWithIssuer ernieCredsWithCert "ernie"
+    idpErnie <- createIdpWithZHostV2 owner (Just ernieZHost) idpMetaErnie
+    idpIdErnie <- asString $ idpErnie.json %. "id"
+
+    SampleIdP idpMetaBert _ _ _ <- makeSampleIdPMetadataWithIssuer bertCredsWithCert "bert"
+    void $ createIdpWithZHostV2 owner (Just bertZHost) idpMetaBert
+
+    (_biboEmail, biboNameId) <- randomEmailNameId
+
+    -- The SAML response's Destination is ernie's ACS (Assertion Consumer Service) URL,
+    -- i.e. ernie's /sso/finalize-login endpoint. Submitting it to bert's endpoint causes
+    -- a Destination mismatch ("bad Recipient").
+    authnReqResp <- buildSamlAuthnResponse domain ernieZHost tid idpIdErnie idpMetaErnie pCredsErnie biboNameId
+
+    -- Finalize on bert ingress — Destination mismatch, bad recipient
+    bindResponse (finalizeSamlLoginWithZHost domain (Just bertZHost) tid authnReqResp) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      let bdy = unpack resp.body
+      bdy `shouldContain` "wire:sso:error:forbidden"
+      bdy `shouldContain` "bad Recipient"
+
+-- | Run a test with the standard multi-ingress backend configuration.
+-- Takes base domain names (e.g. "ernie.example.com"); the ZHost and SSO/webapp URLs
+-- are derived from each base domain.
+-- Optionally accepts IdP certificates to add to the allowlist.
+withMultiIngressBackend :: (HasCallStack) => [String] -> [X509.SignedCertificate] -> (String -> App ()) -> App ()
+withMultiIngressBackend baseDomains certs action =
+  withModifiedBackend
+    def
+      { sparCfg =
+          removeField "saml.spSsoUri"
+            >=> removeField "saml.spAppUri"
+            >=> removeField "saml.contacts"
+            >=> setField "saml.spDomainConfigs" (object (map mkDomainEntry baseDomains))
+            >=> setField "enableIdPByEmailDiscovery" True
+            >=> if null certs
+              then pure
+              else setField "idpCertFingerprintAllowlist" (map fingerprintHex certs),
+        galleyCfg = setField "settings.featureFlags.sso" "enabled-by-default"
+      }
+    action
+  where
+    mkDomainEntry base =
+      ("nginz-https." <> base)
+        .= object
+          [ "spAppUri" .= ("https://webapp." <> base :: String),
+            "spSsoUri" .= ("https://nginz-https." <> base <> "/sso" :: String),
+            "contacts" .= [object ["type" .= ("ContactTechnical" :: String)]]
+          ]
+
+-- | Initiate a SAML login and build a signed authn response for the given NameID.
+-- Use this when testing error cases that require manual control over the finalize step.
+buildSamlAuthnResponse ::
+  (HasCallStack, MakesValue domain) =>
+  domain ->
+  String ->
+  String ->
+  String ->
+  SAML.IdPMetadata ->
+  SAML.SignPrivCreds ->
+  SAML.NameID ->
+  App SAML.SignedAuthnResponse
+buildSamlAuthnResponse domain mbZHost tid idpId idpMeta pcreds nameId = do
+  spmeta <- getSPMetadataWithZHost domain (Just mbZHost) tid
+  authnreq <- initiateSamlLoginWithZHostAndLabel domain (Just mbZHost) Nothing idpId
+  let spMetaData = fromRight (error "could not decode spmetadata") $ SAML.decode $ cs spmeta.body
+      parsedAuthnReq = parseAuthnReqResp authnreq.body
+      idpConfig =
+        SAML.IdPConfig
+          (SAML.IdPId (fromMaybe (error "invalid idp id") (UUID.fromString idpId)))
+          idpMeta
+          ()
+  makeAuthnResponse nameId pcreds idpConfig spMetaData parsedAuthnReq

--- a/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
@@ -93,7 +93,7 @@ getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
         case users of
           [] -> pure Nothing
           [user] -> do
-            if isScimOrSsoUser user
+            if isSsoUser user
               then do
                 mbTeam <- getTeamId (userId user)
                 case mbTeam of
@@ -112,9 +112,11 @@ getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
     userIdToText :: Qualified UserId -> Text
     userIdToText uid = idToText (qUnqualified uid) <> "@" <> domainText (qDomain uid)
 
-    isScimOrSsoUser :: User -> Bool
-    isScimOrSsoUser user =
-      userManagedBy user == ManagedByScim && isJust (userSSOId user)
+    -- This used to check if the user is SCIM AND SSO! The RFC ("2025-05-12
+    -- RFC: Default SSO flow for team by host domain") is ambiguous about this.
+    -- The customer currently provisions non-SCIM, so this fits their usecase.
+    isSsoUser :: User -> Bool
+    isSsoUser = isJust . userSSOId
 
     findIdPByDomain :: (Member (Logger (Log.Msg -> Log.Msg)) r) => [IP.IdP] -> Sem r (Maybe SAML.IdPId)
     findIdPByDomain [] = pure Nothing

--- a/libs/wire-subsystems/test/unit/Wire/IdPSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/IdPSubsystem/InterpreterSpec.hs
@@ -37,7 +37,6 @@ import System.Logger.Message qualified as Log
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
-import Test.QuickCheck.Gen
 import Wire.API.Team.Member
 import Wire.API.User
 import Wire.API.User.IdentityProvider
@@ -318,15 +317,9 @@ spec = describe "IdPSubsystem.Interpreter" $ do
       result `shouldBe` Right Nothing
       expectedSevereLogs logs mempty
 
-    prop "returns Nothing for non SCIM/SSO user" $ \(teamMember :: TeamMember) user idp userRef email teamId -> do
-      (userIdentity, userManagedBy) <-
-        generate $
-          ( do
-              ui <- Test.QuickCheck.Gen.elements [Just (SSOIdentity (UserSSOId userRef) (Just email)), Nothing]
-              mngtBy :: ManagedBy <- arbitrary
-              pure (ui, mngtBy)
-          )
-            `suchThat` (\(ui, mngtBy) -> isNothing ui || mngtBy == ManagedByWire)
+    prop "returns Nothing for non SSO user" $ \(teamMember :: TeamMember) user idp email teamId -> do
+      userManagedBy <- generate (arbitrary :: Gen ManagedBy)
+      userIdentity <- generate (oneof [pure Nothing, pure $ Just (EmailIdentity email)])
 
       let userWithEmail =
             user

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -68,8 +68,6 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import Data.Proxy
 import Data.Range
-import qualified Data.Set as Set
-import qualified Data.Text.Encoding as TE
 import Data.Text.Encoding.Error
 import qualified Data.Text.Lazy as T
 import Data.Text.Lazy.Encoding
@@ -211,6 +209,7 @@ apiSSO ::
     Member VerdictFormatStore r,
     Member AReqIDStore r,
     Member ScimTokenStore r,
+    Member ScimExternalIdStore r,
     Member DefaultSsoCode r,
     Member IdPConfigStore r,
     Member IdPSubsystem r,
@@ -427,6 +426,7 @@ authresp ::
     Member VerdictFormatStore r,
     Member AReqIDStore r,
     Member ScimTokenStore r,
+    Member ScimExternalIdStore r,
     Member IdPConfigStore r,
     Member SAML2 r,
     Member SamlProtocolSettings r,
@@ -457,7 +457,7 @@ authresp mbtid arbody mbHost = do
         SAML.AccessDenied (shouldRedirectToInit -> True) ->
           redirectToInit idp
         _ -> do
-          SAML.ResponseVerdict result <- verdictHandler assertions verdict idp
+          SAML.ResponseVerdict result <- verdictHandler assertions verdict idp mbHost
           throw @SparError $ SAML.CustomServant result
 
     -- Whenever at least one of the denied reasons is `DeniedNoInResponseTo`, try again.
@@ -810,58 +810,6 @@ idpCreateV7 samlConfig tid zUser idpmeta mReplaces mApiversion mHandle = do
       when (numTokens > 0 && numIdps > 0) $
         throwSparSem $
           SparProvisioningMoreThanOneIdP ScimTokenAndSecondIdpForbidden
-
--- | Reject IdPs whose cert SHA-1 is not in the configured allowlist.
---
--- Empty/absent allowlist is a no-op in the regular case, it short-circuits to
--- error for multi-ingress setups. I.e. the allowlist is required for
--- multi-ingress setups.
-assertCertsAllowlisted ::
-  ( Member (Input Opts) r,
-    Member (Logger (Msg -> Msg)) r,
-    Member (Error SparError) r
-  ) =>
-  SAML.IdPMetadata ->
-  Sem r ()
-assertCertsAllowlisted idpmeta = do
-  mAllow <- inputs idpCertFingerprintAllowlist
-  samlConfig <- inputs saml
-  let certs = idpmeta ^. SAML.edCertAuthnResponse
-      issuerTxt =
-        TE.decodeUtf8 $
-          URI.serializeURIRef' (idpmeta ^. SAML.edIssuer . SAML.fromIssuer)
-  when (isEmptyAllowList mAllow && SAML.isMultiIngressConfig samlConfig) $ do
-    let fingerprintHex = renderFingerprintHex . certSha1Fingerprint . NE.head $ certs
-    logMultiIngressEmptyAllowlist fingerprintHex issuerTxt
-    throwSparSem (SparIdPCertNotAllowed (T.fromStrict fingerprintHex))
-  case mAllow of
-    Nothing -> pure ()
-    Just (CertFingerprintAllowlist allowed)
-      | Set.null allowed -> pure ()
-      | otherwise -> do
-          forM_ certs $ \c -> do
-            let fingerprint = certSha1Fingerprint c
-                fingerprintHex = renderFingerprintHex fingerprint
-            unless (Set.member fingerprint allowed) $ do
-              logCertNotInAllowlist fingerprintHex issuerTxt
-              throwSparSem (SparIdPCertNotAllowed (T.fromStrict fingerprintHex))
-  where
-    logMultiIngressEmptyAllowlist fingerprintHex issuerTxt =
-      Logger.warn $
-        Log.msg ("Refusing IdP request: multi-ingress enabled and allowlist empty" :: ByteString)
-          . Log.field "fingerprint" fingerprintHex
-          . Log.field "issuer" issuerTxt
-
-    logCertNotInAllowlist fingerprintHex issuerTxt =
-      Logger.warn $
-        Log.msg ("Refusing IdP request: cert fingerprint not in allowlist" :: ByteString)
-          . Log.field "fingerprint" fingerprintHex
-          . Log.field "issuer" issuerTxt
-
-    isEmptyAllowList :: Maybe CertFingerprintAllowlist -> Bool
-    isEmptyAllowList Nothing = True
-    isEmptyAllowList (Just (CertFingerprintAllowlist allowed)) | Set.null allowed = True
-    isEmptyAllowList (Just _) = False
 
 -- | Check that issuer is not used anywhere in the system ('WireIdPAPIV1', here it is a
 -- database key for finding IdPs), or anywhere in this team ('WireIdPAPIV2'), that request

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -30,6 +30,7 @@ module Spar.App
     validateEmail,
     errorPage,
     deleteTeam,
+    assertCertsAllowlisted,
     sparToServerErrorWithLogging,
     renderSparErrorWithLogging,
   )
@@ -39,26 +40,33 @@ import Bilge
 import qualified Cassandra as Cas
 import Control.Exception (assert)
 import Control.Lens hiding ((.=))
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Aeson as Aeson (encode, object, (.=))
 import Data.Aeson.Text as Aeson (encodeToLazyText)
 import Data.ByteString (toStrict)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.CaseInsensitive as CI
+import Data.Domain
 import Data.Id
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Text.Ascii (encodeBase64, toText)
+import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Lazy.Encoding as LText
 import Data.These
+import qualified Data.X509 as X509
+import Data.X509.Extended
 import Imports hiding (MonadReader, asks, log)
 import qualified Network.HTTP.Types.Status as Http
 import qualified Network.Wai.Utilities.Error as Wai
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input
 import SAML2.Util (renderURI)
 import SAML2.WebSSO
   ( Issuer (..),
@@ -83,6 +91,8 @@ import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
 import Spar.Sem.VerdictFormatStore (VerdictFormatStore)
 import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
+import System.Logger (Msg)
+import qualified System.Logger as Log
 import qualified System.Logger as TinyLog
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)
@@ -276,26 +286,29 @@ validateEmail _ _ _ = pure ()
 verdictHandler ::
   (HasCallStack) =>
   ( Member Random r,
-    Member (Logger String) r,
+    Member (Logger (Msg -> Msg)) r,
     Member GalleyAPIAccess r,
     Member BrigAPIAccess r,
     Member AReqIDStore r,
     Member VerdictFormatStore r,
     Member ScimTokenStore r,
+    Member ScimExternalIdStore r,
     Member IdPConfigStore r,
     Member (Error SparError) r,
     Member Reporter r,
-    Member SAMLUserStore r
+    Member SAMLUserStore r,
+    Member (Input Opts) r
   ) =>
   NonEmpty SAML.Assertion ->
   SAML.AccessVerdict ->
   IdP ->
+  Maybe Domain ->
   Sem r SAML.ResponseVerdict
-verdictHandler aresp verdict idp = do
+verdictHandler aresp verdict idp mbHost = do
   -- [3/4.1.4.2]
   -- <SubjectConfirmation> [...] If the containing message is in response to an <AuthnRequest>, then
   -- the InResponseTo attribute MUST match the request's ID.
-  Logger.log Logger.Debug $ "entering verdictHandler: " <> show (aresp, verdict)
+  Logger.debug $ Log.msg ("entering verdictHandler" :: String) . Log.field "aresp" (show aresp) . Log.field "verdict" (show verdict)
   reqid <- do
     let xs = SAML.assertionToInResponseTo `mapM` aresp
     case NonEmpty.nub <$> xs of
@@ -305,13 +318,13 @@ verdictHandler aresp verdict idp = do
   format :: Maybe VerdictFormat <- VerdictFormatStore.get reqid
   resp <- case format of
     Just (VerdictFormatWeb mlabel) ->
-      verdictHandlerResult verdict idp mlabel >>= verdictHandlerWeb
+      verdictHandlerResult verdict idp mlabel mbHost >>= verdictHandlerWeb
     Just (VerdictFormatMobile granted denied mlabel) ->
-      verdictHandlerResult verdict idp mlabel >>= verdictHandlerMobile granted denied
+      verdictHandlerResult verdict idp mlabel mbHost >>= verdictHandlerMobile granted denied
     Nothing ->
       -- (this shouldn't happen too often, see 'storeVerdictFormat')
       throwSparSem SparNoSuchRequest
-  Logger.log Logger.Debug $ "leaving verdictHandler: " <> show resp
+  Logger.debug $ Log.msg ("leaving verdictHandler" :: String) . Log.field "resp" (show resp)
   pure resp
 
 data VerdictHandlerResult
@@ -323,23 +336,26 @@ data VerdictHandlerResult
 verdictHandlerResult ::
   (HasCallStack) =>
   ( Member Random r,
-    Member (Logger String) r,
+    Member (Logger (Msg -> Msg)) r,
     Member GalleyAPIAccess r,
     Member BrigAPIAccess r,
     Member ScimTokenStore r,
+    Member ScimExternalIdStore r,
     Member IdPConfigStore r,
     Member (Error SparError) r,
     Member Reporter r,
-    Member SAMLUserStore r
+    Member SAMLUserStore r,
+    Member (Input Opts) r
   ) =>
   SAML.AccessVerdict ->
   IdP ->
   Maybe CookieLabel ->
+  Maybe Domain ->
   Sem r VerdictHandlerResult
-verdictHandlerResult verdict idp mlabel = do
-  Logger.log Logger.Debug $ "entering verdictHandlerResult"
-  result <- catchVerdictErrors $ verdictHandlerResultCore idp verdict mlabel
-  Logger.log Logger.Debug $ "leaving verdictHandlerResult" <> show result
+verdictHandlerResult verdict idp mlabel mbHost = do
+  Logger.debug $ Log.msg ("entering verdictHandlerResult" :: String)
+  result <- catchVerdictErrors $ verdictHandlerResultCore idp verdict mlabel mbHost
+  Logger.debug $ Log.msg ("leaving verdictHandlerResult" :: String) . Log.field "result" (show result)
   pure result
 
 catchVerdictErrors ::
@@ -399,48 +415,154 @@ moveUserToNewIssuer oldUserRef newUserRef uid = do
   SAMLUserStore.delete uid oldUserRef
 
 verdictHandlerResultCore ::
+  forall r.
   (HasCallStack) =>
   ( Member Random r,
-    Member (Logger String) r,
+    Member (Logger (Msg -> Msg)) r,
     Member GalleyAPIAccess r,
     Member BrigAPIAccess r,
     Member ScimTokenStore r,
+    Member ScimExternalIdStore r,
     Member IdPConfigStore r,
     Member (Error SparError) r,
-    Member SAMLUserStore r
+    Member SAMLUserStore r,
+    Member (Input Opts) r
   ) =>
   IdP ->
   SAML.AccessVerdict ->
   Maybe CookieLabel ->
+  Maybe Domain ->
   Sem r VerdictHandlerResult
-verdictHandlerResultCore idp verdict mlabel = case verdict of
+verdictHandlerResultCore idp verdict mlabel mbHost = case verdict of
   SAML.AccessDenied reasons -> do
     pure $ VerifyHandlerDenied reasons
   SAML.AccessGranted uref -> do
     uid :: UserId <- do
       let team' = idp ^. idpExtraInfo . team
-          err = SparUserRefInNoOrMultipleTeams . LText.pack . show $ uref
-      getUserByUrefUnsafe uref >>= \case
-        Just usr -> do
-          if userTeam usr == Just team'
-            then pure (userId usr)
-            else throwSparSem err
-        Nothing -> do
-          getUserByUrefViaOldIssuerUnsafe idp uref >>= \case
-            Just (olduref, usr) -> do
-              let uid = userId usr
-              if userTeam usr == Just team'
-                then moveUserToNewIssuer olduref uref uid >> pure uid
-                else throwSparSem err
-            Nothing -> do
-              buid <- Id <$> Random.uuid
-              autoprovisionSamlUser idp buid uref
-              validateSamlEmailIfExists buid uref
-              pure buid
-
-    Logger.log Logger.Debug ("granting sso login for " <> show uid)
+      samlConfig <- input <&> (.saml)
+      findUserWithUref idp team' uref >>= \case
+        Just uid -> pure uid
+        Nothing ->
+          if SAML.isMultiIngressConfig samlConfig
+            then multiIngressFlow team'
+            else provisionNewUser
+    Logger.debug $ Log.msg ("granting sso login" :: String) . Log.field "user" (idToText uid)
     cky <- BrigAPIAccess.ssoLogin uid mlabel
     pure $ VerifyHandlerGranted cky uid
+    where
+      provisionNewUser :: Sem r UserId
+      provisionNewUser = do
+        buid <- Id <$> Random.uuid
+        autoprovisionSamlUser idp buid uref
+        validateSamlEmailIfExists buid uref
+        pure buid
+
+      -- Try to find a user by UserRef, with fallback to old issuers. Returns
+      -- the UserId if found and in the correct team, Nothing if not found.
+      -- Throws SparUserRefInNoOrMultipleTeams if user is found but in the
+      -- wrong team. Side effect: Old-style users (found via old issuers) are
+      -- migrated to the new issuer.
+      findUserWithUref :: IdP -> TeamId -> SAML.UserRef -> Sem r (Maybe UserId)
+      findUserWithUref idp' team'' uref' = do
+        let err = SparUserRefInNoOrMultipleTeams . LText.pack . show $ uref'
+        getUserByUrefUnsafe uref' >>= \case
+          Just usr -> do
+            if userTeam usr == Just team''
+              then pure (Just (userId usr))
+              else throwSparSem err
+          Nothing -> do
+            getUserByUrefViaOldIssuerUnsafe idp' uref' >>= \case
+              Just (olduref, usr) -> do
+                let uid = userId usr
+                if userTeam usr == Just team''
+                  then moveUserToNewIssuer olduref uref' uid >> pure (Just uid)
+                  else throwSparSem err
+              Nothing -> pure Nothing
+
+      -- In multi-ingress scenarios users can be already assigned to one IdP,
+      -- but try to authenticate with another. This happens when users switch
+      -- the used domain as IdPs are domain-bound. We allow this, when the new
+      -- IdP is configured for the user's team and the used domain.
+      -- Additionally, the provided NameId must be an email address (no
+      -- username) to prevent ambiguities (though, we know this won't be
+      -- guarding against all ambiguity cases).
+      -- When we've found the matching IdP and the user's old one, we migrate
+      -- the user to the new one to not have to run this search again when the
+      -- user logs in with this IdP.
+      multiIngressFlow :: TeamId -> Sem r UserId
+      multiIngressFlow team' =
+        case uref of
+          SAML.UserRef _ (view SAML.nameID -> UNameIDEmail _) -> do
+            teamIdPs <- IdPConfigStore.getConfigsByTeam team'
+            let urefIssuer = uref ^. SAML.uidTenant
+
+            case selectAuthenticatingIdP teamIdPs urefIssuer mbHost of
+              Nothing -> do
+                let issuerText = urefIssuer ^. SAML.fromIssuer . to (TE.decodeUtf8 . URI.serializeURIRef')
+                    domainAsText = maybe "default" domainText mbHost
+                    errorMsg =
+                      "IdP with issuer '"
+                        <> issuerText
+                        <> "' for domain '"
+                        <> domainAsText
+                        <> "' is not configured for this team"
+                throwSparSem $ SparIdPNotFound (LText.fromStrict errorMsg)
+              Just multiIngressIdp -> do
+                assertCertsAllowlisted (multiIngressIdp ^. SAML.idpMetadata)
+                let subject = uref ^. SAML.uidSubject
+                findUserInTeamIdPs team' subject teamIdPs >>= \case
+                  Nothing -> do
+                    logMultiIngressProvisioningNewUser idp uref multiIngressIdp mbHost
+                    provisionNewUser
+                  Just (uid, oldUref) -> do
+                    logMultiIngressMigratingUser idp uid oldUref uref multiIngressIdp mbHost
+                    moveUserToNewIssuer oldUref uref uid
+                    pure uid
+          _userRef ->
+            throwSparSem . SparMultiIngressIdPConfiguration $
+              "Multi-ingress SSO only supports email-based NameIDs for cross-IdP migration. "
+                <> "Username-based NameIDs are not allowed."
+
+      -- Try to authenticate against all IdPs. In case, return the UserId and the old UserRef.
+      findUserInTeamIdPs :: TeamId -> SAML.NameID -> [IdP] -> Sem r (Maybe (UserId, SAML.UserRef))
+      findUserInTeamIdPs team'' subject idps = runMaybeT $ asum $ map tryIdP idps
+        where
+          tryIdP :: IdP -> MaybeT (Sem r) (UserId, SAML.UserRef)
+          tryIdP idp' = do
+            let oldIssuer = idp' ^. SAML.idpMetadata . SAML.edIssuer
+                oldUref = SAML.UserRef oldIssuer subject
+            uid <- MaybeT $ findUserWithUref idp' team'' oldUref
+            pure (uid, oldUref)
+
+      selectAuthenticatingIdP :: [IdP] -> Issuer -> Maybe Domain -> Maybe IdP
+      selectAuthenticatingIdP teamIdPs issuer mbDomain =
+        find matchesIssuerAndDomain teamIdPs
+        where
+          matchesIssuerAndDomain idp' =
+            idp' ^. SAML.idpMetadata . SAML.edIssuer == issuer
+              && idp' ^. idpExtraInfo . domain == mbDomain
+
+      logMultiIngressProvisioningNewUser :: IdP -> SAML.UserRef -> IdP -> Maybe Domain -> Sem r ()
+      logMultiIngressProvisioningNewUser idp' uref' multiIngressIdp' mbHost' =
+        Logger.info $
+          Log.msg ("Multi-ingress SSO: IdP found but user does not exist, provisioning new user" :: String)
+            . Log.field "team" (idToText (idp' ^. idpExtraInfo . team))
+            . Log.field "issuer" (uref' ^. SAML.uidTenant . SAML.fromIssuer . to URI.serializeURIRef')
+            . Log.field "multi_ingress_idp" (multiIngressIdp' ^. SAML.idpId . to SAML.fromIdPId . to show)
+            . Log.field "authenticating_idp" (idp' ^. SAML.idpId . to SAML.fromIdPId . to show)
+            . Log.field "domain" (mbHost' & maybe "None" domainText)
+
+      logMultiIngressMigratingUser :: IdP -> UserId -> SAML.UserRef -> SAML.UserRef -> IdP -> Maybe Domain -> Sem r ()
+      logMultiIngressMigratingUser idp' uid' oldUref' uref' multiIngressIdp' mbHost' =
+        Logger.info $
+          Log.msg ("Multi-ingress SSO: user found via different IdP, migrating issuer" :: String)
+            . Log.field "team" (idToText (idp' ^. idpExtraInfo . team))
+            . Log.field "user" (idToText uid')
+            . Log.field "old_issuer" (oldUref' ^. SAML.uidTenant . SAML.fromIssuer . to URI.serializeURIRef')
+            . Log.field "new_issuer" (uref' ^. SAML.uidTenant . SAML.fromIssuer . to URI.serializeURIRef')
+            . Log.field "authenticating_idp" (idp' ^. SAML.idpId . to SAML.fromIdPId . to show)
+            . Log.field "multi_ingress_idp" (multiIngressIdp' ^. SAML.idpId . to SAML.fromIdPId . to show)
+            . Log.field "domain" (mbHost' & maybe "None" domainText)
 
 -- | If the client is web, it will be served with an HTML page that it can process to decide whether
 -- to log the user in or show an error.
@@ -613,6 +735,68 @@ deleteTeam team' = do
     let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer
     SAMLUserStore.deleteByIssuer issuer
     IdPConfigStore.deleteConfig idp
+
+-- | Reject IdPs whose cert SHA-1 is not in the configured allowlist.
+--
+-- Empty/absent allowlist is a no-op in the regular case, it short-circuits to
+-- error for multi-ingress setups. I.e. the allowlist is required for
+-- multi-ingress setups.
+assertCertsAllowlisted ::
+  forall r.
+  ( Member (Input Opts) r,
+    Member (Logger (Msg -> Msg)) r,
+    Member (Error SparError) r
+  ) =>
+  SAML.IdPMetadata ->
+  Sem r ()
+assertCertsAllowlisted idpmeta = do
+  mAllow <- inputs idpCertFingerprintAllowlist
+  let certs = idpmeta ^. SAML.edCertAuthnResponse
+      issuerTxt =
+        TE.decodeUtf8 $
+          URI.serializeURIRef' (idpmeta ^. SAML.edIssuer . SAML.fromIssuer)
+  guardMultiIngressCertsAllowlistNotEmpty mAllow certs issuerTxt
+  case mAllow of
+    Nothing -> pure ()
+    Just (CertFingerprintAllowlist allowed)
+      | Set.null allowed -> pure ()
+      | otherwise -> do
+          forM_ certs $ \c -> do
+            let fingerprint = certSha1Fingerprint c
+                fingerprintHex = renderFingerprintHex fingerprint
+            unless (Set.member fingerprint allowed) $ do
+              logCertNotInAllowlist fingerprintHex issuerTxt
+              throwSparSem (SparIdPCertNotAllowed (LText.fromStrict fingerprintHex))
+  where
+    logCertNotInAllowlist fingerprintHex issuerTxt =
+      Logger.warn $
+        Log.msg ("Refusing IdP request: cert fingerprint not in allowlist" :: ByteString)
+          . Log.field "fingerprint" fingerprintHex
+          . Log.field "issuer" issuerTxt
+
+    guardMultiIngressCertsAllowlistNotEmpty ::
+      Maybe CertFingerprintAllowlist ->
+      NonEmpty X509.SignedCertificate ->
+      Text ->
+      Sem r ()
+    guardMultiIngressCertsAllowlistNotEmpty mAllow certs issuerTxt = do
+      samlConfig <- inputs saml
+
+      when (isEmptyAllowList mAllow && SAML.isMultiIngressConfig samlConfig) $ do
+        let fingerprintHex = renderFingerprintHex . certSha1Fingerprint . NonEmpty.head $ certs
+        logMultiIngressEmptyAllowlist fingerprintHex
+        throwSparSem (SparIdPCertNotAllowed (LText.fromStrict fingerprintHex))
+      where
+        logMultiIngressEmptyAllowlist fingerprintHex =
+          Logger.warn $
+            Log.msg ("Refusing IdP request: multi-ingress enabled and allowlist empty" :: ByteString)
+              . Log.field "fingerprint" fingerprintHex
+              . Log.field "issuer" issuerTxt
+
+        isEmptyAllowList :: Maybe CertFingerprintAllowlist -> Bool
+        isEmptyAllowList Nothing = True
+        isEmptyAllowList (Just (CertFingerprintAllowlist allowed)) | Set.null allowed = True
+        isEmptyAllowList (Just _) = False
 
 sparToServerErrorWithLogging :: (Member Reporter r) => SparError -> Sem r ServerError
 sparToServerErrorWithLogging = fmap httpErrorToServerError . renderSparErrorWithLogging

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -118,6 +118,7 @@ data SparCustomError
     SparScimError Scim.ScimError
   | SparIdPDomainInUse
   | SparIdPCertNotAllowed LText
+  | SparMultiIngressIdPConfiguration LText
   deriving (Eq, Show)
 
 data SparProvisioningMoreThanOneIdP
@@ -230,6 +231,7 @@ renderSparError (SAML.CustomError (SparIdPCertNotAllowed fingerprint)) =
       status403
       "idp-cert-not-allowed"
       ("IdP certificate not in the configured allowlist: " <> fingerprint)
+renderSparError (SAML.CustomError (SparMultiIngressIdPConfiguration msg)) = StdError $ Wai.mkError status400 "multi-ingress-config-error" msg
 -- Errors related to provisioning
 renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = StdError $
   Wai.mkError status400 "more-than-one-idp" do

--- a/services/spar/test-integration/Test/Spar/AppSpec.hs
+++ b/services/spar/test-integration/Test/Spar/AppSpec.hs
@@ -175,7 +175,7 @@ requestAccessVerdict idp isGranted mkAuthnReq = do
           then SAML.AccessGranted uref
           else SAML.AccessDenied [DeniedNoBearerConfSubj, DeniedNoAuthnStatement]
   outcome <- do
-    runSpar $ Spar.verdictHandler (authnresp ^. rspPayload) verdict idp
+    runSpar $ Spar.verdictHandler (authnresp ^. rspPayload) verdict idp Nothing
   let loc :: URI.URI
       loc =
         maybe (error "no location") (either error id . SAML.parseURI' . cs)

--- a/services/spar/test/Test/Spar/Saml/IdPSpec.hs
+++ b/services/spar/test/Test/Spar/Saml/IdPSpec.hs
@@ -38,6 +38,8 @@ import Spar.Sem.SAML2 (SAML2 (..))
 import Spar.Sem.SAMLUserStore
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.SAMLUserStore.Mem
+import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
+import Spar.Sem.ScimExternalIdStore.Mem (scimExternalIdStoreToMem)
 import Spar.Sem.ScimTokenStore
 import Spar.Sem.ScimTokenStore.Mem
 import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
@@ -1075,6 +1077,7 @@ type AuthrespEffs =
      GalleyAPIAccess,
      BrigAPIAccess,
      ScimTokenStore,
+     ScimExternalIdStore,
      IdPConfigStore,
      IdPRawMetadataStore,
      Logger (Msg -> Msg),
@@ -1123,6 +1126,7 @@ interpretAuthrespE opts mbAccount triplet action = do
       . recordLogs lr
       . ignoringState idpRawMetadataStoreToMem
       . ignoringState idPToMem
+      . ignoringState scimExternalIdStoreToMem
       . ignoringState scimTokenStoreToMem
       . brigAccessMock mbAccount
       . galleyAccessMock


### PR DESCRIPTION
I've covered this usecase in the documentation. To avoid duplication, please look at the docs in this PR.

Ticket: https://wearezeta.atlassian.net/browse/WPB-25161

Security notes:
- This requires a final sign off by @wireapp/security 
- The algorithm for multi-ingress SSO cross-IdP logins has been discussed with @emil-wire 
- This PR also lowers the condition to be found by `/sso/get-by-email` from SCIM SSO to SSO user

Further reading:
- https://docs.wire.com/latest/developer/reference/config-options.html?h=multi+ingress#settings-in-cannon
- https://docs.wire.com/latest/how-to/install/multi-ingress.html#what-is-a-multi-ingress-setup

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
