### PR TITLE
Fix concourse SBOM jobs

### DIFF
--- a/changelog.d/5-internal/fix-concourse-sbom-jobs
+++ b/changelog.d/5-internal/fix-concourse-sbom-jobs
@@ -1,0 +1,1 @@
+Fix SBOM generation scripts: stop merging stderr into stdout, which polluted the devShell and image name lists with nix warnings

--- a/hack/bin/create-nix-devshell-sbom.sh
+++ b/hack/bin/create-nix-devshell-sbom.sh
@@ -106,7 +106,7 @@ echo ""
 
 # Get list of devShell names from the devShells attrset
 echo "Discovering devShells..."
-mapfile -t devshell_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#devShells.${SYSTEM}" --apply 'shells: builtins.concatStringsSep "\n" (builtins.attrNames shells)' --raw 2>&1 | grep -v warning)
+mapfile -t devshell_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#devShells.${SYSTEM}" --apply 'shells: builtins.concatStringsSep "\n" (builtins.attrNames shells)' --raw)
 
 echo "Found ${#devshell_names[@]} devShells to process"
 echo ""

--- a/hack/bin/create-nix-docker-image-sboms.sh
+++ b/hack/bin/create-nix-docker-image-sboms.sh
@@ -110,7 +110,7 @@ echo ""
 
 # Get list of image names from the imagesNoDocs attrset (excluding 'all')
 echo "Discovering images from $IMAGES_ATTR..."
-mapfile -t image_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#wireServer.${IMAGES_ATTR}" --apply 'images: builtins.concatStringsSep "\n" (builtins.filter (name: name != "all") (builtins.attrNames images))' --raw 2>&1 | grep -v warning)
+mapfile -t image_names < <(nix --extra-experimental-features 'nix-command flakes' eval "$GIT_ROOT#wireServer.${IMAGES_ATTR}" --apply 'images: builtins.concatStringsSep "\n" (builtins.filter (name: name != "all") (builtins.attrNames images))' --raw)
 
 echo "Found ${#image_names[@]} images to process"
 echo ""


### PR DESCRIPTION
`2>&1 | grep -v warning` merged `stderr` into `stdout`, mixing nix warnings into the `mapfile` expression. Result: devShell/image name list polluted with non-name lines from `stderr`.

Drop the redirect so `stdout` carries only names and `stderr` stays separate.

This PR fixes the related jobs on CI and was tested there.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26357

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
