### PR TITLE
bump wire-server-enterprise

### DIFF
--- a/changelog.d/5-internal/bump-wire-server-enterprise
+++ b/changelog.d/5-internal/bump-wire-server-enterprise
@@ -1,0 +1,1 @@
+Bump wire-server-enterprise submodule (introduces gitignoreSource Nix fix)


### PR DESCRIPTION
Bump to the head of `wire-server-enterprise` main branch.

This introduces the `gitignoreSource` Nix fix.

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
