### PR TITLE
Add .github/copilot-instructions.md referencing AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](../AGENTS.md) at the repository root for project overview, development environment, commands, quality expectations, and security guidelines.


### PR DESCRIPTION
GitHub Copilot in CI/CD does not pick up AGENTS.md, so point it at the canonical agent instructions via copilot-instructions.md.

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
