### PR TITLE
WPB-20754 fix: resetting an MLS conversation returns inconsistent group info

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-20754
+++ b/changelog.d/3-bug-fixes/WPB-20754
@@ -1,0 +1,1 @@
+Reset the MLS group info on conversation reset

--- a/integration/test/Test/MLS/Reset.hs
+++ b/integration/test/Test/MLS/Reset.hs
@@ -29,27 +29,35 @@ testResetGroupConversation domain = do
   [alice, bob, charlie] <- createAndConnectUsers [make OwnDomain, make domain, make OwnDomain]
   [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   void $ uploadNewKeyPackage def bob1
-  conv <- createNewGroup def alice1
-  void $ createAddCommit alice1 conv [bob] >>= sendAndConsumeCommitBundle
-  mlsConv <- getMLSConv conv
+  convId <- createNewGroup def alice1
+  getGroupInfo alice convId `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 404
+    resp.json %. "label" `shouldMatch` "mls-missing-group-info"
+  void $ createAddCommit alice1 convId [bob] >>= sendAndConsumeCommitBundle
+  getGroupInfo alice convId `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 200
+  mlsConv <- getMLSConv convId
 
   resetConversation alice mlsConv.groupId 0 >>= assertStatus 409
   resetConversation bob mlsConv.groupId 0 >>= assertStatus 409
   resetConversation charlie mlsConv.groupId mlsConv.epoch >>= assertStatus 404
 
-  conv' <- withWebSocket alice $ \ws -> do
+  conv <- withWebSocket alice $ \ws -> do
     resetConversation bob mlsConv.groupId mlsConv.epoch >>= assertStatus 200
-    conv' <- getConversation alice conv >>= getJSON 200
+    getGroupInfo alice convId `bindResponse` \resp -> do
+      resp.status `shouldMatchInt` 404
+      resp.json %. "label" `shouldMatch` "mls-missing-group-info"
+    conv <- getConversation alice convId >>= getJSON 200
 
     e <- awaitMatch isConvResetNotif ws
     e %. "payload.0.data.group_id" `shouldMatch` mlsConv.groupId
-    e %. "payload.0.data.new_group_id" `shouldMatch` (conv' %. "group_id")
+    e %. "payload.0.data.new_group_id" `shouldMatch` (conv %. "group_id")
 
-    pure conv'
+    pure conv
 
-  conv' %. "group_id" `shouldNotMatch` (mlsConv.groupId :: String)
-  conv' %. "epoch" `shouldMatchInt` 0
-  otherMember <- assertOne =<< asList (conv' %. "members.others")
+  conv %. "group_id" `shouldNotMatch` (mlsConv.groupId :: String)
+  conv %. "epoch" `shouldMatchInt` 0
+  otherMember <- assertOne =<< asList (conv %. "members.others")
   otherMember %. "qualified_id" `shouldMatch` (bob %. "qualified_id")
 
 testResetSelfConversation :: (HasCallStack) => App ()

--- a/integration/test/Test/MLS/SubConversation.hs
+++ b/integration/test/Test/MLS/SubConversation.hs
@@ -170,9 +170,17 @@ testDeleteSubConversation otherDomain = do
   void $ createAddCommit alice1 convId [bob] >>= sendAndConsumeCommitBundle
 
   createSubConv def convId alice1 "conference1"
+  subConvId <- getSubConvId alice convId "conference1"
+
+  void $ createExternalCommit subConvId bob1 Nothing >>= sendAndConsumeCommitBundle
+
   sub1 <- getSubConversation alice convId "conference1" >>= getJSON 200
   void $ deleteSubConversation charlie sub1 >>= getBody 403
   void $ deleteSubConversation alice sub1 >>= getBody 200
+
+  getGroupInfo alice subConvId `bindResponse` \resp -> do
+    resp.status `shouldMatchInt` 404
+    resp.json %. "label" `shouldMatch` "mls-missing-group-info"
 
   createSubConv def convId alice1 "conference2"
   sub2 <- getSubConversation alice convId "conference2" >>= getJSON 200

--- a/libs/wire-subsystems/src/Wire/ConversationStore.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore.hs
@@ -94,7 +94,7 @@ data ConversationStore m a where
   SetConversationCipherSuite :: ConvId -> CipherSuiteTag -> ConversationStore m ()
   SetConversationCellsState :: ConvId -> CellsState -> ConversationStore m ()
   ResetConversation :: ConvId -> GroupId -> ConversationStore m ()
-  SetGroupInfo :: ConvId -> GroupInfoData -> ConversationStore m ()
+  SetGroupInfo :: ConvId -> Maybe GroupInfoData -> ConversationStore m ()
   UpdateChannelAddPermissions :: ConvId -> AddPermission -> ConversationStore m ()
   UpdateToMixedProtocol :: ConvId -> GroupId -> Epoch -> ConversationStore m ()
   UpdateToMLSProtocol :: ConvId -> ConversationStore m ()

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra.hs
@@ -246,9 +246,9 @@ resetConversation cid groupId =
       Cql.resetConversation
       (params LocalQuorum (groupId, cid))
 
-setGroupInfo :: ConvId -> GroupInfoData -> Client ()
-setGroupInfo conv gid =
-  write Cql.updateGroupInfo (params LocalQuorum (gid, conv))
+setGroupInfo :: ConvId -> Maybe GroupInfoData -> Client ()
+setGroupInfo conv mGid =
+  write Cql.updateGroupInfo (params LocalQuorum (mGid, conv))
 
 getConversation :: ConvId -> Client (Maybe StoredConversation)
 getConversation conv = do

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra/Queries.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Cassandra/Queries.hs
@@ -185,7 +185,7 @@ updateConvCellsState :: PrepQuery W (CellsState, ConvId) ()
 updateConvCellsState = "update conversation set cells_state = ? where conv = ?"
 
 resetConversation :: PrepQuery W (GroupId, ConvId) ()
-resetConversation = "update conversation set group_id = ?, epoch = 0 where conv = ?"
+resetConversation = "update conversation set group_id = ?, epoch = 0, public_group_state = null where conv = ?"
 
 deleteConv :: PrepQuery W (Identity ConvId) ()
 deleteConv = "delete from conversation using timestamp 32503680000000000 where conv = ?"
@@ -196,7 +196,7 @@ markConvDeleted = {- `IF EXISTS`, but that requires benchmarking -} "update conv
 selectGroupInfo :: PrepQuery R (Identity ConvId) (Identity (Maybe GroupInfoData))
 selectGroupInfo = "select public_group_state from conversation where conv = ?"
 
-updateGroupInfo :: PrepQuery W (GroupInfoData, ConvId) ()
+updateGroupInfo :: PrepQuery W (Maybe GroupInfoData, ConvId) ()
 updateGroupInfo = "update conversation set public_group_state = ? where conv = ?"
 
 updateChannelAddPermission :: PrepQuery W (AddPermission, ConvId) ()

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Postgres.hs
@@ -534,18 +534,21 @@ resetConversationImpl convId groupId =
     update =
       lmapPG
         [resultlessStatement|UPDATE conversation
-                             SET group_id = ($2 :: bytea), epoch = 0, epoch_timestamp = NOW()
+                             SET group_id = ($2 :: bytea),
+                             epoch = 0,
+                             epoch_timestamp = NOW(),
+                             public_group_state = NULL
                              WHERE id = ($1 :: uuid)|]
 
-setGroupInfoImpl :: (PGConstraints r) => ConvId -> GroupInfoData -> Sem r ()
+setGroupInfoImpl :: (PGConstraints r) => ConvId -> Maybe GroupInfoData -> Sem r ()
 setGroupInfoImpl convId groupInfo =
   runStatement (convId, groupInfo) update
   where
-    update :: Hasql.Statement (ConvId, GroupInfoData) ()
+    update :: Hasql.Statement (ConvId, Maybe GroupInfoData) ()
     update =
       lmapPG
         [resultlessStatement|UPDATE conversation
-                             SET public_group_state = ($2 :: bytea)
+                             SET public_group_state = ($2 :: bytea?)
                              WHERE id = ($1 :: uuid)|]
 
 updateChannelAddPermissionsImpl :: (PGConstraints r) => ConvId -> AddPermission -> Sem r ()

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
@@ -635,7 +635,7 @@ storeGroupInfo ::
   GroupInfoData ->
   Sem r ()
 storeGroupInfo convOrSub ginfo = case convOrSub of
-  Conv cid -> setGroupInfo cid ginfo
+  Conv cid -> setGroupInfo cid (Just ginfo)
   SubConv cid subconvid -> setSubConversationGroupInfo cid subconvid (Just ginfo)
 
 fetchConvOrSub ::


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
