### PR TITLE
[WPB-25924] Remove redundant "get-app" end-point (use `POST /list-users` instead).

### DIFF
--- a/changelog.d/1-api-changes/WPB-25924-remove-redundant-_get-app_-end-point-_use-_post-_list-users_-instead_
+++ b/changelog.d/1-api-changes/WPB-25924-remove-redundant-_get-app_-end-point-_use-_post-_list-users_-instead_
@@ -1,0 +1,1 @@
+Remove redundant "get-app" end-point (use `POST /list-users` instead).


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-25924

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)