### PR TITLE
[WPB-18127] send emails to team admins on app creation events

### DIFF
--- a/changelog.d/2-features/WPB-18127-send-emails-to-team-admins-on-app-creation-_-update-_-deletion
+++ b/changelog.d/2-features/WPB-18127-send-emails-to-team-admins-on-app-creation-_-update-_-deletion
@@ -1,0 +1,1 @@
+Send emails to team admins on app creation / update / deletion.

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -47,6 +47,8 @@ module Wire.API.Routes.Internal.Brig
     EnterpriseLoginApi,
     SAMLIdPAPI,
     DeleteApp,
+    SendAppDeletionEmail,
+    AppDeletionEmailRequest (..),
     IdpChangedNotification (..),
   )
 where
@@ -730,6 +732,7 @@ type API =
            :<|> EnterpriseLoginApi
            :<|> SAMLIdPAPI
            :<|> DeleteApp
+           :<|> SendAppDeletionEmail
            :<|> GetAppIds
        )
 
@@ -752,6 +755,34 @@ type DeleteApp =
         :> "apps"
         :> Capture "uid" UserId
         :> Delete '[Servant.JSON] NoContent
+    )
+
+data AppDeletionEmailRequest = AppDeletionEmailRequest
+  { actorId :: UserId,
+    teamId :: TeamId,
+    appId :: UserId,
+    mbAppUser :: Maybe User
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON, S.ToSchema) via Schema AppDeletionEmailRequest
+
+instance ToSchema AppDeletionEmailRequest where
+  schema =
+    object $
+      AppDeletionEmailRequest
+        <$> (.actorId) .= field "actor_id" schema
+        <*> (.teamId) .= field "team_id" schema
+        <*> (.appId) .= field "app_id" schema
+        <*> (.mbAppUser) .= optField "app_user" (maybeWithDefault Null schema)
+
+type SendAppDeletionEmail =
+  Named
+    "i-send-app-deletion-email"
+    ( Summary "Send an email about app deletion to all team admins and owners"
+        :> "apps"
+        :> "send-deletion-email"
+        :> ReqBody '[Servant.JSON] AppDeletionEmailRequest
+        :> Post '[Servant.JSON] ()
     )
 
 type GetAppIds =

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -2173,6 +2173,9 @@ data PutApp = PutApp
   deriving (Arbitrary) via (GenericUniform PutApp)
   deriving (A.FromJSON, A.ToJSON, S.ToSchema) via Schema PutApp
 
+instance Default PutApp where
+  def = PutApp Nothing Nothing Nothing Nothing Nothing
+
 newtype Category = Category {fromCategory :: Text}
   deriving (Eq, Ord, Show, Read, Generic)
   deriving (Arbitrary) via GenericUniform Category

--- a/libs/wire-subsystems/src/Wire/AppSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/AppSubsystem.hs
@@ -42,9 +42,10 @@ instance Default AppSubsystemConfig where
 data AppSubsystemError
   = AppSubsystemErrorNoPerm
   | AppSubsystemErrorMissingAuth
-  | AppSubsystemErrorNoUser -- The user having created the app not found
-  | AppSubsystemErrorAppUserNotFound -- The user used to "enact" the app not found
-  | AppSubsystemErrorNoApp
+  | AppSubsystemErrorNoCreator
+  | AppSubsystemErrorNoAppData
+  | AppSubsystemErrorNoAppUser
+  | AppSubsystemErrorNoAppTeamMember
   deriving (Eq, Show)
 
 instance Exception AppSubsystemError
@@ -54,9 +55,10 @@ appSubsystemErrorToHttpError =
   StdError . \case
     AppSubsystemErrorNoPerm -> Wai.mkError status403 "app-no-permission" "User does not have permission to create or manage apps"
     AppSubsystemErrorMissingAuth -> Wai.mkError status403 "missing-auth" "Re-authentication via password required"
-    AppSubsystemErrorNoUser -> Wai.mkError status403 "create-app-no-user" "App owner not found"
-    AppSubsystemErrorAppUserNotFound -> Wai.mkError status403 "app-user-not-found" "App user not found"
-    AppSubsystemErrorNoApp -> Wai.mkError status404 "app-not-found" "App not found"
+    AppSubsystemErrorNoCreator -> Wai.mkError status403 "no-app-creator" "App owner not found"
+    AppSubsystemErrorNoAppData -> Wai.mkError status404 "app-not-found" "App not found (metadata record)"
+    AppSubsystemErrorNoAppUser -> Wai.mkError status404 "app-not-found" "App not found (user record)"
+    AppSubsystemErrorNoAppTeamMember -> Wai.mkError status404 "app-not-found" "App not found (team member record)"
 
 data AppSubsystem m a where
   CreateApp :: Local UserId -> TeamId -> NewApp -> AppSubsystem m CreatedApp
@@ -71,7 +73,16 @@ data AppSubsystem m a where
     AppSubsystem m (Either RetryAfter SomeUserToken)
   -- | Delete app.  This is called when deleting team members.  It
   -- does not check authentication.
+  --
+  -- Don't forget to call InternalDeleteAppSendEmail when you call
+  -- DeleteApp!
+  --
+  -- Rationale: sending the email notification requires some state
+  -- that is lost during deletion.  By calling it explicitly in the
+  -- logic of team member deletion (where everything else happens)
+  -- makes it harder to get it wrong.
   InternalDeleteApp :: TeamId -> UserId -> AppSubsystem m ()
+  DeleteAppSendEmail :: TeamId -> UserId -> Maybe User -> AppSubsystem m ()
 
 makeSem ''AppSubsystem
 

--- a/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
@@ -17,6 +17,7 @@
 
 module Wire.AppSubsystem.Interpreter where
 
+import Control.Lens
 import Data.ByteString.Conversion
 import Data.Default
 import Data.Id
@@ -35,6 +36,7 @@ import Polysemy.TinyLog (TinyLog)
 import Polysemy.TinyLog qualified as Log
 import System.Logger.Message qualified as Log
 import Wire.API.Event.Team
+import Wire.API.Routes.Internal.Galley.TeamsIntra (TeamName (..))
 import Wire.API.Team.Member qualified as T
 import Wire.API.Team.Role qualified as R
 import Wire.API.User
@@ -46,6 +48,8 @@ import Wire.AppSubsystem
 import Wire.AuthenticationSubsystem
 import Wire.AuthenticationSubsystem.Cookie (revokeAllCookies)
 import Wire.AuthenticationSubsystem.ZAuth
+import Wire.EmailSubsystem (AppEvent (..), EmailSubsystem)
+import Wire.EmailSubsystem qualified as Email
 import Wire.Events
 import Wire.GalleyAPIAccess
 import Wire.NotificationSubsystem
@@ -59,17 +63,18 @@ import Wire.UserStore qualified as Store
 import Wire.UserSubsystem (UserSubsystem, internalUpdateSearchIndex)
 
 runAppSubsystem ::
-  ( Member UserStore r,
-    Member TinyLog r,
+  ( Member AppStore r,
+    Member EmailSubsystem r,
     Member (Error AppSubsystemError) r,
-    Member (Input AppSubsystemConfig) r,
+    Member Events r,
     Member GalleyAPIAccess r,
-    Member AppStore r,
-    Member Now r,
-    Member TeamSubsystem r,
+    Member (Input AppSubsystemConfig) r,
     Member NotificationSubsystem r,
+    Member Now r,
     Member Random r,
-    Member Events r
+    Member TeamSubsystem r,
+    Member TinyLog r,
+    Member UserStore r
   ) =>
   InterpreterFor UserSubsystem (AuthenticationSubsystem ': r) ->
   InterpreterFor AuthenticationSubsystem r ->
@@ -84,6 +89,7 @@ runAppSubsystem runUser runAuth =
       UpdateApp lusr tid uid put -> updateAppImpl lusr tid uid put
       RefreshAppCookie lusr tid appId password -> runError $ refreshAppCookieImpl lusr tid appId password
       InternalDeleteApp tid appId -> internalDeleteAppImpl tid appId
+      DeleteAppSendEmail tid actorId mbAppUser -> deleteAppSendEmailImpl tid actorId mbAppUser
 
 createAppImpl ::
   ( Member UserStore r,
@@ -95,6 +101,7 @@ createAppImpl ::
     Member Now r,
     Member TeamSubsystem r,
     Member NotificationSubsystem r,
+    Member EmailSubsystem r,
     Member AuthenticationSubsystem r,
     Member UserSubsystem r,
     Member Random r
@@ -133,6 +140,7 @@ createAppImpl lusr tid newApp = do
 
   -- generate a team event
   generateTeamEvents creator.id tid [EdMemberJoin u.id]
+  createAppSendEmail creator tid newApp
 
   c :: Cookie (Token U) <- newCookie u.id Nothing PersistentCookie Nothing RevokeSameLabel
   pure
@@ -145,24 +153,46 @@ createAppImpl lusr tid newApp = do
         cookie = mkSomeToken c.cookieValue
       }
 
+createAppSendEmail ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member EmailSubsystem r
+  ) =>
+  StoredUser ->
+  TeamId ->
+  NewApp ->
+  Sem r ()
+createAppSendEmail creator tid newApp =
+  notifyAdmins tid $ \teamName now ->
+    NewAppCreated
+      { actor = fromName creator.name,
+        appName = newApp.name,
+        date = now,
+        permissions = "",
+        teamName = teamName,
+        teamId = tid
+      }
+
 -- | Check that @lusr@ is member of team with @tid@.
 ensureTeamMember ::
-  ( Member UserStore r,
-    Member (Error AppSubsystemError) r,
-    Member GalleyAPIAccess r
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member (Error AppSubsystemError) r
   ) =>
   Local UserId ->
   TeamId ->
   Sem r (StoredUser, T.TeamMember)
 ensureTeamMember lusr tid = do
-  storedUser <- Store.getUser (tUnqualified lusr) >>= note AppSubsystemErrorNoUser
-  teamMember <- getTeamMember storedUser.id tid >>= note AppSubsystemErrorNoPerm
+  storedUser <- Store.getUser (tUnqualified lusr) >>= note AppSubsystemErrorNoCreator
+  teamMember <- internalGetTeamMember storedUser.id tid >>= note AppSubsystemErrorNoPerm
   pure (storedUser, teamMember)
 
 getAppImpl ::
   ( Member AppStore r,
+    Member TeamSubsystem r,
     Member (Error AppSubsystemError) r,
-    Member GalleyAPIAccess r,
     Member UserStore r
   ) =>
   Local UserId ->
@@ -171,7 +201,7 @@ getAppImpl ::
   Sem r AppInfo
 getAppImpl lusr tid uid = do
   void $ ensureTeamMember lusr tid
-  storedApp <- Store.getApp uid tid >>= note AppSubsystemErrorNoApp
+  storedApp <- Store.getApp uid tid >>= note AppSubsystemErrorNoAppData
   pure $ storedAppToAppInfo storedApp
 
 storedAppToAppInfo :: StoredApp -> AppInfo
@@ -183,8 +213,8 @@ storedAppToAppInfo app =
 
 getAppsImpl ::
   ( Member AppStore r,
+    Member TeamSubsystem r,
     Member (Error AppSubsystemError) r,
-    Member GalleyAPIAccess r,
     Member UserStore r
   ) =>
   Local UserId ->
@@ -199,8 +229,11 @@ updateAppImpl ::
     Member (Error AppSubsystemError) r,
     Member Events r,
     Member GalleyAPIAccess r,
+    Member Now r,
+    Member TeamSubsystem r,
+    Member UserStore r,
     Member UserSubsystem r,
-    Member UserStore r
+    Member EmailSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -208,11 +241,12 @@ updateAppImpl ::
   PutApp ->
   Sem r ()
 updateAppImpl lusr tid appid upd = do
-  (_updater, umem) <- ensureTeamMember lusr tid
+  (updater, umem) <- ensureTeamMember lusr tid
   note AppSubsystemErrorNoPerm $ guard (T.hasPermission umem T.CreateApp)
+  oldApp <- Store.getUser appid >>= note AppSubsystemErrorNoAppUser
   Store.updateApp tid appid (Store.MkStoredAppUpdate {category = upd.category, description = upd.description}) >>= \case
     Right () -> pure ()
-    Left Store.NotFound -> throw AppSubsystemErrorNoApp
+    Left Store.NotFound -> throw AppSubsystemErrorNoAppData
   Store.updateUser appid (def {Store.name = upd.name, Store.assets = upd.assets, Store.accentId = upd.accentId})
   internalUpdateSearchIndex appid
   generateUserEvent appid Nothing $
@@ -222,13 +256,41 @@ updateAppImpl lusr tid appid upd = do
           eupAccentId = upd.accentId,
           eupAssets = upd.assets
         }
+  updateAppMaybeSendEmail updater tid oldApp.name (fromMaybe oldApp.name upd.name)
+
+updateAppMaybeSendEmail ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member EmailSubsystem r
+  ) =>
+  StoredUser ->
+  TeamId ->
+  Name ->
+  Name ->
+  Sem r ()
+updateAppMaybeSendEmail updater tid oldName newName = when (newName /= oldName) do
+  notifyAdmins tid $ \teamName now ->
+    AppMetadataChanged
+      { actor = fromName updater.name,
+        date = now,
+        newAppName = newName,
+        previousAppName = oldName,
+        teamName = teamName,
+        teamId = tid
+      }
 
 refreshAppCookieImpl ::
   ( Member AuthenticationSubsystem r,
     Member AppStore r,
     Member (Error RetryAfter) r,
     Member (Error AppSubsystemError) r,
-    Member GalleyAPIAccess r
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member TeamSubsystem r,
+    Member UserStore r,
+    Member EmailSubsystem r
   ) =>
   Local UserId ->
   TeamId ->
@@ -239,15 +301,40 @@ refreshAppCookieImpl (tUnqualified -> uid) tid appId mbPassword = do
   reauthenticateEither uid mbPassword
     >>= either (const $ throw AppSubsystemErrorMissingAuth) (const $ pure ())
 
-  mem <- getTeamMember uid tid >>= note AppSubsystemErrorNoPerm
+  mem <- internalGetTeamMember uid tid >>= note AppSubsystemErrorNoPerm
   note AppSubsystemErrorNoPerm $ guard (T.hasPermission mem T.ManageApps)
-  void $ Store.getApp appId tid >>= note AppSubsystemErrorNoApp
+  void $ Store.getApp appId tid >>= note AppSubsystemErrorNoAppData
 
   revokeAllCookies appId
   c :: Cookie (Token U) <-
     newCookieLimited appId Nothing PersistentCookie Nothing RevokeSameLabel
       >>= either throw pure
+  refreshAppCookieSendEmail uid tid appId
   pure $ mkSomeToken c.cookieValue
+
+refreshAppCookieSendEmail ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member (Error AppSubsystemError) r,
+    Member EmailSubsystem r
+  ) =>
+  UserId ->
+  TeamId ->
+  UserId ->
+  Sem r ()
+refreshAppCookieSendEmail actorId tid appId = do
+  appUser <- Store.getUser appId >>= note AppSubsystemErrorNoAppUser
+  actor <- appEventActor actorId
+  notifyAdmins tid $ \teamName now ->
+    AppTokenChanged
+      { actor = actor,
+        appName = appUser.name,
+        date = now,
+        teamName = teamName,
+        teamId = tid
+      }
 
 appNewStoredUser ::
   (Member (Input AppSubsystemConfig) r, Member Random r) =>
@@ -287,10 +374,87 @@ appNewStoredUser creator new = do
 defAppSupportedProtocols :: Set BaseProtocolTag
 defAppSupportedProtocols = Set.singleton BaseProtocolMLSTag
 
-internalDeleteAppImpl ::
-  (Member AppStore r) =>
+-- | Send the notification email for an 'AppEvent' to every team admin/owner.
+-- Admins without an email address are silently skipped.
+-- The callback receives the team name and current timestamp; both are fetched here.
+notifyAdmins ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member EmailSubsystem r
+  ) =>
+  TeamId ->
+  (Text -> UTCTimeMillis -> AppEvent) ->
+  Sem r ()
+notifyAdmins tid makeEvent = do
+  teamName <- tnName <$> getTeamName tid
+  now <- toUTCTimeMillis <$> get
+  let event = makeEvent teamName now
+  admins <- internalGetTeamAdmins tid
+  let adminUids = admins ^.. T.teamMembers . traverse . T.userId
+  adminUsers <- Store.getUsers adminUids
+  forM_ adminUsers $ \u ->
+    for_ u.email $ \email ->
+      Email.sendAppEventEmail email u.name tid event u.locale
+
+-- | Best-effort actor display name for an 'AppEvent'.
+appEventActor :: (Member UserStore r) => UserId -> Sem r Text
+appEventActor actorId = maybe "-/-" (fromName . (.name)) <$> Store.getUser actorId
+
+-- | TODO: no operation toggles app availability yet. This helper wires the
+-- 'AppAvailabilityChanged' event end-to-end; call it from the availability
+-- toggle once that operation exists.
+_changeAppAvailabilitySendEmail ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member EmailSubsystem r
+  ) =>
   TeamId ->
   UserId ->
+  UserId ->
+  Text ->
+  Text ->
   Sem r ()
-internalDeleteAppImpl teamId appId =
+_changeAppAvailabilitySendEmail tid appId actorId previousAvailability newAvailability = do
+  appName <- maybe (Name "-/-") (.name) <$> Store.getUser appId
+  actor <- appEventActor actorId
+  notifyAdmins tid $ \teamName now ->
+    AppAvailabilityChanged
+      { actor = actor,
+        appName = appName,
+        date = now,
+        newAvailability = newAvailability,
+        previousAvailability = previousAvailability,
+        teamName = teamName,
+        teamId = tid
+      }
+
+internalDeleteAppImpl :: (Member AppStore r) => TeamId -> UserId -> Sem r ()
+internalDeleteAppImpl teamId appId = do
   Store.deleteApp appId teamId
+
+deleteAppSendEmailImpl ::
+  ( Member TeamSubsystem r,
+    Member UserStore r,
+    Member GalleyAPIAccess r,
+    Member Now r,
+    Member EmailSubsystem r
+  ) =>
+  TeamId ->
+  UserId ->
+  Maybe User ->
+  Sem r ()
+deleteAppSendEmailImpl tid actorId mbAppUser = do
+  let appName = maybe (Name "-/-") (.userDisplayName) mbAppUser
+  actor <- appEventActor actorId
+  notifyAdmins tid $ \teamName now ->
+    AppDeleted
+      { actor = actor,
+        appName = appName,
+        date = now,
+        teamName = teamName,
+        teamId = tid
+      }

--- a/libs/wire-subsystems/src/Wire/BrigAPIAccess.hs
+++ b/libs/wire-subsystems/src/Wire/BrigAPIAccess.hs
@@ -120,6 +120,7 @@ data BrigAPIAccess m a where
   UpdateGroup :: UpdateGroupInternalRequest -> BrigAPIAccess m (Either Wai.Error ())
   DeleteGroupInternal :: ManagedBy -> TeamId -> UserGroupId -> BrigAPIAccess m (Either DeleteGroupManagedError ())
   DeleteApp :: TeamId -> UserId -> BrigAPIAccess m ()
+  DeleteAppSendEmail :: UserId -> TeamId -> UserId -> Maybe User -> BrigAPIAccess m ()
   GetAppIdsForTeam :: TeamId -> BrigAPIAccess m [UserId]
   SetAccountStatus :: UserId -> AccountStatus -> BrigAPIAccess m ()
   -- SAML / SCIM user management (migrated from Spar.Sem.BrigAccess)

--- a/libs/wire-subsystems/src/Wire/BrigAPIAccess/Rpc.hs
+++ b/libs/wire-subsystems/src/Wire/BrigAPIAccess/Rpc.hs
@@ -49,7 +49,7 @@ import Wire.API.Connection
 import Wire.API.Error.Galley
 import Wire.API.Locale
 import Wire.API.MLS.CipherSuite
-import Wire.API.Routes.Internal.Brig (CreateGroupInternalRequest (..), GetBy, IdpChangedNotification (..), UpdateGroupInternalRequest (..))
+import Wire.API.Routes.Internal.Brig (AppDeletionEmailRequest (..), CreateGroupInternalRequest (..), GetBy, IdpChangedNotification (..), UpdateGroupInternalRequest (..))
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti qualified as Multi
 import Wire.API.Team.Export
@@ -147,6 +147,8 @@ interpretBrigAccess brigEndpoint =
         setAccountStatus uid status
       DeleteApp teamId uid ->
         deleteApp teamId uid
+      DeleteAppSendEmail actorId tid appId mbAppUser ->
+        deleteAppSendEmail actorId tid appId mbAppUser
       CreateSAML uref buid teamid name managedBy handle richInfo mLocale role ->
         createSAML uref buid teamid name managedBy handle richInfo mLocale role
       CreateNoSAML extId email uid teamid uname locale role ->
@@ -753,6 +755,21 @@ deleteApp teamId uid = do
     brigRequest $
       method DELETE
         . paths ["i", "teams", toByteString' teamId, "apps", toByteString' uid]
+        . expect2xx
+
+deleteAppSendEmail ::
+  (Member Rpc r, Member (Input Endpoint) r) =>
+  UserId ->
+  TeamId ->
+  UserId ->
+  Maybe User ->
+  Sem r ()
+deleteAppSendEmail actorId tid appId mbAppUser = do
+  void $
+    brigRequest $
+      method POST
+        . path "/i/apps/send-deletion-email"
+        . json AppDeletionEmailRequest {actorId, teamId = tid, appId, mbAppUser}
         . expect2xx
 
 getAppIdsForTeam ::

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -21,6 +22,7 @@ module Wire.EmailSubsystem where
 
 import Data.Code qualified as Code
 import Data.Id
+import Data.Json.Util
 import Data.X509.Extended (CertDescription)
 import Imports
 import Polysemy
@@ -30,6 +32,57 @@ import Wire.API.Locale
 import Wire.API.User
 import Wire.API.User.Activation (ActivationCode, ActivationKey)
 import Wire.API.User.Client (Client (..))
+
+-- | A typed description of something that happened to an app in a team. Each
+-- constructor corresponds to a distinct admin-notification email (and template).
+--
+-- See https://www.figma.com/design/AMNqFhTUElOZDJfbUYnMmJ/Apps--Services----Integrations?node-id=431-2452
+data AppEvent
+  = NewAppCreated -- app-creation
+      { actor :: Text,
+        appName :: Name,
+        date :: UTCTimeMillis,
+        permissions :: Text,
+        teamId :: TeamId,
+        teamName :: Text
+        -- TODO: team management url (${URL}) and ${support}?  is that included in branding?
+      }
+  | AppMetadataChanged
+      { actor :: Text,
+        date :: UTCTimeMillis,
+        newAppName :: Name,
+        previousAppName :: Name,
+        teamId :: TeamId,
+        teamName :: Text
+        -- TODO: team management url (${URL}) and ${support}?  is that included in branding?
+      }
+  | AppTokenChanged
+      { actor :: Text,
+        appName :: Name,
+        date :: UTCTimeMillis,
+        teamId :: TeamId,
+        teamName :: Text
+        -- TODO: team management url (${URL}) and ${support}?  is that included in branding?
+      }
+  | AppDeleted
+      { actor :: Text,
+        appName :: Name,
+        date :: UTCTimeMillis,
+        teamId :: TeamId,
+        teamName :: Text
+        -- TODO: team management url (${URL}) and ${support}?  is that included in branding?
+      }
+  | AppAvailabilityChanged
+      { actor :: Text,
+        appName :: Name,
+        date :: UTCTimeMillis,
+        newAvailability :: Text,
+        previousAvailability :: Text,
+        teamId :: TeamId,
+        teamName :: Text
+        -- TODO: team management url (${URL}) and ${support}?  is that included in branding?
+      }
+  deriving (Eq, Show)
 
 data EmailSubsystem m a where
   SendPasswordResetMail :: EmailAddress -> PasswordResetPair -> Maybe Locale -> EmailSubsystem m ()
@@ -61,5 +114,6 @@ data EmailSubsystem m a where
     Maybe URI ->
     Maybe Locale ->
     EmailSubsystem m ()
+  SendAppEventEmail :: EmailAddress -> Name -> TeamId -> AppEvent -> Maybe Locale -> EmailSubsystem m ()
 
 makeSem ''EmailSubsystem

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Interpreter.hs
@@ -31,6 +31,7 @@ import Data.Text.Encoding qualified as T
 import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy qualified as TL
 import Data.Text.Template
+import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.UUID (toText)
 import Data.X509.Extended
 import Imports
@@ -76,6 +77,8 @@ emailSubsystemInterpreter userTpls teamTpls branding = interpret \case
   SendNewTeamOwnerWelcomeEmail email tid teamName loc name -> sendNewTeamOwnerWelcomeEmailImpl teamTpls branding email tid teamName loc name
   SendSAMLIdPChanged email tid mbUid addedCerts removedCerts idPId oldIssuer oldEndpoint newIssuer newEndpoint mLocale ->
     sendSAMLIdPChangedImpl teamTpls branding email tid mbUid addedCerts removedCerts idPId oldIssuer oldEndpoint newIssuer newEndpoint mLocale
+  SendAppEventEmail email name tid event mLocale ->
+    sendAppEventEmailImpl teamTpls branding email name tid event mLocale
 
 -------------------------------------------------------------------------------
 -- Verification Email for
@@ -697,6 +700,86 @@ renderIdPConfigChangeEmail email IdPConfigChangeEmailTemplate {..} branding adde
         & Map.insert "fingerprint" (T.pack d.fingerprint)
         & Map.insert "subject" (T.pack d.subject)
         & Map.insert "issuer" (T.pack d.issuer)
+
+-------------------------------------------------------------------------------
+-- App Event Email
+
+-- https://www.figma.com/design/AMNqFhTUElOZDJfbUYnMmJ/Apps--Services----Integrations?node-id=431-2452&p=f&t=PVFSkjqPlWKxbHUw-0
+
+sendAppEventEmailImpl ::
+  (Member EmailSending r, Member TinyLog r) =>
+  Localised TeamTemplates ->
+  Map Text Text ->
+  EmailAddress ->
+  Name ->
+  TeamId ->
+  AppEvent ->
+  Maybe Locale ->
+  Sem r ()
+sendAppEventEmailImpl teamTemplates branding email recipientName tid event mLocale = do
+  let templates = appEmails . snd $ forLocale mLocale teamTemplates
+  mail <- logEmailRenderErrors "app event email" $ renderAppEventEmail email recipientName tid templates event branding
+  sendMail mail
+
+renderAppEventEmail ::
+  (Member (Output Text) r) =>
+  EmailAddress ->
+  Name ->
+  TeamId ->
+  AppEmailTemplates ->
+  AppEvent ->
+  Map Text Text ->
+  Sem r Mail
+renderAppEventEmail email recipientName tid AppEmailTemplates {..} event branding = do
+  url <- toStrict <$> renderTextWithBrandingSem appEmailUrl (Map.singleton "team_id" (idToText tid))
+  let tpl = selectTemplate event
+      replace =
+        branding
+          & Map.insert "team_id" (idToText tid)
+          & Map.insert "team_name" event.teamName
+          & Map.insert "actor" event.actor
+          & Map.insert "date" (formatAppEventDate event.date)
+          & Map.insert "url" url
+          & Map.union (eventVars event)
+  txt <- renderTextWithBrandingSem tpl.appEmailBodyText replace
+  html <- renderHtmlWithBrandingSem tpl.appEmailBodyHtml replace
+  subj <- renderTextWithBrandingSem tpl.appEmailSubject replace
+  let from = Address (Just tpl.appEmailSenderName) (fromEmail tpl.appEmailSender)
+      to = mkMimeAddress recipientName email
+  pure
+    (emptyMail from)
+      { mailTo = [to],
+        mailHeaders =
+          [ ("Subject", toStrict subj),
+            ("X-Zeta-Purpose", "AppEvent")
+          ],
+        mailParts = [[plainPart txt, htmlPart html]]
+      }
+  where
+    selectTemplate = \case
+      NewAppCreated {} -> appCreationEmail
+      AppMetadataChanged {} -> appMetadataChangeEmail
+      AppTokenChanged {} -> appTokenChangeEmail
+      AppDeleted {} -> appDeletionEmail
+      AppAvailabilityChanged {} -> appAvailabilityChangeEmail
+    eventVars = \case
+      NewAppCreated {appName, permissions} ->
+        Map.fromList [("app_name", fromName appName), ("permissions", permissions)]
+      AppMetadataChanged {newAppName, previousAppName} ->
+        Map.fromList [("new_app_name", fromName newAppName), ("previous_app_name", fromName previousAppName)]
+      AppTokenChanged {appName} ->
+        Map.singleton "app_name" (fromName appName)
+      AppDeleted {appName} ->
+        Map.singleton "app_name" (fromName appName)
+      AppAvailabilityChanged {appName, newAvailability, previousAvailability} ->
+        Map.fromList
+          [ ("app_name", fromName appName),
+            ("new_availability", newAvailability),
+            ("previous_availability", previousAvailability)
+          ]
+
+formatAppEventDate :: UTCTimeMillis -> Text
+formatAppEventDate = T.pack . formatTime defaultTimeLocale "%Y-%m-%d" . fromUTCTimeMillis
 
 -------------------------------------------------------------------------------
 -- MIME Conversions

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
@@ -21,7 +21,7 @@
 module Wire.EmailSubsystem.Template where
 
 import Control.Exception
-import Data.Aeson (FromJSON)
+import Data.Aeson (FromJSON, parseJSON, withObject, (.!=), (.:), (.:?))
 import Data.ByteString qualified as BS
 import Data.Map qualified as Map
 import Data.Text (pack, unpack)
@@ -201,10 +201,21 @@ data TeamOpts = TeamOpts
     -- | Team Creator Welcome URL
     tCreatorWelcomeUrl :: !Text,
     -- | Team Member Welcome URL
-    tMemberWelcomeUrl :: !Text
+    tMemberWelcomeUrl :: !Text,
+    -- | App management URL template (may contain ${team_id}); defaults to "" if absent
+    tAppManagementUrl :: !Text
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON)
+
+instance FromJSON TeamOpts where
+  parseJSON = withObject "TeamOpts" $ \o ->
+    TeamOpts
+      <$> o .: "tInvitationUrl"
+      <*> o .: "tExistingUserInvitationUrl"
+      <*> o .: "tActivationUrl"
+      <*> o .: "tCreatorWelcomeUrl"
+      <*> o .: "tMemberWelcomeUrl"
+      <*> o .:? "tAppManagementUrl" .!= ""
 
 loadTeamTemplates :: TeamOpts -> FilePath -> Locale -> EmailAddress -> IO (Localised TeamTemplates)
 loadTeamTemplates tOptions templatesDir defLocale sender = readLocalesDir defLocale templatesDir "team" $ \fp ->
@@ -248,11 +259,26 @@ loadTeamTemplates tOptions templatesDir defLocale sender = readLocalesDir defLoc
             <*> pure sender
             <*> readText' fp "email/sender.txt"
         )
+    <*> ( AppEmailTemplates
+            (template tOptions.tAppManagementUrl)
+            <$> appEmailTpl fp "app-creation"
+            <*> appEmailTpl fp "app-deletion"
+            <*> appEmailTpl fp "app-availability-change"
+            <*> appEmailTpl fp "app-metadata-change"
+            <*> appEmailTpl fp "app-token-change"
+        )
   where
     tUrl = template tOptions.tInvitationUrl
     tExistingUrl = template tOptions.tExistingUserInvitationUrl
     readTemplate' = readTemplateWithDefault templatesDir defLocale "team"
     readText' = readTextWithDefault templatesDir defLocale "team"
+    appEmailTpl fp name =
+      AppEmailTemplate
+        <$> readTemplate' fp ("email/" <> name <> "-subject.txt")
+        <*> readTemplate' fp ("email/" <> name <> ".txt")
+        <*> readTemplate' fp ("email/" <> name <> ".html")
+        <*> pure sender
+        <*> readText' fp "email/sender.txt"
 
 -- | URL templates needed to render the user email templates. These are plain
 -- 'Text' 'Data.Text.Template.template' strings, mirroring the corresponding

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
@@ -203,7 +203,7 @@ data TeamOpts = TeamOpts
     -- | Team Member Welcome URL
     tMemberWelcomeUrl :: !Text,
     -- | App management URL template (may contain ${team_id}); defaults to "" if absent
-    tAppManagementUrl :: !Text
+    tAppManagementUrl :: !Text -- TODO: rename to "tTeamManagementUrl", add to config.
   }
   deriving stock (Show, Generic)
 

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Templates/Team.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Templates/Team.hs
@@ -62,10 +62,28 @@ data IdPConfigChangeEmailTemplate = IdPConfigChangeEmailTemplate
     senderName :: !Text
   }
 
+data AppEmailTemplate = AppEmailTemplate
+  { appEmailSubject :: !Template,
+    appEmailBodyText :: !Template,
+    appEmailBodyHtml :: !Template,
+    appEmailSender :: !EmailAddress,
+    appEmailSenderName :: !Text
+  }
+
+data AppEmailTemplates = AppEmailTemplates
+  { appEmailUrl :: !Template,
+    appCreationEmail :: !AppEmailTemplate,
+    appDeletionEmail :: !AppEmailTemplate,
+    appAvailabilityChangeEmail :: !AppEmailTemplate,
+    appMetadataChangeEmail :: !AppEmailTemplate,
+    appTokenChangeEmail :: !AppEmailTemplate
+  }
+
 data TeamTemplates = TeamTemplates
   { invitationEmail :: !InvitationEmailTemplate,
     existingUserInvitationEmail :: !InvitationEmailTemplate,
     memberWelcomeEmail :: !MemberWelcomeEmailTemplate,
     newTeamOwnerWelcomeEmail :: !NewTeamOwnerWelcomeEmailTemplate,
-    idpConfigChangeEmail :: !IdPConfigChangeEmailTemplate
+    idpConfigChangeEmail :: !IdPConfigChangeEmailTemplate,
+    appEmails :: !AppEmailTemplates
   }

--- a/libs/wire-subsystems/test/unit/Wire/AppSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/AppSubsystem/InterpreterSpec.hs
@@ -1,0 +1,243 @@
+{-# OPTIONS_GHC -Wno-ambiguous-fields -Wno-incomplete-uni-patterns #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.AppSubsystem.InterpreterSpec (spec) where
+
+import Data.Default (def)
+import Data.Domain
+import Data.Id
+import Data.LegalHold (UserLegalHoldStatus (..))
+import Data.Map qualified as Map
+import Data.Misc
+import Data.Qualified
+import Data.Tagged (Tagged)
+import Data.Text qualified as T
+import Imports
+import Polysemy
+import Polysemy.Error
+import Polysemy.Input
+import Polysemy.Internal
+import Polysemy.State
+import Polysemy.TinyLog (TinyLog)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Wire.API.Error (ErrorS)
+import Wire.API.Error.Galley (GalleyError (TeamMemberNotFound, TeamNotFound))
+import Wire.API.Team.Member
+import Wire.API.Team.Permission
+import Wire.API.Team.Role
+import Wire.API.User
+import Wire.AppStore hiding (deleteApp, updateApp)
+import Wire.AppSubsystem
+import Wire.AppSubsystem.Interpreter
+import Wire.EmailSubsystem
+import Wire.Events (Events)
+import Wire.GalleyAPIAccess
+import Wire.MockInterpreters
+import Wire.NotificationSubsystem
+import Wire.Sem.Now (Now)
+import Wire.Sem.Random (Random)
+import Wire.StoredUser
+import Wire.TeamSubsystem
+import Wire.TeamSubsystem.GalleyAPI (interpretTeamSubsystemToGalleyAPI)
+import Wire.UserKeyStore
+import Wire.UserStore
+
+type LowerAppEffects =
+  '[ Now,
+     Random,
+     TinyLog,
+     Input AppSubsystemConfig,
+     State [Push],
+     State [MiniEvent],
+     State (Map EmailAddress [SentMail]),
+     State [StoredApp],
+     State MockAuthenticationState,
+     Error AppSubsystemError,
+     ErrorS 'TeamMemberNotFound,
+     ErrorS 'TeamNotFound
+   ]
+
+-- | (fisx) I wonder if we should do this everywhere?
+(.>) :: (a -> b) -> (b -> c) -> a -> c
+f .> g = g . f
+
+infixr 9 .>
+
+runLowerAppEffects ::
+  [StoredApp] ->
+  Sem (LowerAppEffects `Append` r) a ->
+  Sem r (Either AppSubsystemError (a, Map EmailAddress [SentMail]))
+runLowerAppEffects initialApps =
+  interpretNowConst defaultTime
+    .> runRandomPure
+    .> noopLogger
+    .> runInputConst def
+    .> evalState @[Push] []
+    .> evalState @[MiniEvent] []
+    .> runState @(Map EmailAddress [SentMail]) mempty
+    .> evalState initialApps
+    .> evalState emptyMockAuthenticationState
+    .> runError @AppSubsystemError
+    .> runError @(Tagged 'TeamMemberNotFound ())
+    .> runError @(Tagged 'TeamNotFound ())
+    .> fmap (either (error . show) (either (error . show) (fmap swap)))
+
+-- | Run a single AppSubsystem operation and return the emails that were sent.
+-- UserSubsystem and AuthenticationSubsystem are stubs: they crash loudly if invoked.
+runAppEffects ::
+  [StoredUser] ->
+  [StoredApp] ->
+  Map TeamId [TeamMember] ->
+  Sem
+    ( '[ AppSubsystem,
+         TeamSubsystem,
+         GalleyAPIAccess,
+         UserStore,
+         UserKeyStore,
+         AppStore,
+         EmailSubsystem,
+         NotificationSubsystem,
+         Events
+       ]
+        `Append` LowerAppEffects
+    )
+    a ->
+  Either AppSubsystemError (a, Map EmailAddress [SentMail])
+runAppEffects initialUsers initialApps teams action =
+  run
+    . ( runAppSubsystem inMemoryUserSubsystemInterpreter mockAuthenticationSubsystemInterpreter
+          .> interpretTeamSubsystemToGalleyAPI
+          .> miniGalleyAPIAccess teams def
+          .> runInMemoryUserStoreInterpreter initialUsers mempty
+          .> runInMemoryUserKeyStoreIntepreterWithStoredUsers initialUsers
+          .> inMemoryAppStoreInterpreter
+          .> inMemoryEmailSubsystemInterpreter
+          .> inMemoryNotificationSubsystemInterpreter
+          .> miniEventInterpreter
+          .> runLowerAppEffects initialApps
+      )
+    $ action
+
+-- | Minimal StoredUser with only the fields we care about set.
+mkStoredUser :: UserId -> Name -> Maybe EmailAddress -> Maybe TeamId -> StoredUser
+mkStoredUser uid uname email tid =
+  StoredUser
+    { id = uid,
+      userType = Nothing,
+      name = uname,
+      textStatus = Nothing,
+      pict = Nothing,
+      email = email,
+      emailUnvalidated = Nothing,
+      ssoId = Nothing,
+      accentId = ColourId 0,
+      assets = Nothing,
+      activated = True,
+      status = Just Active,
+      expires = Nothing,
+      language = Nothing,
+      country = Nothing,
+      providerId = Nothing,
+      serviceId = Nothing,
+      handle = Nothing,
+      teamId = tid,
+      managedBy = Nothing,
+      supportedProtocols = Nothing,
+      searchable = Nothing
+    }
+
+-- | A team member with full (owner) permissions, so they pass both CreateApp
+-- and isAdminOrOwner checks.
+mkOwnerMember :: UserId -> TeamMember
+mkOwnerMember uid = mkTeamMember uid fullPermissions Nothing UserLegalHoldDisabled
+
+spec :: Spec
+spec = describe "AppSubsystem" $ do
+  focus . prop "CRUD" . noShrinking {- shrinking takes too long in this test -} $
+    \(tid :: TeamId)
+     (creatorId :: UserId)
+     (memberId :: UserId)
+     (mbMemberEmail :: Maybe EmailAddress)
+     (newApp :: NewApp) ->
+        let mbPassword = plainTextPassword6 "123456aA1!"
+            domain = Domain "localdomain"
+            Just creatorEmail = emailAddressText "creator@example.com"
+            creator = mkStoredUser creatorId (Name "Creator") (Just creatorEmail) (Just tid)
+            lCreatorId = toLocalUnsafe domain creatorId
+            creatorMember = mkOwnerMember creatorId
+            memberUser = mkStoredUser memberId (Name "member") mbMemberEmail (Just tid)
+            memberMember = mkTeamMember memberId (rolePermissions RoleMember) Nothing UserLegalHoldDisabled
+            team = Map.singleton tid [creatorMember, memberMember]
+            putApp = (def :: PutApp) {name = Just (changeName newApp.name)}
+              where
+                changeName :: Name -> Name
+                changeName (Name nm) = Name $ case T.splitAt 3 nm of
+                  (a, b) -> (if a == "aaa" then "BBB" else "aaa") <> b
+
+            result = runAppEffects [creator, memberUser] [] team do
+              createdApp <- Wire.AppSubsystem.createApp lCreatorId tid newApp
+              let appId :: UserId = createdApp.user.profileQualifiedId & qUnqualified
+              appInfo <- Wire.AppSubsystem.getApp lCreatorId tid appId
+              allApps <- Wire.AppSubsystem.getApps lCreatorId tid
+              appUser <- getUser appId
+              updateApp lCreatorId tid appId putApp
+              eNewCookieResult <- refreshAppCookie lCreatorId tid appId mbPassword
+              internalDeleteApp tid appId
+              appUser' <- getUser appId
+              deleteAppSendEmail tid appId (mkUserFromStored domain def <$> appUser')
+              allApps' <- Wire.AppSubsystem.getApps lCreatorId tid
+              pure (createdApp, appInfo, allApps, appUser, eNewCookieResult, appUser', allApps')
+
+            checkState (createdApp, appInfo, allApps, appUser, eNewCookieResult, appUser', allApps') =
+              let appId = createdApp.user.profileQualifiedId & qUnqualified
+               in foldl' (.&&.) (property True) $
+                    [ appId === fst (head allApps),
+                      appInfo.category === newApp.category,
+                      (fst <$> allApps) === [appId],
+                      ((.id) <$> appUser) === Just appId,
+                      -- Just check that the token's there.  It is fake, so nothing interesting to find inside it.
+                      property (either (const False) (const True) eNewCookieResult),
+                      ((.id) <$> appUser') === Just appId,
+                      (fst <$> allApps') === []
+                    ]
+
+            extractEmailEventTypes :: Map EmailAddress [SentMail] -> [String]
+            extractEmailEventTypes emails = reverse eventTypes
+              where
+                eventTypes = xtract <$> fromJust (Map.lookup creatorEmail emails)
+
+                xtract sentMail = case sentMail.content.aeEvent of
+                  AppDeleted {} -> "deleted"
+                  NewAppCreated {} -> "created"
+                  AppMetadataChanged {} -> "metadata-changed"
+                  AppTokenChanged {} -> "token-changed"
+                  AppAvailabilityChanged {} ->
+                    -- FUTUREWORK: https://wearezeta.atlassian.net/browse/WPB-25982
+                    "availability-changed"
+
+            expectedEmailEvents :: [String]
+            expectedEmailEvents =
+              ["created", "metadata-changed", "token-changed", "deleted"]
+         in case result of
+              Left err -> counterexample (show err) False
+              Right (state, sentEmails) ->
+                checkState state
+                  .&&. (extractEmailEventTypes sentEmails `shouldBe` expectedEmailEvents)

--- a/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateDumpSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateDumpSpec.hs
@@ -1,0 +1,189 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Not a unit test: renders every sample email from
+-- "Wire.EmailSubsystem.TemplateFixtures" to disk (subject, plain text and html
+-- for each), plus an @index.html@ that shows all of them one under the other,
+-- for eyeballing template changes.
+--
+-- Only runs when @WIRE_EMAIL_DUMP_DIR@ is set, otherwise it is pending:
+--
+-- > WIRE_EMAIL_DUMP_DIR=/tmp/emails make c package=wire-subsystems test=1
+-- > WIRE_EMAIL_DUMP_DIR=/tmp/emails WIRE_EMAIL_DUMP_LOCALES=de,ar,ja ... # default: en
+-- > WIRE_EMAIL_DUMP_DIR=/tmp/emails WIRE_EMAIL_DUMP_LOCALES=all ...      # all 20 locales
+module Wire.EmailSubsystem.TemplateDumpSpec (spec) where
+
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as LT
+import Data.Text.Lazy.Encoding qualified as LTE
+import Imports
+import Network.Mail.Mime
+import System.FilePath ((</>))
+import Test.Hspec
+import Wire.API.Locale
+import Wire.EmailSubsystem.TemplateFixtures
+
+spec :: Spec
+spec = focus $ describe "email template dump" $ do
+  mDir <- runIO $ lookupEnv "WIRE_EMAIL_DUMP_DIR"
+  case mDir of
+    Nothing ->
+      it "writes all rendered emails to disk" $
+        pendingWith "set WIRE_EMAIL_DUMP_DIR=<dir> to render all email templates for visual inspection"
+    Just dir -> do
+      wanted <- runIO localeFilter
+      teamTemplates <- runIO loadTestTeamTemplates
+      userTemplates <- runIO loadTestUserTemplates
+      it "writes all rendered emails to disk" $ do
+        let teamByLocale = byLocale teamTemplates
+            userByLocale = byLocale userTemplates
+            -- only 'de' and 'en' ship team templates, all locales ship user
+            -- templates, so neither list alone covers everything.
+            entries =
+              concatMap localeEntries . filter wanted . sort . nub $
+                map fst teamByLocale <> map fst userByLocale
+            localeEntries loc =
+              [DumpEntry loc "team" s | ts <- maybeToList (lookup loc teamByLocale), s <- teamSamples ts]
+                <> [DumpEntry loc "user" s | ts <- maybeToList (lookup loc userByLocale), s <- userSamples loc ts]
+        when (null entries) $
+          expectationFailure "no locales selected; check WIRE_EMAIL_DUMP_LOCALES"
+        traverse_ (writeEntry dir) entries
+        writeText (dir </> "index.html") (renderIndex entries)
+        putStrLn $ "\nwrote " <> show (length entries) <> " emails to " <> (dir </> "index.html")
+
+-- | Locales to render, from @WIRE_EMAIL_DUMP_LOCALES@: a comma-separated list
+-- of locale codes (as in the template directory names), or @all@. Defaults to
+-- the default locale only, since all 20 locales make for an unwieldy index.
+localeFilter :: IO (Locale -> Bool)
+localeFilter =
+  lookupEnv "WIRE_EMAIL_DUMP_LOCALES" <&> \case
+    Nothing -> (== defLocale)
+    Just "all" -> const True
+    Just raw ->
+      let selected = map T.strip . T.splitOn "," . T.pack $ raw
+       in \loc -> locToText loc `elem` selected
+
+data DumpEntry = DumpEntry
+  { entryLocale :: Locale,
+    -- | @team@ or @user@, the template set the email comes from.
+    entryGroup :: Text,
+    entrySample :: EmailSample
+  }
+
+-- | Path of this entry's files relative to the dump directory, without
+-- extension, e.g. @en/team-member-welcome@.
+entryStem :: DumpEntry -> FilePath
+entryStem e =
+  T.unpack (locToText e.entryLocale)
+    </> T.unpack (e.entryGroup <> "-" <> T.map dash (T.pack e.entrySample.sampleName))
+  where
+    dash c = if c == ' ' then '-' else c
+
+writeEntry :: FilePath -> DumpEntry -> IO ()
+writeEntry dir e = do
+  let stem = dir </> entryStem e
+      mail = e.entrySample.sampleMail
+  createDirectoryIfMissing True (dir </> T.unpack (locToText e.entryLocale))
+  writeText (stem <> ".subject.txt") (mailSubject mail)
+  LBS.writeFile (stem <> ".txt") (mailBody "text/plain" mail)
+  LBS.writeFile (stem <> ".html") (mailBody "text/html" mail)
+
+writeText :: FilePath -> Text -> IO ()
+writeText path = LBS.writeFile path . LTE.encodeUtf8 . LT.fromStrict
+
+mailSubject :: Mail -> Text
+mailSubject mail = fromMaybe "(no subject)" $ lookup "Subject" mail.mailHeaders
+
+-- | The first body part whose content type starts with the given prefix. The
+-- renderers all produce exactly one @text/plain@ and one @text/html@ part.
+mailBody :: Text -> Mail -> LByteString
+mailBody contentType mail =
+  fromMaybe "" . listToMaybe $
+    [ content
+    | alternatives <- mail.mailParts,
+      part <- alternatives,
+      contentType `T.isPrefixOf` part.partType,
+      PartContent content <- [part.partContent]
+    ]
+
+-------------------------------------------------------------------------------
+-- Index page
+
+renderIndex :: [DumpEntry] -> Text
+renderIndex entries =
+  T.unlines $
+    [ "<!DOCTYPE html>",
+      "<html lang=\"en\"><head><meta charset=\"utf-8\">",
+      "<title>Wire email templates</title>",
+      "<style>",
+      "body { font-family: sans-serif; margin: 2rem; background: #f4f4f6; color: #222; }",
+      "h1 { margin-bottom: 0; }",
+      "h2.locale { margin-top: 3rem; border-bottom: 2px solid #333; }",
+      "nav a { margin-right: .75rem; }",
+      "section.email { background: #fff; border: 1px solid #ddd; border-radius: 4px;",
+      "                margin: 1.5rem 0; padding: 1rem 1.25rem; }",
+      "section.email h3 { margin: 0; font-family: monospace; font-size: 1rem; color: #555; }",
+      ".subject { font-size: 1.15rem; font-weight: bold; margin: .5rem 0 1rem; }",
+      ".errors { color: #b00020; font-weight: bold; }",
+      ".panes { display: flex; gap: 1rem; align-items: stretch; }",
+      "pre { flex: 1 1 30%; margin: 0; background: #fafafa; border: 1px solid #eee;",
+      "      padding: .75rem; white-space: pre-wrap; overflow: auto; font-size: .8rem; }",
+      -- iframes isolate each email's own CSS from the index and from each other;
+      -- drag the bottom edge to resize when a body does not fit.
+      "iframe { flex: 1 1 70%; height: 40rem; border: 1px solid #eee; background: #fff;",
+      "         resize: vertical; }",
+      "</style></head><body>",
+      "<h1>Wire email templates</h1>",
+      "<p>" <> tshow (length entries) <> " emails</p>",
+      "<nav>" <> foldMap localeLink locales <> "</nav>"
+    ]
+      <> concatMap localeSection locales
+      <> ["</body></html>"]
+  where
+    locales = nub (map (locToText . entryLocale) entries)
+    localeLink loc = "<a href=\"#" <> loc <> "\">" <> loc <> "</a>"
+    localeSection loc =
+      ("<h2 class=\"locale\" id=\"" <> loc <> "\">" <> loc <> "</h2>")
+        : map emailSection (filter ((== loc) . locToText . entryLocale) entries)
+
+emailSection :: DumpEntry -> Text
+emailSection e =
+  T.unlines
+    [ "<section class=\"email\">",
+      "<h3>" <> escape (T.pack (entryStem e)) <> "</h3>",
+      "<div class=\"subject\">" <> escape (mailSubject e.entrySample.sampleMail) <> "</div>",
+      errors,
+      "<div class=\"panes\">",
+      "<pre>" <> escape (LT.toStrict (LTE.decodeUtf8 (mailBody "text/plain" e.entrySample.sampleMail))) <> "</pre>",
+      "<iframe src=\"" <> T.pack (entryStem e) <> ".html\" title=\"html body\"></iframe>",
+      "</div>",
+      "</section>"
+    ]
+  where
+    errors = case nub e.entrySample.sampleErrors of
+      [] -> ""
+      errs -> "<p class=\"errors\">unreplaced variables: " <> escape (tshow errs) <> "</p>"
+
+escape :: Text -> Text
+escape =
+  T.replace ">" "&gt;"
+    . T.replace "<" "&lt;"
+    . T.replace "&" "&amp;"
+
+tshow :: (Show a) => a -> Text
+tshow = T.pack . show

--- a/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateFixtures.hs
+++ b/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateFixtures.hs
@@ -20,11 +20,29 @@
 -- mirror the shape of the corresponding Brig configuration.
 module Wire.EmailSubsystem.TemplateFixtures where
 
+import Data.Code
+import Data.Id
+import Data.Json.Util
 import Data.Map qualified as Map
+import Data.Range
+import Data.Text.Ascii (AsciiChars (validate), encodeBase64Url)
+import Data.Text.Ascii qualified as Ascii
+import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
+import Data.UUID qualified as UUID
 import Imports
-import Text.Email.Parser (unsafeEmailAddress)
+import Network.Mail.Mime
+import Polysemy
+import Polysemy.Output
+import Test.Hspec
 import Wire.API.Locale
-import Wire.API.User.EmailAddress (EmailAddress)
+import Wire.API.User (InvitationCode (InvitationCode, fromInvitationCode))
+import Wire.API.User.Activation
+import Wire.API.User.Client (Client (..), ClientCapabilityList (..), ClientType (..))
+import Wire.API.User.EmailAddress
+import Wire.API.User.Password
+import Wire.API.User.Profile
+import Wire.EmailSubsystem (AppEvent (..))
+import Wire.EmailSubsystem.Interpreter
 import Wire.EmailSubsystem.Template
 import Wire.EmailSubsystem.Templates.Team
 import Wire.EmailSubsystem.Templates.User
@@ -36,7 +54,8 @@ teamOpts =
       tExistingUserInvitationUrl = "https://example.com/accept-invitation/?team-code=${code}",
       tActivationUrl = "https://example.com/verify/?key=${key}&code=${code}",
       tCreatorWelcomeUrl = "https://example.com/creator-welcome-website",
-      tMemberWelcomeUrl = "https://example.com/member-welcome-website"
+      tMemberWelcomeUrl = "https://example.com/member-welcome-website",
+      tAppManagementUrl = "https://example.com/team-management-website"
     }
 
 userTemplateOpts :: UserTemplateOpts
@@ -77,3 +96,181 @@ loadTestTeamTemplates = loadTeamTemplates teamOpts "templates" defLocale emailSe
 -- | Load the on-disk user templates. See 'loadTestTeamTemplates'.
 loadTestUserTemplates :: IO (Localised UserTemplates)
 loadTestUserTemplates = loadUserTemplates userTemplateOpts "templates" defLocale emailSender
+
+-- | Insert the default locale into the map of other locales, giving the full
+-- set of locales that ship templates.
+byLocale :: Localised a -> [(Locale, a)]
+byLocale l = Map.assocs $ uncurry Map.insert l.locDefault l.locOther
+
+-------------------------------------------------------------------------------
+-- Sample emails
+
+-- | One sample email rendered from the on-disk templates: its label, the
+-- template variables that were left unreplaced, the resulting 'Mail', and any
+-- assertions specific to this email.
+data EmailSample = EmailSample
+  { sampleName :: String,
+    sampleErrors :: [Text],
+    sampleMail :: Mail,
+    sampleChecks :: Expectation
+  }
+
+mkSample :: String -> ([Text], Mail) -> EmailSample
+mkSample name (errs, mail) = EmailSample name errs mail (pure ())
+
+recipient :: EmailAddress
+recipient = fromJust $ emailAddressText "test@example.com"
+
+sampleTeamId :: TeamId
+sampleTeamId = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000")
+
+sampleTeamName :: Text
+sampleTeamName = "mrs. team"
+
+sampleUserName :: Name
+sampleUserName = Name "mr. user"
+
+sampleDate :: UTCTimeMillis
+sampleDate = toUTCTimeMillis (UTCTime (fromGregorian 2020 1 1) (secondsToDiffTime 0))
+
+sampleActivationKey :: ActivationKey
+sampleActivationKey = ActivationKey . Ascii.unsafeFromText $ "key"
+
+sampleActivationCode :: ActivationCode
+sampleActivationCode = ActivationCode . Ascii.unsafeFromText $ "code666"
+
+sampleVerificationCode :: Value
+sampleVerificationCode = Value . unsafeRange . Ascii.unsafeFromText $ "code666"
+
+teamSamples :: TeamTemplates -> [EmailSample]
+teamSamples templates =
+  [ invitationSample
+      "team invitation"
+      templates.invitationEmail
+      "https://example.com/join/?team-code=zZoMX0xs=",
+    invitationSample
+      "team invitation existing user"
+      templates.existingUserInvitationEmail
+      "https://example.com/accept-invitation/?team-code=ZoMX0xs=",
+    mkSample "member welcome" . run . runOutputList @Text $
+      renderMemberWelcomeMail recipient sampleTeamId sampleTeamName templates.memberWelcomeEmail branding,
+    mkSample "new team owner welcome" . run . runOutputList @Text $
+      renderNewTeamOwnerWelcomeEmail recipient sampleTeamId sampleTeamName sampleUserName templates.newTeamOwnerWelcomeEmail branding
+  ]
+    <> [ mkSample label . run . runOutputList @Text $
+           renderAppEventEmail recipient (Name "admin") sampleTeamId templates.appEmails event branding
+       | (label, event) <- appEvents
+       ]
+
+invitationSample :: String -> InvitationEmailTemplate -> Text -> EmailSample
+invitationSample label tpl expectedUrl =
+  EmailSample label errs mail $ do
+    mail.mailFrom.addressEmail `shouldBe` fromEmail tpl.invitationEmailSender
+    url `shouldBe` expectedUrl
+  where
+    (errs, (mail, url)) = run . runOutputList @Text $ renderInvitationEmail input tpl branding
+    input =
+      InvitationEmail
+        { invTo = recipient,
+          invTeamId = sampleTeamId,
+          invInvCode = InvitationCode {fromInvitationCode = fromRight undefined (validate "ZoMX0xs=")},
+          invInviter = fromJust $ emailAddressText "inviter@example.com"
+        }
+
+-- | The five app-event emails all render through 'renderAppEventEmail' from the
+-- 'AppEmailTemplates' bundled into 'TeamTemplates'. Each event carries a
+-- different set of substitution variables.
+appEvents :: [(String, AppEvent)]
+appEvents =
+  [ ( "app creation email",
+      NewAppCreated
+        { actor = "Actor",
+          appName = Name "app",
+          date = sampleDate,
+          permissions = "read, write",
+          teamId = sampleTeamId,
+          teamName = sampleTeamName
+        }
+    ),
+    ( "app deletion email",
+      AppDeleted
+        { actor = "Actor",
+          appName = Name "app",
+          date = sampleDate,
+          teamId = sampleTeamId,
+          teamName = sampleTeamName
+        }
+    ),
+    ( "app availability change email",
+      AppAvailabilityChanged
+        { actor = "Actor",
+          appName = Name "app",
+          date = sampleDate,
+          newAvailability = "available",
+          previousAvailability = "unavailable",
+          teamId = sampleTeamId,
+          teamName = sampleTeamName
+        }
+    ),
+    ( "app metadata change email",
+      AppMetadataChanged
+        { actor = "Actor",
+          date = sampleDate,
+          newAppName = Name "new app",
+          previousAppName = Name "old app",
+          teamId = sampleTeamId,
+          teamName = sampleTeamName
+        }
+    ),
+    ( "app token change email",
+      AppTokenChanged
+        { actor = "Actor",
+          appName = Name "app",
+          date = sampleDate,
+          teamId = sampleTeamId,
+          teamName = sampleTeamName
+        }
+    )
+  ]
+
+userSamples :: Locale -> UserTemplates -> [EmailSample]
+userSamples loc templates =
+  [ mkSample "password reset email" . run . runOutputList @Text $
+      renderPwResetMail recipient (mkPasswordResetKey (Id UUID.nil)) (PasswordResetCode $ encodeBase64Url "bar") templates.passwordResetEmail branding,
+    mkSample "verification email" . run . runOutputList @Text $
+      renderVerificationMail recipient sampleActivationKey sampleActivationCode templates.verificationEmail branding,
+    mkSample "team deletion verification email" . run . runOutputList @Text $
+      renderSecondFactorVerificationEmail recipient sampleVerificationCode templates.verificationTeamDeletionEmail branding,
+    mkSample "scim token verification email" . run . runOutputList @Text $
+      renderSecondFactorVerificationEmail recipient sampleVerificationCode templates.verificationScimTokenEmail branding,
+    mkSample "login verification email" . run . runOutputList @Text $
+      renderSecondFactorVerificationEmail recipient sampleVerificationCode templates.verificationLoginEmail branding,
+    mkSample "new client email" . run . runOutputList @Text $
+      renderNewClientEmail recipient sampleUserName loc sampleClient templates.newClientEmail branding,
+    mkSample "account deletion email" . run . runOutputList @Text $
+      renderDeletionEmail recipient sampleUserName deletionKey deletionCode templates.deletionEmail branding,
+    mkSample "activation email" . run . runOutputList @Text $
+      renderActivationMail recipient sampleUserName sampleActivationKey sampleActivationCode templates.activationEmail branding,
+    mkSample "activation email update" . run . runOutputList @Text $
+      renderActivationMail recipient sampleUserName sampleActivationKey sampleActivationCode templates.activationEmailUpdate branding,
+    mkSample "team activation email" . run . runOutputList @Text $
+      renderTeamActivationMail recipient sampleUserName "team-name" sampleActivationKey sampleActivationCode templates.teamActivationEmail branding
+  ]
+  where
+    deletionKey = Key . unsafeRange . Ascii.unsafeFromText $ "ABCDEFGHIJKLMNOPQRST"
+    deletionCode = Value . unsafeRange . Ascii.unsafeFromText $ "code123"
+
+sampleClient :: Client
+sampleClient =
+  Client
+    { clientId = ClientId 1,
+      clientType = PermanentClientType,
+      clientTime = sampleDate,
+      clientClass = Nothing,
+      clientLabel = Just "label",
+      clientCookie = Nothing,
+      clientModel = Just "model",
+      clientCapabilities = ClientCapabilityList mempty,
+      clientMLSPublicKeys = Map.empty,
+      clientLastActive = Nothing
+    }

--- a/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateSpec.hs
@@ -17,37 +17,9 @@
 
 module Wire.EmailSubsystem.TemplateSpec (spec) where
 
-import Data.Code
-import Data.Id
-import Data.Json.Util
-import Data.Map qualified as Map
-import Data.Range
-import Data.Text.Ascii (AsciiChars (validate), encodeBase64Url)
-import Data.Text.Ascii qualified as Ascii
-import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
-import Data.UUID qualified as UUID
 import Imports
-import Network.Mail.Mime
-import Polysemy
-import Polysemy.Output
 import Test.Hspec
-import Wire.API.Locale
-import Wire.API.User (InvitationCode (InvitationCode, fromInvitationCode))
-import Wire.API.User.Activation
-import Wire.API.User.Client (Client (..), ClientCapabilityList (..), ClientType (..))
-import Wire.API.User.EmailAddress
-import Wire.API.User.Password
-import Wire.API.User.Profile
-import Wire.EmailSubsystem.Interpreter
-import Wire.EmailSubsystem.Template
 import Wire.EmailSubsystem.TemplateFixtures
-import Wire.EmailSubsystem.Templates.Team
-import Wire.EmailSubsystem.Templates.User
-
--- | Insert the default locale into the map of other locales, giving the full
--- set of locales that ship templates. Each is exercised below.
-byLocale :: Localised a -> [(Locale, a)]
-byLocale l = Map.assocs $ uncurry Map.insert l.locDefault l.locOther
 
 spec :: Spec
 spec = do
@@ -56,177 +28,15 @@ spec = do
   describe "email templates" $ do
     describe "team" $
       for_ (byLocale teamTemplates) $ \(loc, ts) ->
-        describe (show loc) $ do
-          it "team invitation" $ testTeamInvitationEmail ts
-          it "team invitation existing user" $ testTeamInvitationEmailExistingUser ts
-          it "member welcome" $ testMemberWelcomeEmail ts
-          it "new team owner welcome" $ testNewTeamOwnerWelcomeEmail ts
+        describe (show loc) $ for_ (teamSamples ts) checkSample
     describe "user" $
       for_ (byLocale userTemplates) $ \(loc, ts) ->
-        describe (show loc) $ do
-          it "password reset email" $ testPasswordResetEmail ts
-          it "verification email" $ testVerificationEmail ts
-          it "team deletion verification email" $ testTeamDeletionVerificationEmail ts
-          it "scim token verification email" $ testScimTokenVerificationEmail ts
-          it "login verification email" $ testLoginVerificationEmail ts
-          it "new client email" $ testNewClientEmail loc ts
-          it "account deletion email" $ testAccountDeletionEmail ts
-          it "activation email" $ testActivationEmail ts
-          it "activation email update" $ testActivationEmailUpdate ts
-          it "team activation email" $ testTeamActivationEmail ts
+        describe (show loc) $ for_ (userSamples loc ts) checkSample
 
-testTeamInvitationEmailExistingUser :: (HasCallStack) => TeamTemplates -> Expectation
-testTeamInvitationEmailExistingUser templates = do
-  let tpl = templates.existingUserInvitationEmail
-      (errs, (mail, url)) = run $ runOutputList @Text $ renderInvitationEmail input tpl branding
-      input =
-        InvitationEmail
-          { invTo = fromJust $ emailAddressText "test@example.com",
-            invTeamId = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000"),
-            invInvCode = InvitationCode {fromInvitationCode = fromRight undefined (validate "ZoMX0xs=")},
-            invInviter = fromJust $ emailAddressText "inviter@example.com"
-          }
-  mail.mailFrom.addressEmail `shouldBe` fromEmail tpl.invitationEmailSender
-  url `shouldBe` "https://example.com/accept-invitation/?team-code=ZoMX0xs="
-  assertNoErrors errs
-
-testTeamInvitationEmail :: (HasCallStack) => TeamTemplates -> Expectation
-testTeamInvitationEmail templates = do
-  let tpl = templates.invitationEmail
-      (errs, (mail, url)) = run $ runOutputList @Text $ renderInvitationEmail input tpl branding
-      input =
-        InvitationEmail
-          { invTo = fromJust $ emailAddressText "test@example.com",
-            invTeamId = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000"),
-            invInvCode = InvitationCode {fromInvitationCode = fromRight undefined (validate "ZoMX0xs=")},
-            invInviter = fromJust $ emailAddressText "inviter@example.com"
-          }
-  mail.mailFrom.addressEmail `shouldBe` fromEmail tpl.invitationEmailSender
-  url `shouldBe` "https://example.com/join/?team-code=ZoMX0xs="
-  assertNoErrors errs
-
-testMemberWelcomeEmail :: (HasCallStack) => TeamTemplates -> Expectation
-testMemberWelcomeEmail templates = do
-  let tpl = templates.memberWelcomeEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      tid = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000")
-      tname = "funky team"
-      (errs, _) = run $ runOutputList @Text $ renderMemberWelcomeMail to tid tname tpl branding
-  assertNoErrors errs
-
-testNewTeamOwnerWelcomeEmail :: (HasCallStack) => TeamTemplates -> Expectation
-testNewTeamOwnerWelcomeEmail templates = do
-  let tpl = templates.newTeamOwnerWelcomeEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      tid = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000")
-      tname = "funky team"
-      name = Name "name"
-      (errs, _) = run $ runOutputList @Text $ renderNewTeamOwnerWelcomeEmail to tid tname name tpl branding
-  assertNoErrors errs
-
-testPasswordResetEmail :: (HasCallStack) => UserTemplates -> Expectation
-testPasswordResetEmail templates = do
-  let tpl = templates.passwordResetEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      key = mkPasswordResetKey (Id UUID.nil)
-      code = PasswordResetCode . encodeBase64Url $ "bar"
-      (errs, _) = run $ runOutputList @Text $ renderPwResetMail to key code tpl branding
-  assertNoErrors errs
-
-testVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testVerificationEmail templates = do
-  let tpl = templates.verificationEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      key = ActivationKey . Ascii.unsafeFromText $ "key"
-      code = ActivationCode . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderVerificationMail to key code tpl branding
-  assertNoErrors errs
-
-testTeamDeletionVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testTeamDeletionVerificationEmail templates = do
-  let tpl = templates.verificationTeamDeletionEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
-  assertNoErrors errs
-
-testScimTokenVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testScimTokenVerificationEmail templates = do
-  let tpl = templates.verificationScimTokenEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
-  assertNoErrors errs
-
-testLoginVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testLoginVerificationEmail templates = do
-  let tpl = templates.verificationLoginEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
-  assertNoErrors errs
-
-testActivationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testActivationEmail templates = do
-  let tpl = templates.activationEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      name = Name "name"
-      key = ActivationKey . Ascii.unsafeFromText $ "key"
-      code = ActivationCode . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderActivationMail to name key code tpl branding
-  assertNoErrors errs
-
-testActivationEmailUpdate :: (HasCallStack) => UserTemplates -> Expectation
-testActivationEmailUpdate templates = do
-  let tpl = templates.activationEmailUpdate
-      to = fromJust $ emailAddressText "test@example.com"
-      name = Name "name"
-      key = ActivationKey . Ascii.unsafeFromText $ "key"
-      code = ActivationCode . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderActivationMail to name key code tpl branding
-  assertNoErrors errs
-
-testTeamActivationEmail :: (HasCallStack) => UserTemplates -> Expectation
-testTeamActivationEmail templates = do
-  let tpl = templates.teamActivationEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      name = Name "name"
-      teamName = "team-name"
-      key = ActivationKey . Ascii.unsafeFromText $ "key"
-      code = ActivationCode . Ascii.unsafeFromText $ "code"
-      (errs, _) = run $ runOutputList @Text $ renderTeamActivationMail to name teamName key code tpl branding
-  assertNoErrors errs
-
-testNewClientEmail :: (HasCallStack) => Locale -> UserTemplates -> Expectation
-testNewClientEmail loc templates = do
-  let tpl = templates.newClientEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      name = Name "name"
-      client =
-        Client
-          { clientId = ClientId 1,
-            clientType = PermanentClientType,
-            clientTime = toUTCTimeMillis (UTCTime (fromGregorian 2020 1 1) (secondsToDiffTime 0)),
-            clientClass = Nothing,
-            clientLabel = Just "label",
-            clientCookie = Nothing,
-            clientModel = Just "model",
-            clientCapabilities = ClientCapabilityList mempty,
-            clientMLSPublicKeys = Map.empty,
-            clientLastActive = Nothing
-          }
-      (errs, _) = run $ runOutputList @Text $ renderNewClientEmail to name loc client tpl branding
-  assertNoErrors errs
-
-testAccountDeletionEmail :: (HasCallStack) => UserTemplates -> Expectation
-testAccountDeletionEmail templates = do
-  let tpl = templates.deletionEmail
-      to = fromJust $ emailAddressText "test@example.com"
-      name = Name "name"
-      key = Key . unsafeRange . Ascii.unsafeFromText $ "ABCDEFGHIJKLMNOPQRST"
-      code = Value . unsafeRange . Ascii.unsafeFromText $ "code123"
-      (errs, _) = run $ runOutputList @Text $ renderDeletionEmail to name key code tpl branding
-  assertNoErrors errs
+checkSample :: EmailSample -> Spec
+checkSample s = it s.sampleName $ do
+  assertNoErrors s.sampleErrors
+  s.sampleChecks
 
 assertNoErrors :: (HasCallStack) => [Text] -> Expectation
 assertNoErrors errs =

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AppStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AppStore.hs
@@ -23,6 +23,7 @@ import Imports
 import Polysemy
 import Polysemy.State
 import Wire.AppStore
+import Wire.AppStore qualified as Store
 
 inMemoryAppStoreInterpreter ::
   forall r.
@@ -32,5 +33,9 @@ inMemoryAppStoreInterpreter = interpret $ \case
   CreateApp app -> modify (app :)
   GetApp uid tid -> gets $ find $ \app -> app.id == uid && app.teamId == tid
   GetApps tid -> gets $ filter $ \app -> app.teamId == tid
-  UpdateApp _owner _app _upd -> error $ "inMemoryAppStoreInterpreter: UpdateApp"
+  UpdateApp _teamId appId _upd ->
+    gets $ \apps ->
+      if any (\a -> a.id == appId) apps
+        then Right ()
+        else Left Store.NotFound
   DeleteApp uid tid -> modify $ filter $ \app -> not (app.id == uid && app.teamId == tid)

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AuthenticationSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AuthenticationSubsystem.hs
@@ -1,8 +1,15 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 module Wire.MockInterpreters.AuthenticationSubsystem where
 
+import Data.Time
+import Data.UUID qualified as UUID
+import Data.ZAuth.Token as ZAuth
 import Imports
 import Polysemy
 import Polysemy.State
+import Sodium.Crypto.Sign
+import Wire.API.User.Auth
 import Wire.AuthenticationSubsystem
 
 data MockAuthenticationState = MockAuthenticationState

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AuthenticationSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/AuthenticationSubsystem.hs
@@ -32,4 +32,29 @@ mockAuthenticationSubsystemInterpreter = interpret \case
   EnforceVerificationCodeEither {} -> do
     modify \st -> st {verificationCodeCalls = st.verificationCodeCalls + 1}
     pure $ pure ()
-  _ -> error "mockAuthenticationSubsystemInterpreter: implement on demand"
+  VerifyUserPasswordError {} -> pure ()
+  NewCookie {} -> pure fakeCookie
+  NewCookieLimited {} -> pure (Right fakeCookie)
+  --
+  CreatePasswordResetCode {} -> error "AuthenticationSubsystem.CreatePasswordResetCode not implemented in mock interpreter"
+  ResetPassword {} -> error "AuthenticationSubsystem.ResetPassword not implemented in mock interpreter"
+  AuthenticateEither {} -> error "AuthenticationSubsystem.AuthenticateEither not implemented in mock interpreter"
+  VerifyUserPassword {} -> error "AuthenticationSubsystem.VerifyUserPassword not implemented in mock interpreter"
+  VerifyProviderPassword {} -> error "AuthenticationSubsystem.VerifyProviderPassword not implemented in mock interpreter"
+  InternalLookupPasswordResetCode {} -> error "AuthenticationSubsystem.InternalLookupPasswordResetCode not implemented in mock interpreter"
+
+fakeCookie :: forall t. (ZAuth.Body t ~ ZAuth.User) => Cookie (Token t)
+fakeCookie =
+  Cookie
+    { cookieId = CookieId 3,
+      cookieType = PersistentCookie,
+      cookieCreated = now1,
+      cookieExpires = now2,
+      cookieLabel = Nothing,
+      cookieSucc = Nothing,
+      cookieValue = val
+    }
+  where
+    val = Token (Signature "") (Header 0 0 0 Nothing) (ZAuth.User UUID.nil Nothing 0)
+    Just now1 = parseTimeM True defaultTimeLocale "%Y" "1983"
+    Just now2 = parseTimeM True defaultTimeLocale "%Y" "1987"

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/EmailSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/EmailSubsystem.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
@@ -17,6 +19,7 @@
 
 module Wire.MockInterpreters.EmailSubsystem where
 
+import Data.Id
 import Data.Map qualified as Map
 import Imports
 import Polysemy
@@ -30,12 +33,19 @@ data SentMail = SentMail
   }
   deriving (Show, Eq)
 
-data SentMailContent = PasswordResetMail PasswordResetPair
+data SentMailContent
+  = PasswordResetMail PasswordResetPair
+  | AppEventMail
+      { aeTeamId :: TeamId,
+        aeEvent :: AppEvent
+      }
   deriving (Show, Eq)
 
 inMemoryEmailSubsystemInterpreter :: (Member (State (Map EmailAddress [SentMail])) r) => InterpreterFor EmailSubsystem r
 inMemoryEmailSubsystemInterpreter = interpret \case
   SendPasswordResetMail email keyCodePair mLocale -> modify $ Map.insertWith (<>) email [SentMail mLocale $ PasswordResetMail keyCodePair]
+  SendAppEventEmail email _name tid event mLocale ->
+    modify $ Map.insertWith (<>) email [SentMail mLocale $ AppEventMail tid event]
   _ -> error "inMemoryEmailSubsystemInterpreter: implement on demand"
 
 getEmailsSentTo :: (Member (State (Map EmailAddress [SentMail])) r) => EmailAddress -> Sem r [SentMail]
@@ -58,3 +68,4 @@ noopEmailSubsystemInterpreter = interpret \case
   SendMemberWelcomeEmail {} -> pure ()
   SendNewTeamOwnerWelcomeEmail {} -> pure ()
   SendSAMLIdPChanged {} -> pure ()
+  SendAppEventEmail {} -> pure ()

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/GalleyAPIAccess.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/GalleyAPIAccess.hs
@@ -19,71 +19,79 @@ module Wire.MockInterpreters.GalleyAPIAccess where
 
 import Control.Lens (to, (^.))
 import Data.Id
+import Data.LegalHold (defUserLegalHoldStatus)
 import Data.Map qualified as Map
 import Data.Proxy
 import Data.Range
 import Imports
 import Polysemy
+import Polysemy.State
+import Wire.API.Routes.Internal.Galley.TeamsIntra (TeamName (..))
 import Wire.API.Team.Feature (AllTeamFeatures, FeatureStatus (..), IsFeatureConfig (..), LockableFeature (..), SndFactorPasswordChallengeConfig, npProject')
 import Wire.API.Team.Member
 import Wire.API.Team.Member.Info (TeamMemberInfoList (..))
 import Wire.API.Team.SearchVisibility
 import Wire.GalleyAPIAccess
 
--- | interprets galley by statically returning the values passed
 miniGalleyAPIAccess ::
-  -- | what to return when calling GetTeamMember
+  -- | initial team members
   Map TeamId [TeamMember] ->
   -- | what to return when calling GetAllTeamFeaturesForUser
   AllTeamFeatures ->
   InterpreterFor GalleyAPIAccess r
-miniGalleyAPIAccess teams configs = interpret $ \case
-  CreateSelfConv _ -> error "CreateSelfConv not implemented in miniGalleyAPIAccess"
-  GetConv _ _ -> error "GetConv not implemented in miniGalleyAPIAccess"
-  GetTeamConv {} -> error "GetTeamConv not implemented in miniGalleyAPIAccess"
-  NewClient _ _ -> pure ()
-  CheckUserCanJoinTeam _ -> pure Nothing
-  AddTeamMember {} -> error "AddTeamMember not implemented in miniGalleyAPIAccess"
-  CreateTeam {} -> error "CreateTeam not implemented in miniGalleyAPIAccess"
-  GetTeamMember uid tid -> pure $ getTeamMemberImpl teams uid tid
-  GetTeamMembersWithLimit tid maxResults -> pure $ getTeamMembersImpl teams tid maxResults
-  GetTeamId uid ->
-    pure . listToMaybe . Map.keys $
-      Map.filter
-        (\members -> any (\member -> member ^. userId == uid) members)
-        teams
-  GetTeam _ -> error "GetTeam not implemented in miniGalleyAPIAccess"
-  FindTeam _ -> error "FindTeam not implemented in miniGalleyAPIAccess"
-  GetTeamName _ -> error "GetTeamName not implemented in miniGalleyAPIAccess"
-  GetTeamLegalHoldStatus _ -> error "GetTeamLegalHoldStatus not implemented in miniGalleyAPIAccess"
-  GetUserLegalholdStatus _ _ -> error "GetUserLegalholdStatus not implemented in miniGalleyAPIAccess"
-  GetTeamSearchVisibility _ ->
-    pure SearchVisibilityStandard
-  ChangeTeamStatus {} -> error "ChangeTeamStatus not implemented in miniGalleyAPIAccess"
-  FinalizeDeleteTeam {} -> error "FinalizeDeleteTeam not implemented in miniGalleyAPIAccess"
-  MemberIsTeamOwner tid uid ->
-    pure $ memberIsTeamOwnerImpl teams tid uid
-  GetAllTeamFeaturesForUser _ -> pure configs
-  GetFeatureConfigForTeam tid -> pure $ getFeatureConfigForTeamImpl configs tid
-  GetVerificationCodeEnabled _ ->
-    pure $
-      case npProject' (Proxy @SndFactorPasswordChallengeConfig) configs of
-        LockableFeature FeatureStatusEnabled _ _ -> True
-        LockableFeature FeatureStatusDisabled _ _ -> False
-  GetExposeInvitationURLsToTeamAdmin _ -> pure ShowInvitationUrl
-  IsMLSOne2OneEstablished _ _ -> error "IsMLSOne2OneEstablished not implemented in miniGalleyAPIAccess"
-  UnblockConversation {} -> error "UnblockConversation not implemented in miniGalleyAPIAccess"
-  GetEJPDConvInfo _ -> error "GetEJPDConvInfo not implemented in miniGalleyAPIAccess"
-  GetTeamAdmins tid -> pure $ newTeamMemberList (maybe [] (filter (\tm -> isAdminOrOwner (tm ^. permissions))) $ Map.lookup tid teams) ListComplete
-  SelectTeamMemberInfos tid uids -> pure $ selectTeamMemberInfosImpl teams tid uids
-  InternalGetConversation _ -> pure Nothing
-  GetTeamContacts _ -> pure Nothing
-  SelectTeamMembers {} -> error "SelectTeamMembers not implemented in miniGalleyAPIAccess"
-  GetUserLHStatus _ _ -> error "GetUserLHStatus not implemented in miniGalleyAPIAccess"
-  GetUsersLHStatus _ -> error "GetUsersLHStatus not implemented in miniGalleyAPIAccess"
-  GuardLegalHold {} -> pure ()
-  UpdateTeamMember {} -> error "UpdateTeamMember not implemented in miniGalleyAPIAccess"
-  IsEmailValidationEnabledTeam {} -> error "IsEmailValidationEnabledTeam not implemented in miniGalleyAPIAccess"
+miniGalleyAPIAccess initialTeams configs =
+  evalState initialTeams . reinterpret \case
+    CreateSelfConv _ -> error "CreateSelfConv not implemented in miniGalleyAPIAccess"
+    GetConv _ _ -> error "GetConv not implemented in miniGalleyAPIAccess"
+    GetTeamConv {} -> error "GetTeamConv not implemented in miniGalleyAPIAccess"
+    NewClient _ _ -> pure ()
+    CheckUserCanJoinTeam _ -> pure Nothing
+    AddTeamMember uid tid inviter role -> do
+      let member = mkTeamMember uid (rolePermissions role) inviter defUserLegalHoldStatus
+      modify $ Map.insertWith (<>) tid [member]
+      pure True
+    CreateTeam {} -> error "CreateTeam not implemented in miniGalleyAPIAccess"
+    GetTeamMember uid tid -> gets $ \teams -> getTeamMemberImpl teams uid tid
+    GetTeamMembersWithLimit tid maxResults -> gets $ \teams -> getTeamMembersImpl teams tid maxResults
+    GetTeamId uid ->
+      gets $
+        listToMaybe
+          . Map.keys
+          . Map.filter (any (\member -> member ^. userId == uid))
+    GetTeam _ -> error "GetTeam not implemented in miniGalleyAPIAccess"
+    FindTeam _ -> error "FindTeam not implemented in miniGalleyAPIAccess"
+    GetTeamName _ -> pure (TeamName "Test Team")
+    GetTeamLegalHoldStatus _ -> error "GetTeamLegalHoldStatus not implemented in miniGalleyAPIAccess"
+    GetUserLegalholdStatus _ _ -> error "GetUserLegalholdStatus not implemented in miniGalleyAPIAccess"
+    GetTeamSearchVisibility _ ->
+      pure SearchVisibilityStandard
+    ChangeTeamStatus {} -> error "ChangeTeamStatus not implemented in miniGalleyAPIAccess"
+    FinalizeDeleteTeam {} -> error "FinalizeDeleteTeam not implemented in miniGalleyAPIAccess"
+    MemberIsTeamOwner tid uid ->
+      gets $ \teams -> memberIsTeamOwnerImpl teams tid uid
+    GetAllTeamFeaturesForUser _ -> pure configs
+    GetFeatureConfigForTeam tid -> pure $ getFeatureConfigForTeamImpl configs tid
+    GetVerificationCodeEnabled _ ->
+      pure $
+        case npProject' (Proxy @SndFactorPasswordChallengeConfig) configs of
+          LockableFeature FeatureStatusEnabled _ _ -> True
+          LockableFeature FeatureStatusDisabled _ _ -> False
+    GetExposeInvitationURLsToTeamAdmin _ -> pure ShowInvitationUrl
+    IsMLSOne2OneEstablished _ _ -> error "IsMLSOne2OneEstablished not implemented in miniGalleyAPIAccess"
+    UnblockConversation {} -> error "UnblockConversation not implemented in miniGalleyAPIAccess"
+    GetEJPDConvInfo _ -> error "GetEJPDConvInfo not implemented in miniGalleyAPIAccess"
+    GetTeamAdmins tid ->
+      gets $ \teams ->
+        newTeamMemberList (maybe [] (filter (\tm -> isAdminOrOwner (tm ^. permissions))) $ Map.lookup tid teams) ListComplete
+    SelectTeamMemberInfos tid uids -> gets $ \teams -> selectTeamMemberInfosImpl teams tid uids
+    InternalGetConversation _ -> pure Nothing
+    GetTeamContacts _ -> pure Nothing
+    SelectTeamMembers {} -> error "SelectTeamMembers not implemented in miniGalleyAPIAccess"
+    GetUserLHStatus _ _ -> error "GetUserLHStatus not implemented in miniGalleyAPIAccess"
+    GetUsersLHStatus _ -> error "GetUsersLHStatus not implemented in miniGalleyAPIAccess"
+    GuardLegalHold {} -> pure ()
+    UpdateTeamMember {} -> error "UpdateTeamMember not implemented in miniGalleyAPIAccess"
+    IsEmailValidationEnabledTeam {} -> error "IsEmailValidationEnabledTeam not implemented in miniGalleyAPIAccess"
 
 -- this is called but the result is not needed in unit tests
 selectTeamMemberInfosImpl :: Map TeamId [TeamMember] -> TeamId -> [UserId] -> TeamMemberInfoList

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserSubsystem.hs
@@ -87,7 +87,7 @@ inMemoryUserSubsystemInterpreter =
     BlockListInsert _ -> error "BlockListInsert: implement on demand (userSubsystemInterpreter)"
     UpdateTeamSearchVisibilityInbound _ -> error "UpdateTeamSearchVisibilityInbound: implement on demand (userSubsystemInterpreter)"
     AcceptTeamInvitation {} -> error "AcceptTeamInvitation: implement on demand (userSubsystemInterpreter)"
-    InternalUpdateSearchIndex _ -> error "InternalUpdateSearchIndex: implement on demand (userSubsystemInterpreter)"
+    InternalUpdateSearchIndex _ -> pure ()
     InternalFindTeamInvitation {} -> error "InternalFindTeamInvitation: implement on demand (userSubsystemInterpreter)"
     GetUserExportData _ -> error "GetUserExportData: implement on demand (userSubsystemInterpreter)"
     RemoveEmailEither _ -> error "RemoveEmailEither: implement on demand (userSubsystemInterpreter)"

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -628,6 +628,7 @@ test-suite wire-subsystems-tests
   other-modules:
     Spec
     Wire.ActivationCodeStore.InterpreterSpec
+    Wire.AppSubsystem.InterpreterSpec
     Wire.AuthenticationSubsystem.InterpreterSpec
     Wire.BrigAPIAccess.RpcSpec
     Wire.ClientSubsystem.InterpreterSpec
@@ -635,6 +636,7 @@ test-suite wire-subsystems-tests
     Wire.ConversationSubsystem.InterpreterSpec
     Wire.ConversationSubsystem.MessageSpec
     Wire.ConversationSubsystem.One2OneSpec
+    Wire.EmailSubsystem.TemplateDumpSpec
     Wire.EmailSubsystem.TemplateFixtures
     Wire.EmailSubsystem.TemplateSpec
     Wire.EnterpriseLoginSubsystem.InterpreterSpec

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -210,6 +210,7 @@ servantSitemap =
     :<|> enterpriseLoginApi
     :<|> samlIdPApi
     :<|> Named @"i-delete-app" deleteAppH
+    :<|> Named @"i-send-app-deletion-email" sendAppDeletionEmailH
     :<|> Named @"i-get-app-ids" getAppIdsH
 
 istatusAPI :: forall r. ServerT BrigIRoutes.IStatusAPI (Handler r)
@@ -1065,6 +1066,11 @@ deleteGroupManagedInternalH tid gid managedBy = do
 
 deleteAppH :: (Member AppSubsystem r) => TeamId -> UserId -> Handler r NoContent
 deleteAppH tid uid = lift . liftSem $ AppSubsystem.internalDeleteApp tid uid >> pure NoContent
+
+sendAppDeletionEmailH :: (Member AppSubsystem r) => BrigIRoutes.AppDeletionEmailRequest -> Handler r ()
+sendAppDeletionEmailH req =
+  lift . liftSem $
+    AppSubsystem.deleteAppSendEmail req.teamId req.actorId req.mbAppUser
 
 getAppIdsH :: (Member AppStore r) => TeamId -> Handler r [UserId]
 getAppIdsH tid = lift . liftSem $ map (.id) <$> AppStore.getApps tid

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -125,7 +125,8 @@ import Wire.BlockListStore as BlockListStore
 import Wire.ClientStore (ClientStore)
 import Wire.ClientStore qualified as ClientStore
 import Wire.DeleteQueue
-import Wire.EmailSubsystem
+import Wire.EmailSubsystem (EmailSubsystem)
+import Wire.EmailSubsystem qualified as EmailSubsystem
 import Wire.Error
 import Wire.Events (Events)
 import Wire.Events qualified as Events
@@ -330,7 +331,7 @@ upgradePersonalToTeam luid bNewTeam = do
     -- send confirmation email
     for_ (userEmail user) $ \email -> do
       liftSem $
-        sendNewTeamOwnerWelcomeEmail
+        EmailSubsystem.sendNewTeamOwnerWelcomeEmail
           email
           tid
           bNewTeam.bnuTeam.newTeamName.fromRange
@@ -920,7 +921,7 @@ sendActivationCode email loc = do
     sendVerificationEmail ek uc = do
       (key, code) <- mkPair ek uc Nothing
       let em = emailKeyOrig ek
-      lift $ liftSem $ sendVerificationMail em key code loc
+      lift $ liftSem $ EmailSubsystem.sendVerificationMail em key code loc
     sendActivationEmail ek uc uid = do
       -- FUTUREWORK(fisx): we allow for 'PendingInvitations' here, but I'm not sure this
       -- top-level function isn't another piece of a deprecated onboarding flow?
@@ -941,9 +942,9 @@ sendActivationCode email loc = do
         case mbTeam of
           Just team
             | team ^. teamCreator == uid ->
-                liftSem $ sendTeamActivationMail em name aKey aCode loc' (team ^. teamName)
+                liftSem $ EmailSubsystem.sendTeamActivationMail em name aKey aCode loc' (team ^. teamName)
           _otherwise ->
-            liftSem $ (maybe sendActivationMail (const sendEmailAddressUpdateMail) ident) em name aKey aCode loc'
+            liftSem $ (maybe EmailSubsystem.sendActivationMail (const EmailSubsystem.sendEmailAddressUpdateMail) ident) em name aKey aCode loc'
 
     guardBlockedDomainEmail ::
       ( Member (Input UserSubsystemConfig) r',
@@ -1079,7 +1080,7 @@ deleteSelfUser luid@(tUnqualified -> uid) pwd = do
           let v = VerificationCode.codeValue c
           let l = userLocale a
           let n = userDisplayName a
-          lift (liftSem $ sendAccountDeletionEmail target n k v l)
+          lift (liftSem $ EmailSubsystem.sendAccountDeletionEmail target n k v l)
             `onException` lift (liftSem $ deleteCode k VerificationCode.AccountDeletion)
           pure $! Just $! VerificationCode.codeTTL c
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -782,17 +782,20 @@ deleteTeamMember' lusr zcon tid remove mBody = do
     then do
       body <- mBody & note (InvalidPayload "missing request body")
       ensureReAuthorised (tUnqualified lusr) (body ^. tmdAuthPassword) Nothing Nothing
-      uType <-
-        E.getUser remove <&> \case
-          Just u | u.userType == U.UserTypeApp -> UserTypeFilterApp
-          _ -> UserTypeFilterRegular
+      mbUser <- E.getUser remove
+      let uType =
+            if ((.userType) <$> mbUser) == Just U.UserTypeApp
+              then UserTypeFilterApp
+              else UserTypeFilterRegular
       teamSizeAfterDelete <- do
         before <- E.getSize tid
         pure $ updateTeamSize uType before (-1)
       E.deleteUser remove
       case uType of
         UserTypeFilterRegular -> pure ()
-        UserTypeFilterApp -> E.deleteApp tid remove
+        UserTypeFilterApp -> do
+          E.deleteApp tid remove
+          E.deleteAppSendEmail (tUnqualified lusr) tid remove mbUser
       owners <- E.getBillingTeamMembers tid
       Journal.teamUpdate tid teamSizeAfterDelete $ filter (/= remove) owners
       pure TeamMemberDeleteAccepted


### PR DESCRIPTION
TODO:
- [x] https://github.com/wireapp/wire-emails#import-changes-to-wire-server
- [X] no need for new integration tests: unit tests cover contents and all wiring except `BrigAPIAccess`, and `testDeleteAppFromTeam` covers that.
- [x] extend these tests: services/brig/test/integration/API/Template.hs
- [ ] finish / polish our own unit tests.
- [ ] warn about changes to `appSubsystemErrorToHttpError` in https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/2686418945/API+changes+v15+-+v16

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
