### PR TITLE
adding support for federator-specific cert-manager issuers

### DIFF
--- a/changelog.d/2-features/federator-only-cert-manager
+++ b/changelog.d/2-features/federator-only-cert-manager
@@ -1,0 +1,1 @@
+nginx-ingress-services: allow a federator-only cert-manager issuer (e.g. AWS Private CA via AWSPCAClusterIssuer) by setting federator.tls.issuer.{name,kind,group} without having to enable the global tls.useCertManager flag. The wildcard-backed federator-certificate-secret is suppressed in that case so cert-manager can own the secret.

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -4,7 +4,8 @@
 {{- if and .Values.federator.enabled .Values.config.isAdditionalIngress -}}
   {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
 {{- end -}}
-{{- if and .Values.federator.enabled (and .Values.tls.enabled .Values.tls.useCertManager) }}
+{{- $federatorUsesCertManager := or .Values.tls.useCertManager .Values.federator.tls.issuer.name -}}
+{{- if and .Values.federator.enabled .Values.tls.enabled $federatorUsesCertManager }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/nginx-ingress-services/templates/secret_federator.yaml
+++ b/charts/nginx-ingress-services/templates/secret_federator.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.federator.enabled (not .Values.tls.useCertManager) }}
+{{- if and .Values.federator.enabled (not .Values.tls.useCertManager) (not .Values.federator.tls.issuer.name) }}
 {{- if .Values.config.isAdditionalIngress -}}
   {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
 {{- end -}}


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-24032

Adding support for federator-specific cert-manager issuers, needed for configurations with disabled cert-manager and manually managed ingress certs.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
