### PR TITLE
fix: WPB-25750 Enable passing cspExtraConnectSrc value to nginx-ingress-services

### DIFF
--- a/changelog.d/3-bug-fixes/cspExtraConnect-multiIngress
+++ b/changelog.d/3-bug-fixes/cspExtraConnect-multiIngress
@@ -1,0 +1,1 @@
+Enable passing cspExtraConnectSrc value to nginx-ingress-services when working with multi-ingresses (renderCSPInIngress=True). It would be required for webapp to connect to third party sft servers.

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -40,7 +40,7 @@ metadata:
         {{if .Values.websockets.enabled}}
         set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";
         {{end}}
-        set $CSP "${CSP} https://*.{{ .Values.config.dns.base }};";
+        set $CSP "${CSP} https://*.{{ .Values.config.dns.base }}{{- if .Values.config.cspExtraConnectSrc }} {{ .Values.config.cspExtraConnectSrc }}{{- end }};";
         set $CSP "${CSP} default-src 'self';";
         set $CSP "${CSP} font-src 'self' data:;";
         set $CSP "${CSP} frame-src https://*.soundcloud.com https://*.spotify.com https://*.vimeo.com https://*.youtube-nocookie.com;";

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -175,6 +175,10 @@ config:
 # (multi-ingress), because the webapps can only provide CSP headers for one
 # (root) domain.
   renderCSPInIngress: false
+# Adds additional CSP connect-src entries. This is exclusive to `.config.dns.https`.
+# It is only respected when renderCSPInIngress=True. Multiple entries can be passed with a space in between.
+  cspExtraConnectSrc:
+# cspExtraConnectSrc: "https://sft.example-calling.com https://second-domain-example.com"
 # Is this a chart instantiation for an additional backend domain (multi-ingress)?
 #
 # If 'true' some resources aren't created because they're expected to already

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -74,7 +74,7 @@ nginx_conf:
   #     endpoints:
   #       backendURL: "https://nginz-https.red.example.com"
   #       backendWSURL: "https://nginz-ssl.red.example.com"
-  #       blackListURL: "https://clientblacklist.red.example.com/prod"
+  #       blackListURL: "https://clientblacklist.example.com/prod"
   #       teamsURL: "https://teams.red.example.com"
   #       accountsURL: "https://account.red.example.com"
   #       websiteURL: "https://red.example.com"

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -107,8 +107,8 @@ galley:
       # If set it must a map from `Z-Host` to URI prefix
       # Example:
       # multiIngress:
-      #    wire.example: https://accounts.wire.example/conversation-join/
-      #    example.net: https://accounts.example.net/conversation-join/
+      #    wire.example: https://account.wire.example/conversation-join/
+      #    example.net: https://account.example.net/conversation-join/
       multiIngress: null
       # Disable one ore more API versions. Please make sure the configuration value is the same in all these charts:
       # brig, cannon, cargohold, galley, gundeck, proxy, spar.

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1515,8 +1515,8 @@ Example:
 
 ```yaml
 multiIngress:
-   red.example.com: https://accounts.red.example.com/conversation-join/
-   green.example.com: https://accounts.green.example.net/conversation-join/
+   red.example.com: https://account.red.example.com/conversation-join/
+   green.example.com: https://account.green.example.net/conversation-join/
 ```
 
 ### Spar

--- a/docs/src/understand/associate/deeplink.md
+++ b/docs/src/understand/associate/deeplink.md
@@ -110,7 +110,7 @@ nginz:
         backendWSURL: "https://nginz-ssl.example.com"
         teamsURL: "https://teams.example.com"
         accountsURL: "https://account.example.com"
-        blackListURL: "https://clientblacklist.example.com/prod"
+        blackListURL: "https://clientblacklist.wire.com/prod"
         websiteURL: "https://example.com"
       apiProxy: # (optional)
         host: "socks5.proxy.com"
@@ -140,7 +140,7 @@ nginz:
         backendWSURL: "https://nginz-ssl.default.example.com"
         teamsURL: "https://teams.default.example.com"
         accountsURL: "https://account.default.example.com"
-        blackListURL: "https://clientblacklist.default.example.com/prod"
+        blackListURL: "https://clientblacklist.wire.com/prod"
         websiteURL: "https://default.example.com"
       apiProxy: # (optional)
         host: "socks5.proxy.com"
@@ -156,7 +156,7 @@ nginz:
         endpoints:
           backendURL: "https://nginz-https.red.example.com"
           backendWSURL: "https://nginz-ssl.red.example.com"
-          blackListURL: "https://clientblacklist.red.example.com/prod"
+          blackListURL: "https://clientblacklist.wire.com/prod"
           teamsURL: "https://teams.red.example.com"
           accountsURL: "https://account.red.example.com"
           websiteURL: "https://red.example.com"
@@ -169,7 +169,7 @@ nginz:
         endpoints:
           backendURL: "https://nginz-https.green.example.org"
           backendWSURL: "https://nginz-ssl.green.example.org"
-          blackListURL: "https://clientblacklist.green.example.org/prod"
+          blackListURL: "https://clientblacklist.wire.com/prod"
           teamsURL: "https://teams.green.example.org"
           accountsURL: "https://account.green.example.org"
           websiteURL: "https://green.example.org"
@@ -178,7 +178,7 @@ nginz:
         endpoints:
           backendURL: "https://nginz-https.blue.example.net"
           backendWSURL: "https://nginz-ssl.blue.example.net"
-          blackListURL: "https://clientblacklist.blue.example.net/prod"
+          blackListURL: "https://clientblacklist.wire.com/prod"
           teamsURL: "https://teams.blue.example.net"
           accountsURL: "https://account.blue.example.net"
           websiteURL: "https://blue.example.net"

--- a/docs/src/understand/associate/deeplink.md
+++ b/docs/src/understand/associate/deeplink.md
@@ -207,7 +207,7 @@ Otherwise you need to create a `.json` file, and host it somewhere users can get
       "backendWSURL" : "https://prod-nginz-ssl.wire.com",
       "blackListURL" : "https://clientblacklist.wire.com/prod",
       "teamsURL" : "https://teams.wire.com",
-      "accountsURL" : "https://accounts.wire.com",
+      "accountsURL" : "https://account.wire.com",
       "websiteURL" : "https://wire.com"
    },
    "apiProxy" : {

--- a/hack/bin/integration-setup-federation.sh
+++ b/hack/bin/integration-setup-federation.sh
@@ -8,7 +8,7 @@ export NAMESPACE=${NAMESPACE:-test-integration}
 # Available $HELMFILE_ENV profiles: default, default-ssl, kind, kind-ssl
 HELMFILE_ENV=${HELMFILE_ENV:-default}
 # This controls if integration tests run against ingress-nginx or envoy-gateway
-WIRE_INGRESS_MODE=${WIRE_INGRESS_MODE:-nginx}
+WIRE_INGRESS_MODE=${WIRE_INGRESS_MODE:-envoy}
 export WIRE_INGRESS_MODE
 ENVOY_GATEWAY_NAMESPACE=${ENVOY_GATEWAY_NAMESPACE:-envoy-gateway-system}
 export ENVOY_GATEWAY_NAMESPACE

--- a/hack/bin/integration-setup-federation.sh
+++ b/hack/bin/integration-setup-federation.sh
@@ -8,7 +8,7 @@ export NAMESPACE=${NAMESPACE:-test-integration}
 # Available $HELMFILE_ENV profiles: default, default-ssl, kind, kind-ssl
 HELMFILE_ENV=${HELMFILE_ENV:-default}
 # This controls if integration tests run against ingress-nginx or envoy-gateway
-WIRE_INGRESS_MODE=${WIRE_INGRESS_MODE:-envoy}
+WIRE_INGRESS_MODE=${WIRE_INGRESS_MODE:-nginx}
 export WIRE_INGRESS_MODE
 ENVOY_GATEWAY_NAMESPACE=${ENVOY_GATEWAY_NAMESPACE:-envoy-gateway-system}
 export ENVOY_GATEWAY_NAMESPACE


### PR DESCRIPTION
Enable passing cspExtraConnectSrc value to nginx-ingress-services when working with multi-ingresses (renderCSPInIngress=True). It would be required for webapp to connect to third party sft servers.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
