### PR TITLE
[WPB-23765] Refresh ES index after app update, emit event.

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-23765-refresh-es-index-after-app-update_-emit-event
+++ b/changelog.d/3-bug-fixes/WPB-23765-refresh-es-index-after-app-update_-emit-event
@@ -1,0 +1,1 @@
+Refresh ES index after app update, emit event.

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -1261,9 +1261,10 @@ createApp creator tid new = do
         ]
 
 -- | https://staging-nginz-https.zinfra.io/v14/api/swagger-ui/#/default/get-app
-getApp :: (MakesValue self) => self -> String -> String -> App Response
-getApp self tid uid = do
-  req <- baseRequest self Brig Versioned $ joinHttpPath ["teams", tid, "apps", uid]
+getApp :: (MakesValue self, MakesValue app) => self -> String -> app -> App Response
+getApp self tid appId = do
+  appIdStr <- asString appId
+  req <- baseRequest self Brig Versioned $ joinHttpPath ["teams", tid, "apps", appIdStr]
   submit "GET" req
 
 -- | https://staging-nginz-https.zinfra.io/v14/api/swagger-ui/#/default/get-apps
@@ -1272,9 +1273,10 @@ getApps self tid = do
   req <- baseRequest self Brig Versioned $ joinHttpPath ["teams", tid, "apps"]
   submit "GET" req
 
-putAppMetadata :: (HasCallStack, MakesValue user) => String -> user -> String -> Value -> App Response
+putAppMetadata :: (HasCallStack, MakesValue user, MakesValue app) => String -> user -> app -> Value -> App Response
 putAppMetadata tid owner appId appMetadata = do
-  let path = joinHttpPath ["teams", tid, "apps", appId]
+  appIdStr <- asString appId
+  let path = joinHttpPath ["teams", tid, "apps", appIdStr]
   req <- baseRequest owner Brig Versioned path
   submit "PUT" (req & addJSON appMetadata)
 

--- a/integration/test/Notifications.hs
+++ b/integration/test/Notifications.hs
@@ -210,9 +210,6 @@ isTeamMemberJoinNotif = notifTypeIsEqual "team.member-join"
 isTeamMemberLeaveNotif :: (HasCallStack, MakesValue a) => a -> App Bool
 isTeamMemberLeaveNotif = notifTypeIsEqual "team.member-leave"
 
-isTeamMemberUpdateNotif :: (HasCallStack, MakesValue a) => a -> App Bool
-isTeamMemberUpdateNotif = notifTypeIsEqual "team.member-update"
-
 isTeamCollaboratorAddedNotif :: (HasCallStack, MakesValue a) => a -> App Bool
 isTeamCollaboratorAddedNotif = notifTypeIsEqual "team.collaborator-add"
 

--- a/integration/test/Notifications.hs
+++ b/integration/test/Notifications.hs
@@ -210,6 +210,9 @@ isTeamMemberJoinNotif = notifTypeIsEqual "team.member-join"
 isTeamMemberLeaveNotif :: (HasCallStack, MakesValue a) => a -> App Bool
 isTeamMemberLeaveNotif = notifTypeIsEqual "team.member-leave"
 
+isTeamMemberUpdateNotif :: (HasCallStack, MakesValue a) => a -> App Bool
+isTeamMemberUpdateNotif = notifTypeIsEqual "team.member-update"
+
 isTeamCollaboratorAddedNotif :: (HasCallStack, MakesValue a) => a -> App Bool
 isTeamCollaboratorAddedNotif = notifTypeIsEqual "team.collaborator-add"
 

--- a/integration/test/Test/Apps.hs
+++ b/integration/test/Test/Apps.hs
@@ -221,9 +221,11 @@ testPutApp = do
   domain <- make OwnDomain
   (owner, tid, [regularMember]) <- createTeam domain 2
   let new = def {name = "choppie"} :: NewApp
-  app <- bindResponse (createApp owner tid new) $ \resp -> do
+  (app, appId) <- bindResponse (createApp owner tid new) $ \resp -> do
     resp.status `shouldMatchInt` 200
-    resp.json %. "user"
+    (,)
+      <$> (resp.json %. "user")
+      <*> (resp.json %. "user.id")
 
   let Object appMetadata =
         [aesonQQ|
@@ -242,15 +244,15 @@ testPutApp = do
         }|]
 
   withWebSockets [owner, regularMember, app] \[wsOwner, wsRegularMember, wsApp] -> do
-    bindResponse (putAppMetadata tid owner app (Object appMetadata)) $ \resp -> do
+    bindResponse (putAppMetadata tid owner appId (Object appMetadata)) $ \resp -> do
       resp.status `shouldMatchInt` 200
     notifOwner <- awaitMatch isUserUpdatedNotif wsOwner
     notifMember <- awaitMatch isUserUpdatedNotif wsRegularMember
     notifApp <- awaitMatch isUserUpdatedNotif wsApp
-    notifOwner %. "payload.0.user.id" `shouldMatch` app
+    notifOwner %. "payload.0.user.id" `shouldMatch` appId
     length (nub [notifOwner, notifMember, notifApp]) `shouldMatchInt` 1
 
-  bindResponse (getApp owner tid app) $ \resp -> do
+  bindResponse (getApp owner tid appId) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json
       `shouldMatchShapeLenient` SObject
@@ -260,8 +262,8 @@ testPutApp = do
           ("app", SObject [("category", SString), ("description", SString)])
         ]
 
-  let badApp = "5e002eca-114f-11f1-b5a3-7306b8837f91"
-  bindResponse (putAppMetadata tid owner badApp (Object appMetadata)) $ \resp -> do
+  let badAppId = "5e002eca-114f-11f1-b5a3-7306b8837f91"
+  bindResponse (putAppMetadata tid owner badAppId (Object appMetadata)) $ \resp -> do
     resp.status `shouldMatchInt` 404
 
 -- | FUTUREWORK: 'Test.Apps.testFindApp',

--- a/integration/test/Test/Apps.hs
+++ b/integration/test/Test/Apps.hs
@@ -221,11 +221,9 @@ testPutApp = do
   domain <- make OwnDomain
   (owner, tid, [regularMember]) <- createTeam domain 2
   let new = def {name = "choppie"} :: NewApp
-  (app, appId) <- bindResponse (createApp owner tid new) $ \resp -> do
+  app <- bindResponse (createApp owner tid new) $ \resp -> do
     resp.status `shouldMatchInt` 200
-    (,)
-      <$> (resp.json %. "user")
-      <*> (resp.json %. "user.id")
+    resp.json %. "user"
 
   let Object appMetadata =
         [aesonQQ|
@@ -244,15 +242,15 @@ testPutApp = do
         }|]
 
   withWebSockets [owner, regularMember, app] \[wsOwner, wsRegularMember, wsApp] -> do
-    bindResponse (putAppMetadata tid owner appId (Object appMetadata)) $ \resp -> do
+    bindResponse (putAppMetadata tid owner app (Object appMetadata)) $ \resp -> do
       resp.status `shouldMatchInt` 200
     notifOwner <- awaitMatch isUserUpdatedNotif wsOwner
     notifMember <- awaitMatch isUserUpdatedNotif wsRegularMember
     notifApp <- awaitMatch isUserUpdatedNotif wsApp
-    notifOwner %. "payload.0.user.id" `shouldMatch` appId
+    notifOwner %. "payload.0.user.id" `shouldMatch` app
     length (nub [notifOwner, notifMember, notifApp]) `shouldMatchInt` 1
 
-  bindResponse (getApp owner tid appId) $ \resp -> do
+  bindResponse (getApp owner tid app) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json
       `shouldMatchShapeLenient` SObject
@@ -262,8 +260,8 @@ testPutApp = do
           ("app", SObject [("category", SString), ("description", SString)])
         ]
 
-  let badAppId = "5e002eca-114f-11f1-b5a3-7306b8837f91"
-  bindResponse (putAppMetadata tid owner badAppId (Object appMetadata)) $ \resp -> do
+  let badApp = "5e002eca-114f-11f1-b5a3-7306b8837f91"
+  bindResponse (putAppMetadata tid owner badApp (Object appMetadata)) $ \resp -> do
     resp.status `shouldMatchInt` 404
 
 -- | FUTUREWORK: 'Test.Apps.testFindApp',

--- a/integration/test/Test/Apps.hs
+++ b/integration/test/Test/Apps.hs
@@ -221,14 +221,16 @@ testPutApp = do
   domain <- make OwnDomain
   (owner, tid, [regularMember]) <- createTeam domain 2
   let new = def {name = "choppie"} :: NewApp
-  appId <- bindResponse (createApp owner tid new) $ \resp -> do
+  (app, appId) <- bindResponse (createApp owner tid new) $ \resp -> do
     resp.status `shouldMatchInt` 200
-    resp.json %. "user.id" & asString
+    (,)
+      <$> (resp.json %. "user")
+      <*> (resp.json %. "user.id")
 
   let Object appMetadata =
         [aesonQQ|
         {
-          "accent_id": 2147483647,
+          "accent_id": 126,
           "assets": [
             {
               "key": "3-1-47de4580-ae51-4650-acbb-d10c028cb0ac",
@@ -241,11 +243,15 @@ testPutApp = do
           "description": "This is the best app ever."
         }|]
 
-  withWebSockets [owner, regularMember] \[wsOwner, wsRegularMember] -> do
+  withWebSockets [owner, regularMember, app] \[wsOwner, wsRegularMember, wsApp] -> do
     bindResponse (putAppMetadata tid owner appId (Object appMetadata)) $ \resp -> do
       resp.status `shouldMatchInt` 200
-    void $ assertNoEvent 5 wsOwner
-    void $ assertNoEvent 5 wsRegularMember
+    notifOwner <- awaitMatch isUserUpdatedNotif wsOwner
+    notifMember <- awaitMatch isUserUpdatedNotif wsRegularMember
+    notifApp <- awaitMatch isUserUpdatedNotif wsApp
+    notifOwner %. "payload.0.user.id" `shouldMatch` appId
+    length (nub [notifOwner, notifMember, notifApp]) `shouldMatchInt` 1
+
   bindResponse (getApp owner tid appId) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json

--- a/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
@@ -39,12 +39,14 @@ import Wire.API.Team.Member qualified as T
 import Wire.API.Team.Role qualified as R
 import Wire.API.User
 import Wire.API.User.Auth
+import Wire.API.UserEvent hiding (UserLegalHoldDisabled)
 import Wire.AppStore (AppStore, StoredApp (..))
 import Wire.AppStore qualified as Store
 import Wire.AppSubsystem
 import Wire.AuthenticationSubsystem
 import Wire.AuthenticationSubsystem.Cookie (revokeAllCookies)
 import Wire.AuthenticationSubsystem.ZAuth
+import Wire.Events
 import Wire.GalleyAPIAccess
 import Wire.NotificationSubsystem
 import Wire.Sem.Now
@@ -66,7 +68,8 @@ runAppSubsystem ::
     Member Now r,
     Member TeamSubsystem r,
     Member NotificationSubsystem r,
-    Member Random r
+    Member Random r,
+    Member Events r
   ) =>
   InterpreterFor UserSubsystem (AuthenticationSubsystem ': r) ->
   InterpreterFor AuthenticationSubsystem r ->
@@ -194,7 +197,9 @@ getAppsImpl lusr tid = do
 updateAppImpl ::
   ( Member AppStore r,
     Member (Error AppSubsystemError) r,
+    Member Events r,
     Member GalleyAPIAccess r,
+    Member UserSubsystem r,
     Member UserStore r
   ) =>
   Local UserId ->
@@ -209,9 +214,14 @@ updateAppImpl lusr tid appid upd = do
     Right () -> pure ()
     Left Store.NotFound -> throw AppSubsystemErrorNoApp
   Store.updateUser appid (def {Store.name = upd.name, Store.assets = upd.assets, Store.accentId = upd.accentId})
-  -- FUTUREWORK(WPB-21287): internalUpdateSearchIndex appid
-  -- FUTUREWORK(WPB-21287): create event `app.updated`
-  pure ()
+  internalUpdateSearchIndex appid
+  generateUserEvent appid Nothing $
+    UserUpdated $
+      (emptyUserUpdatedData appid)
+        { eupName = upd.name,
+          eupAccentId = upd.accentId,
+          eupAssets = upd.assets
+        }
 
 refreshAppCookieImpl ::
   ( Member AuthenticationSubsystem r,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-23765

updating apps did not refresh the user index and did not send the user-update event.  this is now fixed.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)