### PR TITLE
WPB-24203 log on stale mls commit

### DIFF
--- a/changelog.d/5-internal/WPB-24203
+++ b/changelog.d/5-internal/WPB-24203
@@ -1,0 +1,1 @@
+Added logging on stale MLS commits in subconversations

--- a/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
@@ -108,6 +108,10 @@ data ConvOrSubChoice c s
   = Conv c
   | SubConv c s
 
+isSubConv :: ConvOrSubChoice c s -> Bool
+isSubConv (Conv _) = False
+isSubConv (SubConv _ _) = True
+
 deriving instance (Eq c, Eq s) => Eq (ConvOrSubChoice c s)
 
 deriving instance (Show c, Show s) => Show (ConvOrSubChoice c s)

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Federation.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Federation.hs
@@ -727,7 +727,8 @@ deleteSubConversationForRemoteUser ::
     Member (Input (Local ())) r,
     Member Resource r,
     Member TeamSubsystem r,
-    Member E.MLSCommitLockStore r
+    Member E.MLSCommitLockStore r,
+    Member TinyLog r
   ) =>
   Domain ->
   DeleteSubConversationFedRequest ->

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Message.hs
@@ -25,7 +25,11 @@ module Wire.ConversationSubsystem.MLS.Message
 where
 
 import Control.Monad.Codensity
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.ByteArray.Encoding (Base (Base16), convertToBase)
+import Data.ByteString.Conversion (toByteString')
 import Data.Domain
+import Data.Hex
 import Data.Id
 import Data.Json.Util
 import Data.LegalHold
@@ -43,6 +47,7 @@ import Polysemy.Input
 import Polysemy.Output
 import Polysemy.Resource (Resource)
 import Polysemy.TinyLog
+import System.Logger qualified as Log
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Config (ConversationSubsystemConfig)
 import Wire.API.Conversation.Protocol
@@ -292,7 +297,16 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
       unless (ciphersuite == activeData.ciphersuite) $
         throw $
           mlsProtocolError "GroupInfo ciphersuite does not match conversation"
-      unless (bundle.epoch == activeData.epoch) $ throwS @'MLSStaleMessage
+      unless (bundle.epoch == activeData.epoch) $ do
+        logStaleCommitBundle
+          "commit-bundle-epoch-mismatch"
+          lConvOrSub
+          bundle.groupId
+          bundle.epoch
+          activeData.epoch
+          bundle.groupInfo
+          activeData.ciphersuite
+        throwS @'MLSStaleMessage
       pure False
 
   senderIdentity <- getSenderIdentity qusr c bundle.sender lConvOrSub
@@ -381,6 +395,45 @@ handleGroupInfoMismatch lConvId bundle m =
             convId = tUnqualified lConvId,
             domain = tDomain lConvId
           }
+
+logStaleCommitBundle ::
+  (Member TinyLog r) =>
+  ByteString ->
+  Local ConvOrSubConv ->
+  GroupId ->
+  Epoch ->
+  Epoch ->
+  RawMLS GroupInfo ->
+  CipherSuiteTag ->
+  Sem r ()
+logStaleCommitBundle reason lConvOrSub gid messageEpoch storedEpoch groupInfo storedCipherSuite = do
+  let convOrSub = tUnqualified lConvOrSub
+      convOrSubId = tUnqualified (fmap (.id) lConvOrSub)
+      groupContext = groupInfo.value.groupContext
+  warn $
+    Log.msg ("rejecting stale MLS commit bundle" :: ByteString)
+      . Log.field "reason" reason
+      . Log.field "groupId" ("0x" <> hex (unGroupId gid))
+      . Log.field "messageEpoch" (epochNumber messageEpoch)
+      . Log.field "storedEpoch" (epochNumber storedEpoch)
+      . Log.field "storedCipherSuite" (cipherSuiteNumber (tagCipherSuite storedCipherSuite))
+      . Log.field "activeDataPresent" True
+      . Log.field "groupInfoPresent" True
+      . Log.field "groupInfoSha256" (sha256Hex groupInfo.raw)
+      . Log.field "groupInfoGroupId" ("0x" <> hex (unGroupId groupContext.groupId))
+      . Log.field "groupInfoEpoch" (epochNumber groupContext.epoch)
+      . Log.field "groupInfoCipherSuite" (cipherSuiteNumber groupContext.cipherSuite)
+      . Log.field "domain" (toByteString' (show (tDomain lConvOrSub)))
+      . Log.field "parentConvId" (toByteString' (show convOrSubId.conv))
+      . Log.field "subConvId" (maybe ("none" :: ByteString) (toByteString' . show) convOrSubId.subconv)
+      . Log.field
+        "convOrSubConvId"
+        (toByteString' (show convOrSubId))
+      . Log.field "isSubConversation" (isSubConv convOrSub)
+      . Log.field "memberCount" (length (cmAssocs convOrSub.members))
+
+sha256Hex :: ByteString -> ByteString
+sha256Hex bs = convertToBase Base16 (hash bs :: Digest SHA256)
 
 postMLSCommitBundleToRemoteConv ::
   ( Member BrigAPIAccess r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/SubConversation.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/SubConversation.hs
@@ -220,7 +220,8 @@ deleteSubConversation ::
     Member (Input (Maybe (MLSKeysByPurpose MLSPrivateKeys))) r,
     Member Resource r,
     Member Conversation.MLSCommitLockStore r,
-    Member TeamSubsystem r
+    Member TeamSubsystem r,
+    Member TinyLog r
   ) =>
   Local UserId ->
   Qualified ConvId ->
@@ -395,7 +396,8 @@ resetLocalSubConversation ::
     Member (ErrorS 'MLSStaleMessage) r,
     Member Resource r,
     Member Conversation.MLSCommitLockStore r,
-    Member TeamSubsystem r
+    Member TeamSubsystem r,
+    Member TinyLog r
   ) =>
   Qualified UserId ->
   Local ConvId ->

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Util.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Util.hs
@@ -19,6 +19,7 @@ module Wire.ConversationSubsystem.MLS.Util where
 
 import Control.Comonad
 import Control.Monad.Codensity
+import Data.ByteString.Conversion (toByteString')
 import Data.Hex
 import Data.Id
 import Data.Qualified
@@ -102,7 +103,8 @@ withCommitLock ::
   ( Member Resource r,
     Member ConversationStore r,
     Member (ErrorS 'MLSStaleMessage) r,
-    Member MLSCommitLockStore r
+    Member MLSCommitLockStore r,
+    Member TinyLog r
   ) =>
   Local ConvOrSubConvId ->
   GroupId ->
@@ -112,7 +114,13 @@ withCommitLock lConvOrSubId gid epoch =
   Codensity $ \k ->
     bracket
       ( acquireCommitLock gid epoch ttl >>= \lockAcquired ->
-          when (lockAcquired == NotAcquired) $
+          when (lockAcquired == NotAcquired) $ do
+            logStaleCommitLock
+              "commit-lock-not-acquired"
+              lConvOrSubId
+              gid
+              epoch
+              Nothing
             throwS @'MLSStaleMessage
       )
       (const $ releaseCommitLock gid epoch)
@@ -121,11 +129,40 @@ withCommitLock lConvOrSubId gid epoch =
             fromMaybe (Epoch 0) <$> case tUnqualified lConvOrSubId of
               Conv cnv -> getConversationEpoch cnv
               SubConv cnv sub -> getSubConversationEpoch cnv sub
-          unless (actualEpoch == epoch) $ throwS @'MLSStaleMessage
+          unless (actualEpoch == epoch) $ do
+            logStaleCommitLock
+              "commit-lock-epoch-mismatch"
+              lConvOrSubId
+              gid
+              epoch
+              (Just actualEpoch)
+            throwS @'MLSStaleMessage
           k ()
       )
   where
     ttl = fromIntegral (600 :: Int) -- 10 minutes
+
+logStaleCommitLock ::
+  (Member TinyLog r) =>
+  ByteString ->
+  Local ConvOrSubConvId ->
+  GroupId ->
+  Epoch ->
+  Maybe Epoch ->
+  Sem r ()
+logStaleCommitLock reason lConvOrSubId gid messageEpoch mStoredEpoch =
+  let convOrSubId = tUnqualified lConvOrSubId
+   in TinyLog.warn $
+        Log.msg ("rejecting stale MLS commit due to commit lock" :: ByteString)
+          . Log.field "reason" reason
+          . Log.field "groupId" ("0x" <> hex (unGroupId gid))
+          . Log.field "messageEpoch" (epochNumber messageEpoch)
+          . Log.field "storedEpoch" (maybe ("unknown" :: ByteString) (toByteString' . epochNumber) mStoredEpoch)
+          . Log.field "domain" (toByteString' (show (tDomain lConvOrSubId)))
+          . Log.field "parentConvId" (toByteString' (show convOrSubId.conv))
+          . Log.field "subConvId" (maybe ("none" :: ByteString) (toByteString' . show) convOrSubId.subconv)
+          . Log.field "convOrSubConvId" (toByteString' (show convOrSubId))
+          . Log.field "isSubConversation" (isSubConv convOrSubId)
 
 getConvFromGroupId ::
   (Member (Error MLSProtocolError) r) =>


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-24203

example log:

`
[galley@example.com] W, request=10595a67-ee78-4730-8c9a-ee9198e63dba, rejecting stale MLS commit bundle, reason=commit-bundle-epoch-mismatch, groupId=0x000100003E45A622BD7A45869A464C4797B34B530A636F6E666572656E6365000000006578616D706C652E636F6D, messageEpoch=3, storedEpoch=4, storedCipherSuite=2, activeDataPresent=True, groupInfoPresent=True, groupInfoSha256=13f2755d03c1ae975ee430747a3ef30f57cfb5770a6329c565a6f098b08109f9, groupInfoGroupId=0x000100003E45A622BD7A45869A464C4797B34B530A636F6E666572656E6365000000006578616D706C652E636F6D, groupInfoEpoch=4, groupInfoCipherSuite=2, domain=Domain {_domainText = "example.com"}, parentConvId=3e45a622-bd7a-4586-9a46-4c4797b34b53, subConvId=SubConvId {unSubConvId = "conference"}, convOrSubConvId=SubConv 3e45a622-bd7a-4586-9a46-4c4797b34b53 (SubConvId {unSubConvId = "conference"}), isSubConversation=True, memberCount=2
`

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
