### PR TITLE
Add test about expired IdP descriptor certificates

### DIFF
--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -31,8 +31,12 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as A
 import qualified Data.CaseInsensitive as CI
+import qualified Data.Hourglass as Hourglass
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.String.Conversions (cs)
 import qualified Data.Text as ST
+import qualified Data.UUID as UUID
+import Data.UUID.V4 (nextRandom)
 import qualified SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.Test.MockResponse as SAML
 import qualified SAML2.WebSSO.Test.Util as SAML
@@ -41,6 +45,8 @@ import SetupHelpers
 import Testlib.JSON
 import Testlib.PTest
 import Testlib.Prelude
+import qualified Text.XML.DSig as SAML
+import qualified Time.System as Hourglass
 
 ----------------------------------------------------------------------
 -- scim stuff
@@ -811,6 +817,50 @@ testSparEmulateSPInitiatedLogin = do
     -- /sso/initiate-login here.
     resp.status `shouldMatchInt` 200
     (cs resp.body) `shouldContain` "SAMLRequest"
+
+-- | The backend accepts an IdP descriptor whose signing cert is already
+-- expired, both at config-import time (POST /identity-providers) and at
+-- AuthnResponse verification time (POST /sso/finalize-login).
+--
+-- This was probably built this way to not force team admins to reconfigure
+-- IdPs over and over again (and if they forget, having angry users who cannot
+-- login).
+testSparExpiredIdpCertStillWorks :: (HasCallStack) => App ()
+testSparExpiredIdpCertStillWorks = do
+  (owner, tid, _) <- createTeam OwnDomain 1
+  void $ setTeamFeatureStatus owner tid "sso" "enabled"
+
+  (idpMeta, privcreds) <- makeSampleIdPMetadataExpired
+
+  createResp <- createIdp owner idpMeta
+  assertSuccess createResp
+  idpId <- asString =<< (createResp.json %. "id")
+
+  subject <- nextSubject
+  (mUid, _authnResponse) <- loginWithSaml True tid subject (idpId, (idpMeta, privcreds))
+  void $ assertJust "expected zuid cookie to carry any user id" mUid
+  where
+    makeSampleIdPMetadataExpired :: App (SAML.IdPMetadata, SAML.SignPrivCreds)
+    makeSampleIdPMetadataExpired = do
+      now <- liftIO Hourglass.dateCurrent
+      let validSince = now `addHours` (-48)
+          validUntil = now `addHours` (-24)
+      issuer <- SAML.makeIssuer
+      uuid <- liftIO nextRandom
+      requri <-
+        either (error . show) pure
+          $ SAML.parseURI' @(Either String) (ST.pack ("https://requri.net/" <> UUID.toString uuid))
+      (privcreds, _signcreds, expiredCert) <-
+        liftIO $ SAML.mkSignCredsWithCertWithLifespan validSince validUntil 96
+      let meta = SAML.IdPMetadata issuer requri (NonEmpty.singleton expiredCert)
+      pure (meta, privcreds)
+
+    addHours :: Hourglass.DateTime -> Hourglass.Hours -> Hourglass.DateTime
+    addHours t h =
+      t
+        `Hourglass.timeAdd` mempty
+          { Hourglass.durationHours = h
+          }
 
 -- | UTF-8 chars (non-Latin-1) caused issues in XML parsing.
 testSparSPInitiatedLoginWithUtf8 :: (HasCallStack) => App ()

--- a/libs/saml2-web-sso/src/Text/XML/DSig.hs
+++ b/libs/saml2-web-sso/src/Text/XML/DSig.hs
@@ -22,6 +22,7 @@ module Text.XML.DSig
     certToCreds,
     mkSignCreds,
     mkSignCredsWithCert,
+    mkSignCredsWithCertWithLifespan,
 
     -- * signature verification
     verify,
@@ -164,7 +165,7 @@ certToCreds cert = do
 mkSignCreds :: (Crypto.MonadRandom m, MonadIO m) => Int -> m (SignPrivCreds, SignCreds)
 mkSignCreds size = mkSignCredsWithCert Nothing size <&> \(priv, pub, _) -> (priv, pub)
 
--- | If first argument @validSince@ is @Nothing@, use cucrent system time.
+-- | If first argument @validSince@ is @Nothing@, use current system time.
 mkSignCredsWithCert ::
   forall m.
   (Crypto.MonadRandom m, MonadIO m) =>
@@ -172,14 +173,31 @@ mkSignCredsWithCert ::
   Int ->
   m (SignPrivCreds, SignCreds, X509.SignedCertificate)
 mkSignCredsWithCert mValidSince size = do
-  let rsaexp = 17
-  (pubkey, privkey) <- RSA.generate size rsaexp
   let -- https://github.com/vincenthz/hs-certificate/issues/119
       cropToSecs :: Hourglass.DateTime -> Hourglass.DateTime
       cropToSecs dt = dt {Hourglass.dtTime = (Hourglass.dtTime dt) {Hourglass.todNSec = 0}}
   validSince :: Hourglass.DateTime <- cropToSecs <$> maybe (liftIO Hourglass.dateCurrent) pure mValidSince
   let validUntil = validSince `Hourglass.timeAdd` mempty {Hourglass.durationHours = 24 * 365 * 20}
-      signcert :: SBS -> m (SBS, X509.SignatureALG)
+  mkSignCredsWithCertWithLifespan validSince validUntil size
+
+-- | Generate signing credentials and a self-signed X509 certificate with the
+-- given validity window.
+mkSignCredsWithCertWithLifespan ::
+  forall m.
+  (Crypto.MonadRandom m, MonadIO m) =>
+  Hourglass.DateTime ->
+  Hourglass.DateTime ->
+  Int ->
+  m (SignPrivCreds, SignCreds, X509.SignedCertificate)
+mkSignCredsWithCertWithLifespan validSince validUntil size = do
+  when (validSince > validUntil) . liftIO . throwIO . ErrorCall $
+    "mkSignCredsWithCertWithLifespan: validSince > validUntil: "
+      <> show validSince
+      <> " > "
+      <> show validUntil
+  let rsaexp = 17
+  (pubkey, privkey) <- RSA.generate size rsaexp
+  let signcert :: SBS -> m (SBS, X509.SignatureALG)
       signcert sbs = (,sigalg) <$> sigval
         where
           sigalg = X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_RSA

--- a/libs/saml2-web-sso/src/Text/XML/DSig.hs
+++ b/libs/saml2-web-sso/src/Text/XML/DSig.hs
@@ -173,10 +173,7 @@ mkSignCredsWithCert ::
   Int ->
   m (SignPrivCreds, SignCreds, X509.SignedCertificate)
 mkSignCredsWithCert mValidSince size = do
-  let -- https://github.com/vincenthz/hs-certificate/issues/119
-      cropToSecs :: Hourglass.DateTime -> Hourglass.DateTime
-      cropToSecs dt = dt {Hourglass.dtTime = (Hourglass.dtTime dt) {Hourglass.todNSec = 0}}
-  validSince :: Hourglass.DateTime <- cropToSecs <$> maybe (liftIO Hourglass.dateCurrent) pure mValidSince
+  validSince :: Hourglass.DateTime <- maybe (liftIO Hourglass.dateCurrent) pure mValidSince
   let validUntil = validSince `Hourglass.timeAdd` mempty {Hourglass.durationHours = 24 * 365 * 20}
   mkSignCredsWithCertWithLifespan validSince validUntil size
 
@@ -189,7 +186,12 @@ mkSignCredsWithCertWithLifespan ::
   Hourglass.DateTime ->
   Int ->
   m (SignPrivCreds, SignCreds, X509.SignedCertificate)
-mkSignCredsWithCertWithLifespan validSince validUntil size = do
+mkSignCredsWithCertWithLifespan validSinceRaw validUntilRaw size = do
+  -- https://github.com/vincenthz/hs-certificate/issues/119
+  let cropToSecs :: Hourglass.DateTime -> Hourglass.DateTime
+      cropToSecs dt = dt {Hourglass.dtTime = (Hourglass.dtTime dt) {Hourglass.todNSec = 0}}
+      validSince = cropToSecs validSinceRaw
+      validUntil = cropToSecs validUntilRaw
   when (validSince > validUntil) . liftIO . throwIO . ErrorCall $
     "mkSignCredsWithCertWithLifespan: validSince > validUntil: "
       <> show validSince

--- a/libs/saml2-web-sso/src/Text/XML/DSig.hs
+++ b/libs/saml2-web-sso/src/Text/XML/DSig.hs
@@ -194,9 +194,9 @@ mkSignCredsWithCertWithLifespan validSinceRaw validUntilRaw size = do
       validUntil = cropToSecs validUntilRaw
   when (validSince > validUntil) . liftIO . throwIO . ErrorCall $
     "mkSignCredsWithCertWithLifespan: validSince > validUntil: "
-      <> show validSince
+      <> Hourglass.timePrint Hourglass.ISO8601_DateAndTime validSince
       <> " > "
-      <> show validUntil
+      <> Hourglass.timePrint Hourglass.ISO8601_DateAndTime validUntil
   let rsaexp = 17
   (pubkey, privkey) <- RSA.generate size rsaexp
   let signcert :: SBS -> m (SBS, X509.SignatureALG)

--- a/libs/saml2-web-sso/test/Test/Text/XML/DSigSpec.hs
+++ b/libs/saml2-web-sso/test/Test/Text/XML/DSigSpec.hs
@@ -76,7 +76,7 @@ spec = describe "xml:dsig" $ do
       stored `shouldBe` (validSinceCropped, validUntilCropped)
     it "throws ErrorCall when validSince > validUntil" $ do
       mkSignCredsWithCertWithLifespan validUntilCropped validSinceCropped 192
-        `shouldThrow` (\(ErrorCall msg) -> "validSince > validUntil" `isInfixOf` msg)
+        `shouldThrow` (\(ErrorCall msg) -> msg == "mkSignCredsWithCertWithLifespan: validSince > validUntil: 2026-01-01T11:00:00Z > 2026-01-01T10:00:00Z")
 
   describe "parseKeyInfo / renderKeyInfo roundtrip" $ do
     let check :: (HasCallStack) => Int -> Expectation

--- a/libs/saml2-web-sso/test/Test/Text/XML/DSigSpec.hs
+++ b/libs/saml2-web-sso/test/Test/Text/XML/DSigSpec.hs
@@ -23,8 +23,10 @@ module Test.Text.XML.DSigSpec
   )
 where
 
+import Control.Exception (ErrorCall (..))
 import Data.ByteString.Base64.Lazy qualified as EL
 import Data.Either
+import Data.Hourglass qualified as Hourglass
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
@@ -57,6 +59,24 @@ spec = describe "xml:dsig" $ do
       (_privcreds, creds, cert) <- mkSignCredsWithCert Nothing 192
       verifySelfSignature cert `shouldBe` Right ()
       certToCreds cert `shouldBe` Right creds
+
+  describe "mkSignCredsWithCertWithLifespan" $ do
+    let date = Hourglass.Date 2026 Hourglass.January 1
+        validSinceWithNanos =
+          Hourglass.DateTime date (Hourglass.TimeOfDay 10 0 0 12345)
+        validUntilWithNanos =
+          Hourglass.DateTime date (Hourglass.TimeOfDay 11 0 0 67890)
+        validSinceCropped =
+          Hourglass.DateTime date (Hourglass.TimeOfDay 10 0 0 0)
+        validUntilCropped =
+          Hourglass.DateTime date (Hourglass.TimeOfDay 11 0 0 0)
+    it "stores the provided validity window in the certificate (nanoseconds cropped, see hs-certificate#119)" $ do
+      (_priv, _pub, cert) <- mkSignCredsWithCertWithLifespan validSinceWithNanos validUntilWithNanos 192
+      let stored = X509.certValidity . X509.signedObject $ X509.getSigned cert
+      stored `shouldBe` (validSinceCropped, validUntilCropped)
+    it "throws ErrorCall when validSince > validUntil" $ do
+      mkSignCredsWithCertWithLifespan validUntilCropped validSinceCropped 192
+        `shouldThrow` (\(ErrorCall msg) -> "validSince > validUntil" `isInfixOf` msg)
 
   describe "parseKeyInfo / renderKeyInfo roundtrip" $ do
     let check :: (HasCallStack) => Int -> Expectation


### PR DESCRIPTION
The fact that the backend allows SAML authentication with expired certificates is astonishing. Adding a test with a meaningful comment to describe this behaviour.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26150

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
