### PR TITLE
Remove bogus warning from 5.32.0 release notes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 
 * - `postgresMigration` now has a single source of truth in the Galley chart values. Galley, Brig, and background-worker all read their PostgreSQL migration settings from there.
-  - If your deployment overrides the full `postgresMigration` object, add the new `domainRegistration` field to that override. Otherwise services may fail to start because the config is incomplete.
   - To migrate domain registration data to PostgreSQL, set `postgresMigration.domainRegistration` to `migration-to-postgresql`, run the background-worker migration with `migrateDomainRegistration: true`, and switch the setting to `postgresql` after completion.
   - The domain registration migration covers these Cassandra tables:
     `domain_registration`, `domain_registration_by_team`, and `domain_registration_challenge`. (#5195)


### PR DESCRIPTION
(Already fixed in https://github.com/wireapp/wire-server/releases, https://github.com/wireapp/wire-server/pull/5225.)

Helm charts are deep-merged, so if the `domainRegistration` field is missing, the default will be used.

## Checklist

 - [x] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
