### PR TITLE
WPB-25109: Move meetings feature check from galley service layer into the MeetingsSubsystem interpreter

### DIFF
--- a/changelog.d/5-internal/WPB-25109
+++ b/changelog.d/5-internal/WPB-25109
@@ -1,0 +1,1 @@
+Move meetings feature check from galley service layer into the MeetingsSubsystem interpreter, ensuring the check is enforced consistently within the subsystem.

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -37,7 +37,7 @@ import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Meeting qualified as API
 import Wire.API.Routes.MultiTablePaging qualified as MultiTablePaging
-import Wire.API.Team.Feature (FeatureStatus (..), LockableFeature (..), MeetingsPremiumConfig)
+import Wire.API.Team.Feature (FeatureStatus (..), LockableFeature (..), MeetingsConfig, MeetingsPremiumConfig)
 import Wire.API.User (BaseProtocolTag (BaseProtocolMLSTag), EmailAddress)
 import Wire.ConversationSubsystem (ConversationSubsystem)
 import Wire.ConversationSubsystem qualified as ConversationSubsystem
@@ -50,8 +50,22 @@ import Wire.StoredConversation
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem qualified as TeamSubsystem
 
-data MeetingError = InvalidTimes | EmptyUpdate
+data MeetingError = InvalidTimes | EmptyUpdate | MeetingsFeatureDisabled
   deriving stock (Eq, Show)
+
+checkMeetingsEnabled ::
+  ( Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r
+  ) =>
+  Maybe TeamId ->
+  Sem r ()
+checkMeetingsEnabled maybeTeamId = do
+  case maybeTeamId of
+    Nothing -> pure ()
+    Just teamId -> do
+      meetingFeature <- getFeatureForTeam @_ @MeetingsConfig teamId
+      unless (meetingFeature.status == FeatureStatusEnabled) $
+        throw MeetingsFeatureDisabled
 
 interpretMeetingsSubsystem ::
   ( Member Store.MeetingsStore r,
@@ -90,12 +104,14 @@ createMeetingImpl ::
   API.NewMeeting ->
   Sem r (API.Meeting, StoredConversation)
 createMeetingImpl zUser newMeeting = do
+  -- Look up user's team once and reuse for both checks
+  conversationTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled conversationTeamId
   -- Validate that endTime > startTime
   when (newMeeting.endTime <= newMeeting.startTime) $
     throw InvalidTimes
 
   -- Determine trial status based on team membership and premium feature
-  conversationTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
   trial <- case conversationTeamId of
     Nothing -> pure True -- Personal users create trial meetings
     Just teamId -> do
@@ -146,6 +162,8 @@ createMeetingImpl zUser newMeeting = do
 
 updateMeetingImpl ::
   ( Member Store.MeetingsStore r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
     Member (Error MeetingError) r,
     Member Now r
   ) =>
@@ -155,6 +173,8 @@ updateMeetingImpl ::
   NominalDiffTime ->
   Sem r (Maybe API.Meeting)
 updateMeetingImpl zUser meetingId update validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   when (isNothing update.title && isNothing update.startTime && isNothing update.endTime && isNothing update.recurrence) $
     throw EmptyUpdate
 
@@ -182,6 +202,9 @@ updateMeetingImpl zUser meetingId update validityPeriod = do
 deleteMeetingImpl ::
   ( Member Store.MeetingsStore r,
     Member ConversationSubsystem r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r,
     Member Now r
   ) =>
   Local UserId ->
@@ -190,6 +213,8 @@ deleteMeetingImpl ::
   NominalDiffTime ->
   Sem r Bool
 deleteMeetingImpl zUser connId meetingId validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   result <-
     runMaybeT $ do
       meeting <- MaybeT $ Store.getMeeting (qUnqualified meetingId)
@@ -211,6 +236,9 @@ deleteMeetingImpl zUser connId meetingId validityPeriod = do
 getMeetingImpl ::
   ( Member Store.MeetingsStore r,
     Member ConversationSubsystem r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r,
     Member Now r
   ) =>
   Local UserId ->
@@ -218,6 +246,8 @@ getMeetingImpl ::
   NominalDiffTime ->
   Sem r (Maybe API.Meeting)
 getMeetingImpl zUser meetingId validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   -- Get meeting from store
   runMaybeT $ do
     storedMeeting <- MaybeT $ Store.getMeeting (qUnqualified meetingId)
@@ -255,12 +285,17 @@ storedMeetingToMeeting domain sm =
 listMeetingsImpl ::
   ( Member Store.MeetingsStore r,
     Member ConversationSubsystem r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r,
     Member Now r
   ) =>
   Local UserId ->
   NominalDiffTime ->
   Sem r [API.Meeting]
 listMeetingsImpl zUser validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   now <- Now.get
   let cutoff = addUTCTime (negate validityPeriod) now
   -- List all meetings created by the user
@@ -319,6 +354,9 @@ getAllMemberMeetings zUser cutoff = do
 
 addInvitedEmailsImpl ::
   ( Member Store.MeetingsStore r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r,
     Member Now r
   ) =>
   Local UserId ->
@@ -327,6 +365,8 @@ addInvitedEmailsImpl ::
   NominalDiffTime ->
   Sem r Bool
 addInvitedEmailsImpl zUser meetingId emails validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   result <-
     runMaybeT $ do
       storedMeeting <- MaybeT $ Store.getMeeting (qUnqualified meetingId)
@@ -341,6 +381,9 @@ addInvitedEmailsImpl zUser meetingId emails validityPeriod = do
 
 removeInvitedEmailsImpl ::
   ( Member Store.MeetingsStore r,
+    Member TeamSubsystem r,
+    Member FeaturesConfigSubsystem r,
+    Member (Error MeetingError) r,
     Member Now r
   ) =>
   Local UserId ->
@@ -349,6 +392,8 @@ removeInvitedEmailsImpl ::
   NominalDiffTime ->
   Sem r Bool
 removeInvitedEmailsImpl zUser meetingId emails validityPeriod = do
+  maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
+  checkMeetingsEnabled maybeTeamId
   result <-
     runMaybeT $ do
       storedMeeting <- MaybeT $ Store.getMeeting (qUnqualified meetingId)

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -751,3 +751,128 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
           removeInvitedEmails zUser1 nonExistentId [email1]
 
       result `shouldBe` Right False
+
+  describe "checkMeetingsEnabled" $ do
+    let now = UTCTime (fromGregorian 2026 1 1) 0
+        gen = mkStdGen 42
+        uidPersonal = Id $ read "00000000-0000-0000-0000-000000000001"
+        uidTeam = Id $ read "00000000-0000-0000-0000-000000000002"
+        zUserPersonal = toLocalUnsafe (Domain "wire.com") uidPersonal
+        zUserTeam = toLocalUnsafe (Domain "wire.com") uidTeam
+        teamId = Id $ read "00000000-0000-0000-0000-000000000100"
+        teamMember = mkTeamMember uidTeam fullPermissions Nothing UserLegalHoldDisabled
+        meetingsEnabled =
+          npUpdate @MeetingsConfig (LockableFeature FeatureStatusEnabled LockStatusUnlocked def) def
+        meetingsDisabled =
+          npUpdate @MeetingsConfig (LockableFeature FeatureStatusDisabled LockStatusUnlocked def) def
+        newMeeting =
+          API.NewMeeting
+            { title = fromJust $ checked "Test Meeting",
+              startTime = addUTCTime 3600 now,
+              endTime = addUTCTime 7200 now,
+              recurrence = Nothing,
+              invitedEmails = []
+            }
+
+    it "allows operations for personal user even when meetings disabled" $ do
+      result <-
+        runTestStack now gen Map.empty meetingsDisabled $
+          createMeeting zUserPersonal newMeeting
+
+      result `shouldSatisfy` isRight
+
+    it "allows operations for team user with meetings enabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $
+          createMeeting zUserTeam newMeeting
+
+      result `shouldSatisfy` isRight
+
+    it "throws MeetingsFeatureDisabled on createMeeting for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+          createMeeting zUserTeam newMeeting
+
+      result `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on getMeeting for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $ do
+          (meeting, _conv) <- createMeeting zUserTeam newMeeting
+          pure meeting
+
+      case result of
+        Left err -> fail $ "Failed to create meeting: " <> show err
+        Right meeting -> do
+          result2 <-
+            runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+              getMeeting zUserTeam meeting.id
+
+          result2 `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on updateMeeting for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $ do
+          (meeting, _conv) <- createMeeting zUserTeam newMeeting
+          pure meeting
+
+      case result of
+        Left err -> fail $ "Failed to create meeting: " <> show err
+        Right meeting -> do
+          result2 <-
+            runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+              updateMeeting zUserTeam meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
+
+          result2 `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on deleteMeeting for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $ do
+          (meeting, _conv) <- createMeeting zUserTeam newMeeting
+          pure meeting
+
+      case result of
+        Left err -> fail $ "Failed to create meeting: " <> show err
+        Right meeting -> do
+          result2 <-
+            runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+              deleteMeeting zUserTeam (ConnId "test-conn") meeting.id
+
+          result2 `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on listMeetings for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+          listMeetings zUserTeam
+
+      result `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on addInvitedEmails for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $ do
+          (meeting, _conv) <- createMeeting zUserTeam newMeeting
+          pure meeting
+
+      case result of
+        Left err -> fail $ "Failed to create meeting: " <> show err
+        Right meeting -> do
+          result2 <-
+            runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+              addInvitedEmails zUserTeam meeting.id [unsafeEmailAddress "test" "example.com"]
+
+          result2 `shouldBe` Left MeetingsFeatureDisabled
+
+    it "throws MeetingsFeatureDisabled on removeInvitedEmails for team user with meetings disabled" $ do
+      result <-
+        runTestStack now gen (Map.singleton teamId [teamMember]) meetingsEnabled $ do
+          (meeting, _conv) <- createMeeting zUserTeam newMeeting
+          pure meeting
+
+      case result of
+        Left err -> fail $ "Failed to create meeting: " <> show err
+        Right meeting -> do
+          result2 <-
+            runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
+              removeInvitedEmails zUserTeam meeting.id [unsafeEmailAddress "test" "example.com"]
+
+          result2 `shouldBe` Left MeetingsFeatureDisabled

--- a/services/galley/src/Galley/API/Meetings.hs
+++ b/services/galley/src/Galley/API/Meetings.hs
@@ -34,48 +34,20 @@ import Polysemy
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Meeting
-import Wire.API.Team.Feature (FeatureStatus (..), LockableFeature (..), MeetingsConfig)
-import Wire.FeaturesConfigSubsystem (FeaturesConfigSubsystem, getFeatureForTeam)
 import Wire.MeetingsSubsystem qualified as Meetings
-import Wire.TeamStore qualified as TeamStore
-
--- | Check if meetings feature is enabled for the user (if they're in a team)
-checkMeetingsEnabled ::
-  ( Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r,
-    Member (ErrorS 'InvalidOperation) r
-  ) =>
-  UserId ->
-  Sem r ()
-checkMeetingsEnabled userId = do
-  maybeTeamId <- TeamStore.getOneUserTeam userId
-  case maybeTeamId of
-    Nothing -> pure () -- Personal users can use meetings
-    Just teamId -> do
-      meetingFeature <- getFeatureForTeam @_ @MeetingsConfig teamId
-      unless (meetingFeature.status == FeatureStatusEnabled) $
-        throwS @'InvalidOperation
 
 createMeeting ::
-  ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r
-  ) =>
+  (Member Meetings.MeetingsSubsystem r) =>
   Local UserId ->
   NewMeeting ->
   Sem r Meeting
 createMeeting lUser newMeeting = do
-  checkMeetingsEnabled (tUnqualified lUser)
   (meeting, _conversation) <- Meetings.createMeeting lUser newMeeting
   pure meeting
 
 updateMeeting ::
   ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'MeetingNotFound) r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r
+    Member (ErrorS 'MeetingNotFound) r
   ) =>
   Local UserId ->
   Domain ->
@@ -83,7 +55,6 @@ updateMeeting ::
   UpdateMeeting ->
   Sem r Meeting
 updateMeeting zUser domain meetingId update = do
-  checkMeetingsEnabled (tUnqualified zUser)
   let qMeetingId = Qualified meetingId domain
   maybeMeeting <- Meetings.updateMeeting zUser qMeetingId update
   case maybeMeeting of
@@ -92,10 +63,7 @@ updateMeeting zUser domain meetingId update = do
 
 deleteMeeting ::
   ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'MeetingNotFound) r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r
+    Member (ErrorS 'MeetingNotFound) r
   ) =>
   Local UserId ->
   ConnId ->
@@ -103,24 +71,19 @@ deleteMeeting ::
   MeetingId ->
   Sem r ()
 deleteMeeting zUser connId domain meetingId = do
-  checkMeetingsEnabled (tUnqualified zUser)
   let qMeetingId = Qualified meetingId domain
   success <- Meetings.deleteMeeting zUser connId qMeetingId
   unless success $ throwS @'MeetingNotFound
 
 getMeeting ::
   ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'MeetingNotFound) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r,
-    Member (ErrorS 'InvalidOperation) r
+    Member (ErrorS 'MeetingNotFound) r
   ) =>
   Local UserId ->
   Domain ->
   MeetingId ->
   Sem r Meeting
 getMeeting zUser domain meetingId = do
-  checkMeetingsEnabled (tUnqualified zUser)
   let qMeetingId = Qualified meetingId domain
   maybeMeeting <- Meetings.getMeeting zUser qMeetingId
   case maybeMeeting of
@@ -128,23 +91,14 @@ getMeeting zUser domain meetingId = do
     Just meeting -> pure meeting
 
 listMeetings ::
-  ( Member Meetings.MeetingsSubsystem r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r,
-    Member (ErrorS 'InvalidOperation) r
-  ) =>
+  (Member Meetings.MeetingsSubsystem r) =>
   Local UserId ->
   Sem r [Meeting]
-listMeetings lUser = do
-  checkMeetingsEnabled (tUnqualified lUser)
-  Meetings.listMeetings lUser
+listMeetings lUser = Meetings.listMeetings lUser
 
 addMeetingInvitation ::
   ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'MeetingNotFound) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r,
-    Member (ErrorS 'InvalidOperation) r
+    Member (ErrorS 'MeetingNotFound) r
   ) =>
   Local UserId ->
   Domain ->
@@ -152,17 +106,13 @@ addMeetingInvitation ::
   MeetingEmailsInvitation ->
   Sem r ()
 addMeetingInvitation zUser domain meetingId (MeetingEmailsInvitation emails) = do
-  checkMeetingsEnabled (tUnqualified zUser)
   let qMeetingId = Qualified meetingId domain
   success <- Meetings.addInvitedEmails zUser qMeetingId emails
   unless success $ throwS @'MeetingNotFound
 
 removeMeetingInvitation ::
   ( Member Meetings.MeetingsSubsystem r,
-    Member (ErrorS 'MeetingNotFound) r,
-    Member TeamStore.TeamStore r,
-    Member FeaturesConfigSubsystem r,
-    Member (ErrorS 'InvalidOperation) r
+    Member (ErrorS 'MeetingNotFound) r
   ) =>
   Local UserId ->
   Domain ->
@@ -170,7 +120,6 @@ removeMeetingInvitation ::
   MeetingEmailsInvitation ->
   Sem r ()
 removeMeetingInvitation zUser domain meetingId (MeetingEmailsInvitation emails) = do
-  checkMeetingsEnabled (tUnqualified zUser)
   let qMeetingId = Qualified meetingId domain
   success <- Meetings.removeInvitedEmails zUser qMeetingId emails
   unless success $ throwS @'MeetingNotFound

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -581,3 +581,4 @@ meetingError =
   \case
     Meeting.InvalidTimes -> Servant.Tagged @'InvalidOperation ()
     Meeting.EmptyUpdate -> Servant.Tagged @'InvalidOperation ()
+    Meeting.MeetingsFeatureDisabled -> Servant.Tagged @'InvalidOperation ()


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-25109

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
