### PR TITLE
WPB-25915 add timeout and duration metric for conversation migration

### DIFF
--- a/changelog.d/0-release-notes/WPB-25915
+++ b/changelog.d/0-release-notes/WPB-25915
@@ -1,0 +1,1 @@
+The background-worker migration timeout configuration was renamed from `migrateConversationsOptions` to `migrationOptions`. The old key is no longer read, so update any custom Helm overrides to the new name to avoid unexpected defaults.

--- a/changelog.d/5-internal/WPB-25915
+++ b/changelog.d/5-internal/WPB-25915
@@ -1,1 +1,1 @@
-Add timout and duration metric to cassandra to postgres migration options
+Add timeout and duration metrics to Cassandra-to-PostgreSQL migration options

--- a/changelog.d/5-internal/WPB-25915
+++ b/changelog.d/5-internal/WPB-25915
@@ -1,0 +1,1 @@
+Add timout and duration metric to cassandra to postgres migration options

--- a/charts/wire-server/templates/background-worker/configmap.yaml
+++ b/charts/wire-server/templates/background-worker/configmap.yaml
@@ -84,8 +84,8 @@ data:
     migrateConversationCodes: {{ .migrateConversationCodes }}
     migrateTeamFeatures: {{ .migrateTeamFeatures }}
     migrateDomainRegistration: {{ .migrateDomainRegistration }}
-    migrateConversationsOptions:
-{{toYaml .migrateConversationsOptions | indent 6 }}
+    migrationOptions:
+{{toYaml .migrationOptions | indent 6 }}
 
     backendNotificationPusher:
 {{toYaml .backendNotificationPusher | indent 6 }}

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -952,7 +952,7 @@ background-worker:
     # `settings.postgresMigration.conversation` with `migration-to-postgresql`
     # before setting this to `true`.
     migrateConversations: false
-    migrateConversationsOptions:
+    migrationOptions:
       pageSize: 10000
       parallelism: 2
       timeout: 5s

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -955,6 +955,7 @@ background-worker:
     migrateConversationsOptions:
       pageSize: 10000
       parallelism: 2
+      timtout: 5s
     # This will start the migration of conversation codes.
     # It's important to set `settings.postgresMigration.conversationCodes` to `migration-to-postgresql`
     # before starting the migration.

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -955,7 +955,7 @@ background-worker:
     migrateConversationsOptions:
       pageSize: 10000
       parallelism: 2
-      timtout: 5s
+      timeout: 5s
     # This will start the migration of conversation codes.
     # It's important to set `settings.postgresMigration.conversationCodes` to `migration-to-postgresql`
     # before starting the migration.

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1922,9 +1922,15 @@ time. For conversations, this is necessary for channel search and management of
 channels from the team-management UI. It is highly recommended to take a backup
 of the affected Cassandra data before triggering a migration.
 
-The `background-worker.config.migrateConversationsOptions.timeout`
-defaults to 5s. It sets a per-conversation upper bound for the migration attempt, 
-so a stuck conversation does not keep the migration run blocked indefinitely. 
+The `background-worker.config.migrationOptions.timeout` defaults to 5s. It
+sets an upper bound for a single migration attempt after it has acquired the
+migration lock, so a stuck item does not keep the migration run blocked
+indefinitely.
+
+Although `migrationOptions` is a shared background-worker setting, the
+migrations run sequentially. That means the same configured timeout can be
+used as a practical per-migration limit, because only one migration type is
+executing at a time in the worker.
 
 Migrations are independent and can be run separately, in batches, or all at
 once. This is expected, because migrations will be released over time. The
@@ -2100,11 +2106,11 @@ migrateConversationCodes: false
 migrateTeamFeatures: false
 migrateDomainRegistration: false
 
-# conversation migration settings
-migrateConversationsOptions:
+# migration settings
+migrationOptions:
   pageSize: 10000
   parallelism: 2
-  # Required migration timeout for a single conversation migration attempt.
+  # Required migration timeout for a single migration attempt.
   timeout: 5s
 
 # Background jobs consumer
@@ -2117,10 +2123,9 @@ backgroundJobs:
 federationDomain: example.org
 ```
 
-The `migrateConversationsOptions.timeout` setting limits how long a single
-conversation migration attempt may run after it has acquired the migration
-lock. If the timeout is exceeded, that conversation migration is aborted and the
-migration of this conversation is treated as failed.
+The `migrationOptions.timeout` setting limits how long a single migration
+attempt may run after it has acquired the migration lock. If the timeout is
+exceeded, that migration attempt is aborted and treated as failed.
 
 Choose a value that is comfortably above the normal time for one conversation
 migration, but still low enough to catch a genuinely stuck migration in a

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -2107,8 +2107,8 @@ migrateDomainRegistration: false
 migrateConversationsOptions:
   pageSize: 10000
   parallelism: 2
-  # (optional) migration timeout in seconds, applies to a single conversation
-  timeout: 60
+  # (optional) migration timeout, applies to a single conversation
+  timeout: 5s
 
 # Background jobs consumer
 backgroundJobs:

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1922,6 +1922,13 @@ time. For conversations, this is necessary for channel search and management of
 channels from the team-management UI. It is highly recommended to take a backup
 of the affected Cassandra data before triggering a migration.
 
+When migrating conversations, `background-worker.config.migrateConversationsOptions.timeout`
+should be configured as well. It sets a per-conversation upper bound for the
+migration attempt, so a stuck conversation does not keep the migration run
+blocked indefinitely. Start with a value that is comfortably above the normal
+time for one conversation migration, then adjust it based on observed runtime
+and the size of your dataset.
+
 Migrations are independent and can be run separately, in batches, or all at
 once. This is expected, because migrations will be released over time. The
 pattern below applies per `postgresMigration` setting. A single setting may
@@ -2096,6 +2103,13 @@ migrateConversationCodes: false
 migrateTeamFeatures: false
 migrateDomainRegistration: false
 
+# conversation migration settings
+migrateConversationsOptions:
+  pageSize: 10000
+  parallelism: 2
+  # (optional) migration timeout in seconds, applies to a single conversation
+  timeout: 60
+
 # Background jobs consumer
 backgroundJobs:
   concurrency: 8     # in-flight jobs per process
@@ -2105,6 +2119,19 @@ backgroundJobs:
 # Required for addressing local vs remote backends
 federationDomain: example.org
 ```
+
+The optional `migrateConversationsOptions.timeout` setting limits how long a single
+conversation migration attempt may run after it has acquired the migration
+lock. The value is a plain number of seconds, so `60` means 1 minute.
+If the timeout is exceeded, that conversation migration is aborted and the
+whole migration run is treated as failed.
+
+Choose a value that is comfortably above the normal time for one conversation
+migration, but still low enough to catch a genuinely stuck migration in a
+reasonable time. A good starting point for most deployments is `60` seconds
+(1 minute), then adjust based on observed migration durations.
+
+If the setting is omitted, no timeout will be enforced. In case of a stalling conversation migration, this can lead to exclusive advisory locks leak.
 
 Secrets
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -2107,7 +2107,7 @@ migrateDomainRegistration: false
 migrateConversationsOptions:
   pageSize: 10000
   parallelism: 2
-  # (optional) migration timeout, applies to a single conversation
+  # Required migration timeout for a single conversation migration attempt.
   timeout: 5s
 
 # Background jobs consumer
@@ -2120,18 +2120,15 @@ backgroundJobs:
 federationDomain: example.org
 ```
 
-The optional `migrateConversationsOptions.timeout` setting limits how long a single
+The `migrateConversationsOptions.timeout` setting limits how long a single
 conversation migration attempt may run after it has acquired the migration
 lock. If the timeout is exceeded, that conversation migration is aborted and the
 migration of this conversation is treated as failed.
 
 Choose a value that is comfortably above the normal time for one conversation
 migration, but still low enough to catch a genuinely stuck migration in a
-reasonable time. A good starting point for most deployments is `5s`, 
+reasonable time. A good starting point for most deployments is `5s`,
 then adjust based on observed migration durations.
-
-If the setting is omitted, no timeout will be enforced. If a conversation
-migration stalls, this can lead to leaked exclusive advisory locks.
 
 Secrets
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -2122,9 +2122,8 @@ federationDomain: example.org
 
 The optional `migrateConversationsOptions.timeout` setting limits how long a single
 conversation migration attempt may run after it has acquired the migration
-lock. The value is a plain number of seconds, so `60` means 1 minute.
-If the timeout is exceeded, that conversation migration is aborted and the
-whole migration run is treated as failed.
+lock. If the timeout is exceeded, that conversation migration is aborted and the
+migration of this conversation is treated as failed.
 
 Choose a value that is comfortably above the normal time for one conversation
 migration, but still low enough to catch a genuinely stuck migration in a

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -2131,7 +2131,8 @@ migration, but still low enough to catch a genuinely stuck migration in a
 reasonable time. A good starting point for most deployments is `60` seconds
 (1 minute), then adjust based on observed migration durations.
 
-If the setting is omitted, no timeout will be enforced. In case of a stalling conversation migration, this can lead to exclusive advisory locks leak.
+If the setting is omitted, no timeout will be enforced. If a conversation
+migration stalls, this can lead to leaked exclusive advisory locks.
 
 Secrets
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1922,12 +1922,9 @@ time. For conversations, this is necessary for channel search and management of
 channels from the team-management UI. It is highly recommended to take a backup
 of the affected Cassandra data before triggering a migration.
 
-When migrating conversations, `background-worker.config.migrateConversationsOptions.timeout`
-should be configured as well. It sets a per-conversation upper bound for the
-migration attempt, so a stuck conversation does not keep the migration run
-blocked indefinitely. Start with a value that is comfortably above the normal
-time for one conversation migration, then adjust it based on observed runtime
-and the size of your dataset.
+The `background-worker.config.migrateConversationsOptions.timeout`
+defaults to 5s. It sets a per-conversation upper bound for the migration attempt, 
+so a stuck conversation does not keep the migration run blocked indefinitely. 
 
 Migrations are independent and can be run separately, in batches, or all at
 once. This is expected, because migrations will be released over time. The

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -2127,8 +2127,8 @@ migration of this conversation is treated as failed.
 
 Choose a value that is comfortably above the normal time for one conversation
 migration, but still low enough to catch a genuinely stuck migration in a
-reasonable time. A good starting point for most deployments is `60` seconds
-(1 minute), then adjust based on observed migration durations.
+reasonable time. A good starting point for most deployments is `5s`, 
+then adjust based on observed migration durations.
 
 If the setting is omitted, no timeout will be enforced. If a conversation
 migration stalls, this can lead to leaked exclusive advisory locks.

--- a/libs/types-common/default.nix
+++ b/libs/types-common/default.nix
@@ -36,6 +36,7 @@
 , optparse-applicative
 , pem
 , polysemy
+, polysemy-time
 , protobuf
 , QuickCheck
 , quickcheck-instances
@@ -95,6 +96,7 @@ mkDerivation {
     optparse-applicative
     pem
     polysemy
+    polysemy-time
     protobuf
     QuickCheck
     quickcheck-instances

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -104,6 +104,8 @@ import Data.Time
 import GHC.TypeLits (Nat)
 import GHC.TypeNats (KnownNat)
 import Imports
+import Polysemy.Time
+import Polysemy.Time.Data.TimeUnit
 import Servant (FromHttpApiData (..))
 import Test.QuickCheck (Arbitrary (arbitrary), chooseInteger)
 import Test.QuickCheck qualified as QC
@@ -268,6 +270,16 @@ instance Cql Milliseconds where
 
 newtype Duration = Duration {duration :: DiffTime}
   deriving (Eq, Show)
+
+instance TimeUnit Duration where
+  nanos = NanoSeconds 1_000_000_000
+
+  toNanos (Duration dt) =
+    NanoSeconds . fromInteger $
+      diffTimeToPicoseconds dt `div` 1_000
+
+  fromNanos (NanoSeconds ns) =
+    Duration $ picosecondsToDiffTime (fromIntegral ns * 1_000)
 
 diffTimeParser :: Parser DiffTime
 diffTimeParser = do

--- a/libs/types-common/src/Util/Timeout.hs
+++ b/libs/types-common/src/Util/Timeout.hs
@@ -26,12 +26,13 @@ import Data.Aeson.Types
 import Data.Scientific
 import Data.Time.Clock
 import Imports
+import Polysemy.Time
 import Test.QuickCheck (Arbitrary (arbitrary), choose)
 
 newtype Timeout = Timeout
   { timeoutDiff :: NominalDiffTime
   }
-  deriving newtype (Eq, Enum, Ord, Num, Real, Fractional, RealFrac, Show)
+  deriving newtype (Eq, Enum, Ord, Num, Real, Fractional, RealFrac, Show, TimeUnit)
 
 instance Arbitrary Timeout where
   arbitrary = Timeout . fromIntegral <$> choose (60 :: Int, 10 * 24 * 3600)

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -125,6 +125,7 @@ library
     , optparse-applicative   >=0.10
     , pem
     , polysemy
+    , polysemy-time
     , protobuf               >=0.2
     , QuickCheck             >=2.9
     , quickcheck-instances   >=0.3.16

--- a/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
@@ -130,15 +130,15 @@ migrateCodeRow ::
   Prometheus.Vector Text Prometheus.Histogram ->
   (Key, Value, Int32, ConvId, Maybe Password) ->
   Sem r ()
-migrateCodeRow migOpts migCounter migDuration (k, v, ttl, cnv, mPw) = do
-  outcomeRef <- liftIO $ IORef.newIORef @Text "error"
-  bracket
-    (liftIO getCurrentTime)
-    (observeDuration migDuration outcomeRef)
-    ( const $
-        when (ttl > 0) $ do
-          let (code, _) = toCode k (v, ttl, cnv, mPw)
-              keyText = T.pack (show k)
+migrateCodeRow migOpts migCounter migDuration (k, v, ttl, cnv, mPw) =
+  when (ttl > 0) $ do
+    let (code, _) = toCode k (v, ttl, cnv, mPw)
+        keyText = T.pack (show k)
+    outcomeRef <- liftIO $ IORef.newIORef @Text "error"
+    bracket
+      (liftIO getCurrentTime)
+      (observeDuration migDuration outcomeRef)
+      ( const $ do
           timeoutResult <- Conc.timeout (migOpts.timeout <$ handleTimeout) migOpts.timeout $ Postgres.interpretCodeStoreToPostgres $ createCode code mPw
           case timeoutResult of
             Left timedOutAfter -> do
@@ -147,7 +147,7 @@ migrateCodeRow migOpts migCounter migDuration (k, v, ttl, cnv, mPw) = do
             Right () -> do
               markOutcome outcomeRef "success"
               liftIO $ Prometheus.incCounter migCounter
-    )
+      )
   where
     handleTimeout =
       err $

--- a/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
@@ -22,16 +22,25 @@ import Data.ByteString.Conversion
 import Data.Code (Key, Value)
 import Data.Conduit
 import Data.Conduit.List qualified as C
+import Data.IORef qualified as IORef
 import Data.Id (ConvId)
 import Data.Misc (HttpsUrl)
+import Data.Text qualified as T
+import Data.Time
 import Hasql.Pool qualified as Hasql
 import Imports
 import Polysemy
+import Polysemy.Async
+import Polysemy.Conc (interpretRace)
+import Polysemy.Conc qualified as Conc
+import Polysemy.Conc.Effect.Race hiding (Timeout)
 import Polysemy.Input
+import Polysemy.Resource (Resource, bracket, resourceToIOFinal)
 import Polysemy.State
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
+import UnliftIO qualified
 import Wire.API.Password
 import Wire.CodeStore
 import Wire.CodeStore.Cassandra.Queries qualified as Cql
@@ -47,6 +56,9 @@ type EffectStack =
     Input ClientState,
     Input Hasql.Pool,
     Input (Either HttpsUrl (Map Text HttpsUrl)),
+    Resource,
+    Async,
+    Race,
     TinyLog,
     Embed IO,
     Final IO
@@ -60,15 +72,16 @@ migrateCodesLoop ::
   Prometheus.Counter ->
   Prometheus.Counter ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   IO ()
-migrateCodesLoop migOpts cassClient pgPool logger migCounter migFinished migFailed =
+migrateCodesLoop migOpts cassClient pgPool logger migCounter migFinished migFailed migDuration =
   migrationLoop
     logger
     "conversation codes"
     migFinished
     migFailed
     (interpreter cassClient pgPool logger "conversation codes")
-    (migrateAllCodes migOpts migCounter)
+    (migrateAllCodes migOpts migCounter migDuration)
 
 interpreter :: ClientState -> Hasql.Pool -> Log.Logger -> ByteString -> Sem EffectStack a -> IO (Int, a)
 interpreter cassClient pgPool logger name =
@@ -77,6 +90,9 @@ interpreter cassClient pgPool logger name =
     . loggerToTinyLog logger
     . mapLogger (Log.field "migration" (Log.val name) .)
     . raiseUnder
+    . interpretRace
+    . asyncToIOFinal
+    . resourceToIOFinal
     . runInputConst (Right mempty)
     . runInputConst pgPool
     . runInputConst cassClient
@@ -88,26 +104,60 @@ migrateAllCodes ::
     Member (Embed IO) r,
     Member (Input ClientState) r,
     Member TinyLog r,
-    Member (State Int) r
+    Member (State Int) r,
+    Member Resource r,
+    Member Race r
   ) =>
   MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConduitM () Void (Sem r) ()
-migrateAllCodes migOpts migCounter = do
+migrateAllCodes migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllCodes")
   withCount (paginateSem Cql.selectAllCodes (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize id
-    .| C.mapM_ (traverse_ (\row@(key, _, _, _, _) -> handleErrors (toByteString' key) (migrateCodeRow migCounter row)))
+    .| C.mapM_ (traverse_ (\row@(key, _, _, _, _) -> handleErrors (toByteString' key) (migrateCodeRow migOpts migCounter migDuration row)))
 
 migrateCodeRow ::
   ( Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r,
-    PGConstraints r
+    PGConstraints r,
+    Member TinyLog r,
+    Member Resource r,
+    Member Race r
   ) =>
+  MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   (Key, Value, Int32, ConvId, Maybe Password) ->
   Sem r ()
-migrateCodeRow migCounter (k, v, ttl, cnv, mPw) =
-  when (ttl > 0) $ do
-    let (code, _) = toCode k (v, ttl, cnv, mPw)
-    Postgres.interpretCodeStoreToPostgres $ createCode code mPw
-    liftIO $ Prometheus.incCounter migCounter
+migrateCodeRow migOpts migCounter migDuration (k, v, ttl, cnv, mPw) = do
+  outcomeRef <- liftIO $ IORef.newIORef @Text "error"
+  bracket
+    (liftIO getCurrentTime)
+    (observeDuration migDuration outcomeRef)
+    ( const $
+        when (ttl > 0) $ do
+          let (code, _) = toCode k (v, ttl, cnv, mPw)
+              keyText = T.pack (show k)
+          timeoutResult <- Conc.timeout (migOpts.timeout <$ handleTimeout) migOpts.timeout $ Postgres.interpretCodeStoreToPostgres $ createCode code mPw
+          case timeoutResult of
+            Left timedOutAfter -> do
+              markOutcome outcomeRef "timeout"
+              liftIO . UnliftIO.throwIO $ MigrationTimedOut keyText timedOutAfter
+            Right () -> do
+              markOutcome outcomeRef "success"
+              liftIO $ Prometheus.incCounter migCounter
+    )
+  where
+    handleTimeout =
+      err $
+        Log.msg (Log.val "conversation code migration timed out")
+          . Log.field "key" (show k)
+          . Log.field "timeout" (show migOpts.timeout)
+
+    markOutcome ref outcome = liftIO $ IORef.writeIORef ref outcome
+
+    observeDuration metric outcomeRef start = do
+      outcome <- liftIO $ IORef.readIORef outcomeRef
+      end <- liftIO getCurrentTime
+      liftIO $ Prometheus.withLabel metric outcome (`Prometheus.observe` realToFrac (diffUTCTime end start))

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
@@ -48,7 +48,6 @@ import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Resource (Resource, resourceToIOFinal)
 import Polysemy.State
-import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
@@ -120,15 +119,16 @@ migrateUsersLoop ::
   Prometheus.Counter ->
   Prometheus.Counter ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   IO ()
-migrateUsersLoop migOpts cassClient pgPool logger migCounter migFinished migFailed =
+migrateUsersLoop migOpts cassClient pgPool logger migCounter migFinished migFailed migDuration =
   migrationLoop
     logger
     "users"
     migFinished
     migFailed
     (interpreter cassClient pgPool logger "users")
-    (migrateAllUsers migOpts migCounter)
+    (migrateAllUsers migOpts migCounter migDuration)
 
 interpreter :: ClientState -> Hasql.Pool -> Log.Logger -> ByteString -> Sem EffectStack a -> IO (Int, a)
 interpreter cassClient pgPool logger name =
@@ -170,7 +170,7 @@ migrateAllConversations migOpts migCounter migDuration = do
     select = "select conv from conversation"
 
     migrateConversationWithLock timeout_ cid =
-      withMigrationLocksAndTimeout timeout_ migDuration [cid] $ migrateConversation cid migCounter
+      withExclusiveMigrationLockAndTimeout timeout_ migDuration [cid] $ migrateConversation cid migCounter
 
 migrateAllUsers ::
   ( Member (Input Hasql.Pool) r,
@@ -185,12 +185,13 @@ migrateAllUsers ::
   ) =>
   MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConduitM () Void (Sem r) ()
-migrateAllUsers migOpts migCounter = do
+migrateAllUsers migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllUsers")
   withCount (paginateSem select (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize runIdentity
-    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateUser migCounter) "user"))
+    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateUser migOpts migCounter migDuration) "user"))
   where
     select :: PrepQuery R () (Identity UserId)
     select = "select distinct user from user_remote_conv"
@@ -442,9 +443,22 @@ saveConvToPostgres allConvData = do
 
 -- * Users
 
-migrateUser :: (PGConstraints r, Member (Input ClientState) r, Member TinyLog r, Member Async r, Member (Error MigrationLockError) r, Member Race r, Member Resource r) => Prometheus.Counter -> UserId -> Sem r ()
-migrateUser migCounter uid = do
-  withMigrationLocks LockExclusive (Seconds 10) [uid] $ do
+migrateUser ::
+  ( PGConstraints r,
+    Member (Input ClientState) r,
+    Member TinyLog r,
+    Member Async r,
+    Member (Error MigrationLockError) r,
+    Member Race r,
+    Member Resource r
+  ) =>
+  MigrationOptions ->
+  Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
+  UserId ->
+  Sem r ()
+migrateUser migOpts migCounter migDuration uid = do
+  withExclusiveMigrationLockAndTimeout migOpts.timeout migDuration [uid] $ do
     statusses <- getRemoteMemberStatusFromCassandra uid
     saveRemoteMemberStatusToPostgres uid statusses
     deleteRemoteMemberStatusesFromCassandra uid

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
@@ -25,6 +25,7 @@ import Control.Error (lastMay)
 import Data.Conduit
 import Data.Conduit.List qualified as C
 import Data.Domain
+import Data.IORef qualified as IORef
 import Data.Id
 import Data.IntMap qualified as IntMap
 import Data.Map qualified as Map
@@ -46,12 +47,14 @@ import Polysemy.Async
 import Polysemy.Conc
 import Polysemy.Error
 import Polysemy.Input
-import Polysemy.Resource (Resource, resourceToIOFinal)
+import Polysemy.Resource (Resource, bracket, resourceToIOFinal)
 import Polysemy.State
 import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
+import UnliftIO.Exception qualified as UnliftIO
+import Util.Timeout
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.CellsState
 import Wire.API.Conversation.Protocol
@@ -101,15 +104,16 @@ migrateConvsLoop ::
   Prometheus.Counter ->
   Prometheus.Counter ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   IO ()
-migrateConvsLoop migOpts cassClient pgPool logger migCounter migFinished migFailed =
+migrateConvsLoop migOpts cassClient pgPool logger migCounter migFinished migFailed migDuration =
   migrationLoop
     logger
     "conversations"
     migFinished
     migFailed
     (interpreter cassClient pgPool logger "conversations")
-    (migrateAllConversations migOpts migCounter)
+    (migrateAllConversations migOpts migCounter migDuration)
 
 migrateUsersLoop ::
   MigrationOptions ->
@@ -157,12 +161,13 @@ migrateAllConversations ::
   ) =>
   MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConduitM () Void (Sem r) ()
-migrateAllConversations migOpts migCounter = do
+migrateAllConversations migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllConversations")
   withCount (paginateSem select (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize runIdentity
-    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateConversation migCounter) "conv"))
+    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateConversationWithLock migOpts.timeout migCounter migDuration) "conv"))
   where
     select :: PrepQuery R () (Identity ConvId)
     select = "select conv from conversation"
@@ -209,7 +214,7 @@ handleError action lockType id_ = do
 
 -- * Conversations
 
-migrateConversation ::
+migrateConversationWithLock ::
   ( PGConstraints r,
     Member (Input ClientState) r,
     Member TinyLog r,
@@ -218,17 +223,61 @@ migrateConversation ::
     Member Race r,
     Member Resource r
   ) =>
+  Maybe Timeout ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConvId ->
   Sem r ()
-migrateConversation migCounter cid = do
-  void . withMigrationLocks LockExclusive (Seconds 10) [cid] $ do
-    mConvData <- withCassandra $ getAllConvData cid
-    for_ mConvData $ \convData -> do
-      saveConvToPostgres convData
-      withCassandra $ deleteConv convData
-    markDeletionComplete DeleteConv cid
-    liftIO $ Prometheus.incCounter migCounter
+migrateConversationWithLock mTimeout migCounter migDuration cid = do
+  outcomeRef <- liftIO $ IORef.newIORef @Text "error"
+  bracket
+    (liftIO getCurrentTime)
+    (observeDuration migDuration outcomeRef)
+    ( const do
+        result <-
+          runError $
+            withMigrationLocks LockExclusive (Seconds 10) [cid] $ do
+              case mTimeout of
+                Just to -> do
+                  timeoutResult <- Polysemy.Conc.timeout (to <$ handleTimeout to) to $ migrateConversation
+                  case timeoutResult of
+                    Left timedOutAfter -> do
+                      markOutcome outcomeRef "timeout"
+                      -- this aborts the whole migration process
+                      liftIO . UnliftIO.throwIO $ MigrationTimedOut (idToText cid) timedOutAfter
+                    Right () -> do
+                      markOutcome outcomeRef "success"
+                Nothing -> do
+                  migrateConversation
+                  markOutcome outcomeRef "success"
+
+        case result of
+          Left TimedOutAcquiringLock -> do
+            markOutcome outcomeRef "lock_timeout"
+            throw TimedOutAcquiringLock
+          Right () -> pure ()
+    )
+  where
+    migrateConversation = do
+      mConvData <- withCassandra $ getAllConvData cid
+      for_ mConvData $ \convData -> do
+        saveConvToPostgres convData
+        withCassandra $ deleteConv convData
+      markDeletionComplete DeleteConv cid
+      liftIO $ Prometheus.incCounter migCounter
+
+    handleTimeout to = do
+      err $
+        Log.msg (Log.val "conversation migrations timed out")
+          . Log.field "conv" (idToText cid)
+          . Log.field "timeout" (show to)
+
+    markOutcome ref outcome = liftIO $ IORef.writeIORef ref outcome
+
+    observeDuration metric outcomeRef start = do
+      outcome <- liftIO $ IORef.readIORef outcomeRef
+      end <- liftIO getCurrentTime
+      liftIO $ Prometheus.withLabel metric outcome (`Prometheus.observe` realToFrac (diffUTCTime end start))
 
 deleteConvFromCassandra :: (Member (Input ClientState) r, Member TinyLog r, Member (Embed IO) r) => AllConvData -> Sem r ()
 deleteConvFromCassandra allConvData = withCassandra $ do

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
@@ -25,7 +25,6 @@ import Control.Error (lastMay)
 import Data.Conduit
 import Data.Conduit.List qualified as C
 import Data.Domain
-import Data.IORef qualified as IORef
 import Data.Id
 import Data.IntMap qualified as IntMap
 import Data.Map qualified as Map
@@ -47,13 +46,12 @@ import Polysemy.Async
 import Polysemy.Conc hiding (timeout_)
 import Polysemy.Error
 import Polysemy.Input
-import Polysemy.Resource (Resource, bracket, resourceToIOFinal)
+import Polysemy.Resource (Resource, resourceToIOFinal)
 import Polysemy.State
 import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
-import UnliftIO.Exception qualified as UnliftIO
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.CellsState
 import Wire.API.Conversation.Protocol
@@ -166,10 +164,13 @@ migrateAllConversations migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllConversations")
   withCount (paginateSem select (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize runIdentity
-    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateConversationWithLock migOpts.timeout migCounter migDuration) "conv"))
+    .| C.mapM_ (unsafePooledMapConcurrentlyN_ migOpts.parallelism (handleErrors (migrateConversationWithLock migOpts.timeout) "conv"))
   where
     select :: PrepQuery R () (Identity ConvId)
     select = "select conv from conversation"
+
+    migrateConversationWithLock timeout_ cid =
+      withMigrationLocksAndTimeout timeout_ migDuration [cid] $ migrateConversation cid migCounter
 
 migrateAllUsers ::
   ( Member (Input Hasql.Pool) r,
@@ -213,65 +214,14 @@ handleError action lockType id_ = do
 
 -- * Conversations
 
-migrateConversationWithLock ::
-  ( PGConstraints r,
-    Member (Input ClientState) r,
-    Member TinyLog r,
-    Member Async r,
-    Member (Error MigrationLockError) r,
-    Member Race r,
-    Member Resource r
-  ) =>
-  Duration ->
-  Prometheus.Counter ->
-  Prometheus.Vector Text Prometheus.Histogram ->
-  ConvId ->
-  Sem r ()
-migrateConversationWithLock timeout_ migCounter migDuration cid = do
-  outcomeRef <- liftIO $ IORef.newIORef @Text "error"
-  bracket
-    (liftIO getCurrentTime)
-    (observeDuration migDuration outcomeRef)
-    ( const do
-        result <-
-          runError $
-            withMigrationLocks LockExclusive (Seconds 10) [cid] $ do
-              timeoutResult <- Polysemy.Conc.timeout (timeout_ <$ handleTimeout) timeout_ $ migrateConversation
-              case timeoutResult of
-                Left timedOutAfter -> do
-                  markOutcome outcomeRef "timeout"
-                  -- this aborts the whole migration process
-                  liftIO . UnliftIO.throwIO $ MigrationTimedOut (idToText cid) timedOutAfter
-                Right () -> do
-                  markOutcome outcomeRef "success"
-
-        case result of
-          Left TimedOutAcquiringLock -> do
-            markOutcome outcomeRef "lock_timeout"
-            throw TimedOutAcquiringLock
-          Right () -> pure ()
-    )
-  where
-    migrateConversation = do
-      mConvData <- withCassandra $ getAllConvData cid
-      for_ mConvData $ \convData -> do
-        saveConvToPostgres convData
-        withCassandra $ deleteConv convData
-      markDeletionComplete DeleteConv cid
-      liftIO $ Prometheus.incCounter migCounter
-
-    handleTimeout = do
-      err $
-        Log.msg (Log.val "conversation migrations timed out")
-          . Log.field "conv" (idToText cid)
-          . Log.field "timeout" (show timeout_)
-
-    markOutcome ref outcome = liftIO $ IORef.writeIORef ref outcome
-
-    observeDuration metric outcomeRef start = do
-      outcome <- liftIO $ IORef.readIORef outcomeRef
-      end <- liftIO getCurrentTime
-      liftIO $ Prometheus.withLabel metric outcome (`Prometheus.observe` realToFrac (diffUTCTime end start))
+migrateConversation :: (PGConstraints r, Member (Input ClientState) r, Member TinyLog r) => ConvId -> Prometheus.Counter -> Sem r ()
+migrateConversation cid migCounter = do
+  mConvData <- withCassandra $ getAllConvData cid
+  for_ mConvData $ \convData -> do
+    saveConvToPostgres convData
+    withCassandra $ deleteConv convData
+  markDeletionComplete DeleteConv cid
+  liftIO $ Prometheus.incCounter migCounter
 
 deleteConvFromCassandra :: (Member (Input ClientState) r, Member TinyLog r, Member (Embed IO) r) => AllConvData -> Sem r ()
 deleteConvFromCassandra allConvData = withCassandra $ do

--- a/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationStore/Migration.hs
@@ -44,7 +44,7 @@ import Hasql.Transaction.Sessions
 import Imports
 import Polysemy
 import Polysemy.Async
-import Polysemy.Conc
+import Polysemy.Conc hiding (timeout_)
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Resource (Resource, bracket, resourceToIOFinal)
@@ -54,7 +54,6 @@ import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
 import UnliftIO.Exception qualified as UnliftIO
-import Util.Timeout
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.CellsState
 import Wire.API.Conversation.Protocol
@@ -223,12 +222,12 @@ migrateConversationWithLock ::
     Member Race r,
     Member Resource r
   ) =>
-  Maybe Timeout ->
+  Duration ->
   Prometheus.Counter ->
   Prometheus.Vector Text Prometheus.Histogram ->
   ConvId ->
   Sem r ()
-migrateConversationWithLock mTimeout migCounter migDuration cid = do
+migrateConversationWithLock timeout_ migCounter migDuration cid = do
   outcomeRef <- liftIO $ IORef.newIORef @Text "error"
   bracket
     (liftIO getCurrentTime)
@@ -237,18 +236,13 @@ migrateConversationWithLock mTimeout migCounter migDuration cid = do
         result <-
           runError $
             withMigrationLocks LockExclusive (Seconds 10) [cid] $ do
-              case mTimeout of
-                Just to -> do
-                  timeoutResult <- Polysemy.Conc.timeout (to <$ handleTimeout to) to $ migrateConversation
-                  case timeoutResult of
-                    Left timedOutAfter -> do
-                      markOutcome outcomeRef "timeout"
-                      -- this aborts the whole migration process
-                      liftIO . UnliftIO.throwIO $ MigrationTimedOut (idToText cid) timedOutAfter
-                    Right () -> do
-                      markOutcome outcomeRef "success"
-                Nothing -> do
-                  migrateConversation
+              timeoutResult <- Polysemy.Conc.timeout (timeout_ <$ handleTimeout) timeout_ $ migrateConversation
+              case timeoutResult of
+                Left timedOutAfter -> do
+                  markOutcome outcomeRef "timeout"
+                  -- this aborts the whole migration process
+                  liftIO . UnliftIO.throwIO $ MigrationTimedOut (idToText cid) timedOutAfter
+                Right () -> do
                   markOutcome outcomeRef "success"
 
         case result of
@@ -266,11 +260,11 @@ migrateConversationWithLock mTimeout migCounter migDuration cid = do
       markDeletionComplete DeleteConv cid
       liftIO $ Prometheus.incCounter migCounter
 
-    handleTimeout to = do
+    handleTimeout = do
       err $
         Log.msg (Log.val "conversation migrations timed out")
           . Log.field "conv" (idToText cid)
-          . Log.field "timeout" (show to)
+          . Log.field "timeout" (show timeout_)
 
     markOutcome ref outcome = liftIO $ IORef.writeIORef ref outcome
 

--- a/libs/wire-subsystems/src/Wire/DomainRegistrationStore.hs
+++ b/libs/wire-subsystems/src/Wire/DomainRegistrationStore.hs
@@ -80,6 +80,7 @@ instance PostgresUnmarshall Text DomainKey where
 instance MigrationLockable DomainKey where
   lockKey = fromIntegral . hash . CI.foldedCase . unDomainKey
   lockScope = "domain_registration"
+  toText = original . unDomainKey
 
 type DomainRegistrationRow =
   ( Text,

--- a/libs/wire-subsystems/src/Wire/DomainRegistrationStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/DomainRegistrationStore/Migration.hs
@@ -37,7 +37,6 @@ import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Resource (Resource, resourceToIOFinal)
 import Polysemy.State
-import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
@@ -74,15 +73,16 @@ migrateDomainRegistrationsLoop ::
   Prometheus.Counter ->
   Prometheus.Counter ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   IO ()
-migrateDomainRegistrationsLoop migOpts cassClient pgPool logger migCounter migFinished migFailed =
+migrateDomainRegistrationsLoop migOpts cassClient pgPool logger migCounter migFinished migFailed migDuration =
   migrationLoop
     logger
     "domain registrations"
     migFinished
     migFailed
     (interpreter cassClient pgPool logger "domain registrations")
-    (migrateAllDomainRegistrations migOpts migCounter)
+    (migrateAllDomainRegistrations migOpts migCounter migDuration)
 
 interpreter :: ClientState -> Hasql.Pool -> Log.Logger -> ByteString -> Sem EffectStack a -> IO (Int, a)
 interpreter cassClient pgPool logger name =
@@ -110,8 +110,9 @@ migrateAllDomainRegistrations ::
   ) =>
   MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConduitM () Void (Sem r) ()
-migrateAllDomainRegistrations migOpts migCounter = do
+migrateAllDomainRegistrations migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllDomainRegistrationChallenges")
   withCount (paginateSem selectAllChallenges (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize id
@@ -120,7 +121,7 @@ migrateAllDomainRegistrations migOpts migCounter = do
   lift $ info $ Log.msg (Log.val "migrateAllDomainRegistrations")
   withCount (paginateSem selectAllRegistrations (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize asRecord
-    .| C.mapM_ (traverse_ (\row -> handleRegistrationErrors (toByteString' (show row.domain)) (migrateDomainRegistrationRow migCounter row)))
+    .| C.mapM_ (traverse_ (\row -> handleRegistrationErrors (toByteString' (show row.domain)) (migrateDomainRegistrationRow migOpts migCounter migDuration row)))
 
 migrateDomainRegistrationRow ::
   ( PGConstraints r,
@@ -131,11 +132,13 @@ migrateDomainRegistrationRow ::
     Member Race r,
     Member Resource r
   ) =>
+  MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   StoredDomainRegistration ->
   Sem r ()
-migrateDomainRegistrationRow migCounter row = do
-  void . withMigrationLocks LockExclusive (Seconds 10) [row.domain] $ do
+migrateDomainRegistrationRow migOpts migCounter migDuration row = do
+  void . withExclusiveMigrationLockAndTimeout migOpts.timeout migDuration [row.domain] $ do
     isMigrated <- DomainRegistrationPostgres.exists row.domain
     unless isMigrated $ do
       cassClient <- input @ClientState

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -169,7 +169,7 @@ handleErrors key action = do
           . Log.field "error" (show e)
       modify (+ 1)
 
-withMigrationLocksAndTimeout ::
+withExclusiveMigrationLockAndTimeout ::
   forall x r.
   ( PGConstraints r,
     Member TinyLog r,
@@ -184,7 +184,7 @@ withMigrationLocksAndTimeout ::
   [x] ->
   Sem (Error MigrationLockError : r) () ->
   Sem r ()
-withMigrationLocksAndTimeout timeout_ migDuration xs action = do
+withExclusiveMigrationLockAndTimeout timeout_ migDuration xs action = do
   outcomeRef <- liftIO $ IORef.newIORef @Text "error"
   bracket
     (liftIO getCurrentTime)

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -23,18 +23,28 @@ import Data.Aeson
 import Data.Conduit
 import Data.Conduit.Internal (zipSources)
 import Data.Conduit.List qualified as C
+import Data.IORef qualified as IORef
 import Data.Misc
+import Data.Text qualified as T
+import Data.Time
 import GHC.Generics (Generically (..))
 import Hasql.Pool qualified as Hasql
 import Imports
 import Polysemy
+import Polysemy.Async
+import Polysemy.Conc hiding (timeout_)
+import Polysemy.Conc qualified as Conc
 import Polysemy.Error
 import Polysemy.Input
+import Polysemy.Resource
 import Polysemy.State
+import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
 import UnliftIO qualified
+import Wire.MigrationLock
+import Wire.Postgres (PGConstraints)
 import Wire.Util (embedClient)
 
 data MigrationOptions = MigrationOptions
@@ -158,3 +168,58 @@ handleErrors key action = do
           . Log.field "key" (show key)
           . Log.field "error" (show e)
       modify (+ 1)
+
+withMigrationLocksAndTimeout ::
+  forall x r.
+  ( PGConstraints r,
+    Member TinyLog r,
+    Member Async r,
+    Member (Error MigrationLockError) r,
+    Member Race r,
+    Member Resource r,
+    MigrationLockable x
+  ) =>
+  Duration ->
+  Prometheus.Vector Text Prometheus.Histogram ->
+  [x] ->
+  Sem (Error MigrationLockError : r) () ->
+  Sem r ()
+withMigrationLocksAndTimeout timeout_ migDuration xs action = do
+  outcomeRef <- liftIO $ IORef.newIORef @Text "error"
+  bracket
+    (liftIO getCurrentTime)
+    (observeDuration migDuration outcomeRef)
+    ( const do
+        result <-
+          runError $
+            withMigrationLocks LockExclusive (Seconds 10) xs $ do
+              timeoutResult <- Conc.timeout (timeout_ <$ handleTimeout) timeout_ action
+              case timeoutResult of
+                Left timedOutAfter -> do
+                  markOutcome outcomeRef "timeout"
+                  -- this aborts the whole migration process
+                  liftIO . UnliftIO.throwIO $ MigrationTimedOut lockables timedOutAfter
+                Right () -> do
+                  markOutcome outcomeRef "success"
+
+        case result of
+          Left TimedOutAcquiringLock -> do
+            markOutcome outcomeRef "lock_timeout"
+            throw TimedOutAcquiringLock
+          Right () -> pure ()
+    )
+  where
+    handleTimeout = do
+      err $
+        Log.msg (Log.val (lockScope @x <> " migrations timed out"))
+          . Log.field "ids" lockables
+          . Log.field "timeout" (show timeout_)
+
+    lockables = T.intercalate ", " (toText <$> xs)
+
+    markOutcome ref outcome = liftIO $ IORef.writeIORef ref outcome
+
+    observeDuration metric outcomeRef start = do
+      outcome <- liftIO $ IORef.readIORef outcomeRef
+      end <- liftIO getCurrentTime
+      liftIO $ Prometheus.withLabel metric outcome (`Prometheus.observe` realToFrac (diffUTCTime end start))

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -196,6 +196,7 @@ withExclusiveMigrationLockAndTimeout timeout_ migDuration xs action = do
               timeoutResult <- Conc.timeout (timeout_ <$ handleTimeout) timeout_ action
               case timeoutResult of
                 Left timedOutAfter -> do
+                  handleTimeout
                   markOutcome outcomeRef "timeout"
                   -- this aborts the whole migration process
                   liftIO . UnliftIO.throwIO $ MigrationTimedOut lockables timedOutAfter

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -23,6 +23,7 @@ import Data.Aeson
 import Data.Conduit
 import Data.Conduit.Internal (zipSources)
 import Data.Conduit.List qualified as C
+import Data.Misc
 import GHC.Generics (Generically (..))
 import Hasql.Pool qualified as Hasql
 import Imports
@@ -34,21 +35,19 @@ import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
 import UnliftIO qualified
-import Util.Timeout (Timeout)
 import Wire.Util (embedClient)
 
 data MigrationOptions = MigrationOptions
   { pageSize :: Int32,
     parallelism :: Int,
-    -- optional timeout that applies to a single conversation and
-    -- limits how long a single conversation migration attempt may run
-    -- after it has acquired the migration lock
-    timeout :: Maybe Timeout
+    -- Required timeout for a single migration attempt after it has acquired
+    -- the migration lock.
+    timeout :: Duration
   }
   deriving (Show, Eq, Generic)
   deriving (FromJSON) via Generically MigrationOptions
 
-data MigrationTimedOut = MigrationTimedOut Text Timeout
+data MigrationTimedOut = MigrationTimedOut Text Duration
   deriving stock (Show)
 
 instance Exception MigrationTimedOut

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -193,12 +193,12 @@ withExclusiveMigrationLockAndTimeout timeout_ migDuration xs action = do
         result <-
           runError $
             withMigrationLocks LockExclusive (Seconds 10) xs $ do
-              timeoutResult <- Conc.timeout (timeout_ <$ handleTimeout) timeout_ action
+              timeoutResult <- Conc.timeout handleTimeout timeout_ action
               case timeoutResult of
-                Left timedOutAfter -> do
+                Left () -> do
                   markOutcome outcomeRef "timeout"
                   -- this aborts the whole migration process
-                  liftIO . UnliftIO.throwIO $ MigrationTimedOut lockables timedOutAfter
+                  liftIO . UnliftIO.throwIO $ MigrationTimedOut lockables timeout_
                 Right () -> do
                   markOutcome outcomeRef "success"
 

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -34,14 +34,21 @@ import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
 import UnliftIO qualified
+import Util.Timeout (Timeout)
 import Wire.Util (embedClient)
 
 data MigrationOptions = MigrationOptions
   { pageSize :: Int32,
-    parallelism :: Int
+    parallelism :: Int,
+    timeout :: Maybe Timeout
   }
   deriving (Show, Eq, Generic)
   deriving (FromJSON) via Generically MigrationOptions
+
+data MigrationTimedOut = MigrationTimedOut Text Timeout
+  deriving stock (Show)
+
+instance Exception MigrationTimedOut
 
 migrationLoop ::
   Log.Logger ->

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -40,6 +40,9 @@ import Wire.Util (embedClient)
 data MigrationOptions = MigrationOptions
   { pageSize :: Int32,
     parallelism :: Int,
+    -- optional timeout that applies to a single conversation and
+    -- limits how long a single conversation migration attempt may run
+    -- after it has acquired the migration lock
     timeout :: Maybe Timeout
   }
   deriving (Show, Eq, Generic)

--- a/libs/wire-subsystems/src/Wire/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/Migration.hs
@@ -196,7 +196,6 @@ withExclusiveMigrationLockAndTimeout timeout_ migDuration xs action = do
               timeoutResult <- Conc.timeout (timeout_ <$ handleTimeout) timeout_ action
               case timeoutResult of
                 Left timedOutAfter -> do
-                  handleTimeout
                   markOutcome outcomeRef "timeout"
                   -- this aborts the whole migration process
                   liftIO . UnliftIO.throwIO $ MigrationTimedOut lockables timedOutAfter

--- a/libs/wire-subsystems/src/Wire/MigrationLock.hs
+++ b/libs/wire-subsystems/src/Wire/MigrationLock.hs
@@ -54,6 +54,8 @@ class MigrationLockable a where
   -- | key used for advisory locks; should be collision-resistant (unique with high probability)
   lockKey :: a -> Int64
 
+  toText :: a -> Text
+
 data LockType
   = -- | Used for migrating a set of data, will block any other locks
     LockExclusive
@@ -164,14 +166,17 @@ instance MigrationLockable (TeamId, Text) where
         featureHash = fromIntegral (hash featureName)
      in teamHash `xor` rotateL featureHash 1
   lockScope = "team_feature"
+  toText (tid, feat) = idToText tid <> ":" <> feat
 
 instance MigrationLockable ConvId where
   lockKey = hashUUID
   lockScope = "conv"
+  toText = idToText
 
 instance MigrationLockable UserId where
   lockKey = hashUUID
   lockScope = "user"
+  toText = idToText
 
 hashUUID :: Id a -> Int64
 hashUUID (toUUID -> uuid) =

--- a/libs/wire-subsystems/src/Wire/TeamFeatureStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/TeamFeatureStore/Migration.hs
@@ -31,7 +31,6 @@ import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Resource (Resource, resourceToIOFinal)
 import Polysemy.State
-import Polysemy.Time
 import Polysemy.TinyLog
 import Prometheus qualified
 import System.Logger qualified as Log
@@ -56,12 +55,13 @@ migrateAllTeamFeatures ::
   ) =>
   MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   ConduitM () Void (Sem r) ()
-migrateAllTeamFeatures migOpts migCounter = do
+migrateAllTeamFeatures migOpts migCounter migDuration = do
   lift $ info $ Log.msg (Log.val "migrateAllTeamFeatures  ")
   withCount (paginateSem Cql.selectAll (paramsP LocalQuorum () migOpts.pageSize) x5)
     .| logRetrievedPage migOpts.pageSize id
-    .| C.mapM_ (traverse_ (\row@(tid, feat, _, _, _) -> handleErrors (toByteString' (idToText tid <> " - " <> feat)) (migrateTeamFeature migCounter row)))
+    .| C.mapM_ (traverse_ (\row@(tid, feat, _, _, _) -> handleErrors (toByteString' (idToText tid <> " - " <> feat)) (migrateTeamFeature migOpts migCounter migDuration row)))
 
 type EffectStack =
   [ State Int,
@@ -83,15 +83,16 @@ migrateTeamFeaturesLoop ::
   Prometheus.Counter ->
   Prometheus.Counter ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   IO ()
-migrateTeamFeaturesLoop migOpts cassClient pgPool logger migCounter migFinished migFailed =
+migrateTeamFeaturesLoop migOpts cassClient pgPool logger migCounter migFinished migFailed migDuration =
   migrationLoop
     logger
     "team features"
     migFinished
     migFailed
     (interpreter cassClient pgPool logger "team features")
-    (migrateAllTeamFeatures migOpts migCounter)
+    (migrateAllTeamFeatures migOpts migCounter migDuration)
 
 interpreter :: ClientState -> Hasql.Pool -> Log.Logger -> ByteString -> Sem EffectStack a -> IO (Int, a)
 interpreter cassClient pgPool logger name =
@@ -115,15 +116,17 @@ migrateTeamFeature ::
     Member Race r,
     Member Resource r
   ) =>
+  MigrationOptions ->
   Prometheus.Counter ->
+  Prometheus.Vector Text Prometheus.Histogram ->
   (TeamId, Text, Maybe FeatureStatus, Maybe LockStatus, Maybe DbConfig) ->
   Sem r ()
-migrateTeamFeature migCounter (tid, name, status, lockStatus, dbConfig) = do
+migrateTeamFeature migOpts migCounter migDuration (tid, name, status, lockStatus, dbConfig) = do
   -- We do not delete Cassandra rows during migration. Writes and migration use
   -- the same per-row lock, so we avoid races without deleting early. Deletion is
   -- deferred to keep rollback options and to remove the Cassandra table only after
   -- a full cutover to Postgres-only.
-  void . withMigrationLocks LockExclusive (Seconds 10) [(tid, name)] $ do
+  void . withExclusiveMigrationLockAndTimeout migOpts.timeout migDuration [(tid, name)] $ do
     isMigrated <- runStatement (tid, name) Psql.exists
     unless isMigrated $ do
       runStatement (tid, name, status, lockStatus, dbConfig) Psql.upsertPatch

--- a/services/background-worker/background-worker.integration.yaml
+++ b/services/background-worker/background-worker.integration.yaml
@@ -52,7 +52,7 @@ backendNotificationPusher:
   remotesRefreshInterval: 10000 # 10ms
 
 migrateConversations: false
-migrateConversationsOptions:
+migrationOptions:
   pageSize: 10000
   parallelism: 2
   timeout: 5s

--- a/services/background-worker/background-worker.integration.yaml
+++ b/services/background-worker/background-worker.integration.yaml
@@ -55,6 +55,7 @@ migrateConversations: false
 migrateConversationsOptions:
   pageSize: 10000
   parallelism: 2
+  timeout: 5s
 migrateConversationCodes: false
 migrateTeamFeatures: false
 migrateDomainRegistration: false

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -20,7 +20,6 @@
 module Wire.BackgroundWorker where
 
 import Data.Metrics.Servant qualified as Metrics
-import Data.Misc
 import Data.Text qualified as T
 import Imports
 import Network.AMQP.Extended (demoteOpts)
@@ -57,28 +56,28 @@ run opts galleyOpts = do
       then
         runAppT env $
           withNamedLogger "migrate-conversations" $
-            Migrations.conversations opts.migrateConversationsOptions
+            Migrations.conversations opts.migrationOptions
       else pure $ pure ()
   cleanUpConvCodesMigration <-
     if opts.migrateConversationCodes
       then
         runAppT env $
           withNamedLogger "migrate-conversation-codes" $
-            Migrations.conversationCodes (MigrationOptions 1000 1 (Duration 5))
+            Migrations.conversationCodes opts.migrationOptions
       else pure $ pure ()
   cleanupTeamFeaturesMigration <-
     if opts.migrateTeamFeatures
       then
         runAppT env $
           withNamedLogger "migrate-team-features" $
-            Migrations.teamFeatures (MigrationOptions 1000 1 (Duration 5))
+            Migrations.teamFeatures opts.migrationOptions
       else pure $ pure ()
   cleanupDomainRegistrationMigration <-
     if opts.migrateDomainRegistration
       then
         runAppT env $
           withNamedLogger "migrate-domain-registration" $
-            Migrations.domainRegistration (MigrationOptions 1000 1 (Duration 5))
+            Migrations.domainRegistration opts.migrationOptions
       else pure $ pure ()
   cleanupJobs <-
     runAppT env $

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -20,6 +20,7 @@
 module Wire.BackgroundWorker where
 
 import Data.Metrics.Servant qualified as Metrics
+import Data.Misc
 import Data.Text qualified as T
 import Imports
 import Network.AMQP.Extended (demoteOpts)
@@ -63,21 +64,21 @@ run opts galleyOpts = do
       then
         runAppT env $
           withNamedLogger "migrate-conversation-codes" $
-            Migrations.conversationCodes (MigrationOptions 1000 1 Nothing)
+            Migrations.conversationCodes (MigrationOptions 1000 1 (Duration 5))
       else pure $ pure ()
   cleanupTeamFeaturesMigration <-
     if opts.migrateTeamFeatures
       then
         runAppT env $
           withNamedLogger "migrate-team-features" $
-            Migrations.teamFeatures (MigrationOptions 1000 1 Nothing)
+            Migrations.teamFeatures (MigrationOptions 1000 1 (Duration 5))
       else pure $ pure ()
   cleanupDomainRegistrationMigration <-
     if opts.migrateDomainRegistration
       then
         runAppT env $
           withNamedLogger "migrate-domain-registration" $
-            Migrations.domainRegistration (MigrationOptions 1000 1 Nothing)
+            Migrations.domainRegistration (MigrationOptions 1000 1 (Duration 5))
       else pure $ pure ()
   cleanupJobs <-
     runAppT env $

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -35,7 +35,6 @@ import Wire.BackgroundWorker.Jobs.Consumer qualified as Jobs
 import Wire.BackgroundWorker.Options
 import Wire.DeadUserNotificationWatcher qualified as DeadUserNotificationWatcher
 import Wire.MeetingsCleanupWorker qualified as MeetingsCleanupWorker
-import Wire.Migration
 import Wire.Options.Galley qualified as Galley
 import Wire.PostgresMigrations qualified as Migrations
 

--- a/services/background-worker/src/Wire/BackgroundWorker.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker.hs
@@ -63,21 +63,21 @@ run opts galleyOpts = do
       then
         runAppT env $
           withNamedLogger "migrate-conversation-codes" $
-            Migrations.conversationCodes (MigrationOptions 1000 1)
+            Migrations.conversationCodes (MigrationOptions 1000 1 Nothing)
       else pure $ pure ()
   cleanupTeamFeaturesMigration <-
     if opts.migrateTeamFeatures
       then
         runAppT env $
           withNamedLogger "migrate-team-features" $
-            Migrations.teamFeatures (MigrationOptions 1000 1)
+            Migrations.teamFeatures (MigrationOptions 1000 1 Nothing)
       else pure $ pure ()
   cleanupDomainRegistrationMigration <-
     if opts.migrateDomainRegistration
       then
         runAppT env $
           withNamedLogger "migrate-domain-registration" $
-            Migrations.domainRegistration (MigrationOptions 1000 1)
+            Migrations.domainRegistration (MigrationOptions 1000 1 Nothing)
       else pure $ pure ()
   cleanupJobs <-
     runAppT env $

--- a/services/background-worker/src/Wire/BackgroundWorker/Options.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Options.hs
@@ -51,7 +51,7 @@ data Opts = Opts
     postgresqlPool :: !PoolConfig,
     postgresMigration :: !PostgresMigrationOpts,
     migrateConversations :: !Bool,
-    migrateConversationsOptions :: !MigrationOptions,
+    migrationOptions :: !MigrationOptions,
     migrateConversationCodes :: !Bool,
     migrateTeamFeatures :: !Bool,
     migrateDomainRegistration :: !Bool,

--- a/services/background-worker/src/Wire/PostgresMigrations.hs
+++ b/services/background-worker/src/Wire/PostgresMigrations.hs
@@ -39,11 +39,11 @@ conversations migOpts = do
   convMigCounter <- register $ counter $ Prometheus.Info "wire_local_convs_migrated_to_pg" "Number of local conversations migrated to Postgresql"
   convMigFinished <- register $ counter $ Prometheus.Info "wire_local_convs_migration_finished" "Whether the conversation migration to Postgresql is finished successfully"
   convMigFailed <- register $ counter $ Prometheus.Info "wire_local_convs_migration_failed" "Whether the conversation migration to Postgresql has failed"
-  convMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_local_convs_migration_duration_seconds_bucket" "Duration of local conversation migration attempts") defaultBuckets
+  convMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_local_convs_migration_duration_seconds" "Duration of local conversation migration attempts") defaultBuckets
   userMigCounter <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migrated_to_pg" "Number of users whose remote conversation membership data is migrated to Postgresql"
   userMigFinished <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_finished" "Whether the migration of remote conversation membership data to Postgresql is finished successfully"
   userMigFailed <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_failed" "Whether the migration of remote conversation membership data to Postgresql has failed"
-  userMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_user_remote_convs_migration_duration_seconds_bucket" "Duration of remote conversation membership migration attempts") defaultBuckets
+  userMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_user_remote_convs_migration_duration_seconds" "Duration of remote conversation membership migration attempts") defaultBuckets
 
   convLoop <- async . lift $ migrateConvsLoop migOpts cassClient pgPool logger convMigCounter convMigFinished convMigFailed convMigDuration
   userLoop <- async . lift $ migrateUsersLoop migOpts cassClient pgPool logger userMigCounter userMigFinished userMigFailed userMigDuration
@@ -63,7 +63,7 @@ conversationCodes migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_conv_codes_migrated_to_pg" "Number of conversation codes migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_conv_codes_migration_finished" "Whether the conversation codes migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_conv_codes_migration_failed" "Whether the conversation codes migration to Postgresql has failed"
-  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_conv_codes_migration_duration_seconds_bucket" "Duration of conversation code migration attempts") defaultBuckets
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_conv_codes_migration_duration_seconds" "Duration of conversation code migration attempts") defaultBuckets
 
   migrationLoop <- async . lift $ migrateCodesLoop migOpts cassClient pgPool logger count finished failed duration
 
@@ -81,7 +81,7 @@ teamFeatures migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_team_features_migrated_to_pg" "Number of team features migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_team_features_migration_finished" "Whether the team features migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_team_features_migration_failed" "Whether the team features migration to Postgresql has failed"
-  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_team_features_migration_duration_seconds_bucket" "Duration of team feature migration attempts") defaultBuckets
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_team_features_migration_duration_seconds" "Duration of team feature migration attempts") defaultBuckets
 
   migrationLoop <- async . lift $ migrateTeamFeaturesLoop migOpts cassClient pgPool logger count finished failed duration
 
@@ -99,7 +99,7 @@ domainRegistration migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_domain_registration_migrated_to_pg" "Number of domain registration rows migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_domain_registration_migration_finished" "Whether the domain registration migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_domain_registration_migration_failed" "Whether the domain registration migration to Postgresql has failed"
-  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_domain_registration_migration_duration_seconds_bucket" "Duration of domain registration migration attempts") defaultBuckets
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_domain_registration_migration_duration_seconds" "Duration of domain registration migration attempts") defaultBuckets
 
   migrationLoop <- async . lift $ migrateDomainRegistrationsLoop migOpts cassClient pgPool logger count finished failed duration
 

--- a/services/background-worker/src/Wire/PostgresMigrations.hs
+++ b/services/background-worker/src/Wire/PostgresMigrations.hs
@@ -63,8 +63,9 @@ conversationCodes migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_conv_codes_migrated_to_pg" "Number of conversation codes migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_conv_codes_migration_finished" "Whether the conversation codes migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_conv_codes_migration_failed" "Whether the conversation codes migration to Postgresql has failed"
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_conv_codes_migration_duration_seconds_bucket" "Duration of conversation code migration attempts") defaultBuckets
 
-  migrationLoop <- async . lift $ migrateCodesLoop migOpts cassClient pgPool logger count finished failed
+  migrationLoop <- async . lift $ migrateCodesLoop migOpts cassClient pgPool logger count finished failed duration
 
   Log.info logger $ Log.msg (Log.val "started conversation codes migration")
   pure $ do

--- a/services/background-worker/src/Wire/PostgresMigrations.hs
+++ b/services/background-worker/src/Wire/PostgresMigrations.hs
@@ -39,7 +39,7 @@ conversations migOpts = do
   convMigCounter <- register $ counter $ Prometheus.Info "wire_local_convs_migrated_to_pg" "Number of local conversations migrated to Postgresql"
   convMigFinished <- register $ counter $ Prometheus.Info "wire_local_convs_migration_finished" "Whether the conversation migration to Postgresql is finished successfully"
   convMigFailed <- register $ counter $ Prometheus.Info "wire_local_convs_migration_failed" "Whether the conversation migration to Postgresql has failed"
-  convMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_local_convs_migration_duration_seconds" "Duration of local conversation migration attempts") defaultBuckets
+  convMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_local_convs_migration_duration_seconds_bucket" "Duration of local conversation migration attempts") defaultBuckets
   userMigCounter <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migrated_to_pg" "Number of users whose remote conversation membership data is migrated to Postgresql"
   userMigFinished <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_finished" "Whether the migration of remote conversation membership data to Postgresql is finished successfully"
   userMigFailed <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_failed" "Whether the migration of remote conversation membership data to Postgresql has failed"

--- a/services/background-worker/src/Wire/PostgresMigrations.hs
+++ b/services/background-worker/src/Wire/PostgresMigrations.hs
@@ -39,11 +39,12 @@ conversations migOpts = do
   convMigCounter <- register $ counter $ Prometheus.Info "wire_local_convs_migrated_to_pg" "Number of local conversations migrated to Postgresql"
   convMigFinished <- register $ counter $ Prometheus.Info "wire_local_convs_migration_finished" "Whether the conversation migration to Postgresql is finished successfully"
   convMigFailed <- register $ counter $ Prometheus.Info "wire_local_convs_migration_failed" "Whether the conversation migration to Postgresql has failed"
+  convMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_local_convs_migration_duration_seconds" "Duration of local conversation migration attempts") defaultBuckets
   userMigCounter <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migrated_to_pg" "Number of users whose remote conversation membership data is migrated to Postgresql"
   userMigFinished <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_finished" "Whether the migration of remote conversation membership data to Postgresql is finished successfully"
   userMigFailed <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_failed" "Whether the migration of remote conversation membership data to Postgresql has failed"
 
-  convLoop <- async . lift $ migrateConvsLoop migOpts cassClient pgPool logger convMigCounter convMigFinished convMigFailed
+  convLoop <- async . lift $ migrateConvsLoop migOpts cassClient pgPool logger convMigCounter convMigFinished convMigFailed convMigDuration
   userLoop <- async . lift $ migrateUsersLoop migOpts cassClient pgPool logger userMigCounter userMigFinished userMigFailed
 
   Log.info logger $ Log.msg (Log.val "started conversation migration")

--- a/services/background-worker/src/Wire/PostgresMigrations.hs
+++ b/services/background-worker/src/Wire/PostgresMigrations.hs
@@ -43,9 +43,10 @@ conversations migOpts = do
   userMigCounter <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migrated_to_pg" "Number of users whose remote conversation membership data is migrated to Postgresql"
   userMigFinished <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_finished" "Whether the migration of remote conversation membership data to Postgresql is finished successfully"
   userMigFailed <- register $ counter $ Prometheus.Info "wire_user_remote_convs_migration_failed" "Whether the migration of remote conversation membership data to Postgresql has failed"
+  userMigDuration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_user_remote_convs_migration_duration_seconds_bucket" "Duration of remote conversation membership migration attempts") defaultBuckets
 
   convLoop <- async . lift $ migrateConvsLoop migOpts cassClient pgPool logger convMigCounter convMigFinished convMigFailed convMigDuration
-  userLoop <- async . lift $ migrateUsersLoop migOpts cassClient pgPool logger userMigCounter userMigFinished userMigFailed
+  userLoop <- async . lift $ migrateUsersLoop migOpts cassClient pgPool logger userMigCounter userMigFinished userMigFailed userMigDuration
 
   Log.info logger $ Log.msg (Log.val "started conversation migration")
   pure $ do
@@ -79,8 +80,9 @@ teamFeatures migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_team_features_migrated_to_pg" "Number of team features migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_team_features_migration_finished" "Whether the team features migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_team_features_migration_failed" "Whether the team features migration to Postgresql has failed"
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_team_features_migration_duration_seconds_bucket" "Duration of team feature migration attempts") defaultBuckets
 
-  migrationLoop <- async . lift $ migrateTeamFeaturesLoop migOpts cassClient pgPool logger count finished failed
+  migrationLoop <- async . lift $ migrateTeamFeaturesLoop migOpts cassClient pgPool logger count finished failed duration
 
   Log.info logger $ Log.msg (Log.val "started team features migration")
   pure $ do
@@ -96,8 +98,9 @@ domainRegistration migOpts = do
   count <- register $ counter $ Prometheus.Info "wire_domain_registration_migrated_to_pg" "Number of domain registration rows migrated to Postgresql"
   finished <- register $ counter $ Prometheus.Info "wire_domain_registration_migration_finished" "Whether the domain registration migration to Postgresql is finished successfully"
   failed <- register $ counter $ Prometheus.Info "wire_domain_registration_migration_failed" "Whether the domain registration migration to Postgresql has failed"
+  duration <- register $ vector "outcome" $ histogram (Prometheus.Info "wire_domain_registration_migration_duration_seconds_bucket" "Duration of domain registration migration attempts") defaultBuckets
 
-  migrationLoop <- async . lift $ migrateDomainRegistrationsLoop migOpts cassClient pgPool logger count finished failed
+  migrationLoop <- async . lift $ migrateDomainRegistrationsLoop migOpts cassClient pgPool logger count finished failed duration
 
   Log.info logger $ Log.msg (Log.val "started domain registration migration")
   pure $ do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-25915

I have tested that it works. However, those test cannot be committed, because they hook into the production migration code to simulate the blocking conversation migration.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
