### PR TITLE
charts/integration: Allocate more resources to the integration tests pod

### DIFF
--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -172,8 +172,8 @@ spec:
         {{- end }}
     resources:
       requests:
-        memory: "512Mi"
-        cpu: "2"
+        memory: "3Gi"
+        cpu: "4"
 
   containers:
   - name: integration


### PR DESCRIPTION
Actual resource usage:

<img width="1691" height="348" alt="image" src="https://github.com/user-attachments/assets/b9efbd04-963a-4a32-8bcd-deb0d4281d63" />


## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
