### PR TITLE
Migrate ephemeral postgresql from bitnami chart to CloudNativePG

### DIFF
--- a/hack/helm_vars/postgresql/values.yaml.gotmpl
+++ b/hack/helm_vars/postgresql/values.yaml.gotmpl
@@ -1,12 +1,21 @@
-auth:
-  postgresPassword: "posty-the-gres"
-  username: wire-server
-  password: "posty-the-gres"
-primary:
+version:
+  postgresql: "17"
+cluster:
+  instances: 1
+  storage:
+    size: 8Gi
+    storageClass: {{ .Values.storageClass }}
   resources:
     requests:
       cpu: 1
       memory: 2Gi
-    limits: {}
-  extendedConfiguration: |
-    max_connections = 1500
+  monitoring:
+    enabled: false
+  postgresql:
+    parameters:
+      max_connections: "1500"
+  initdb:
+    database: wire-server
+    owner: postgres
+backups:
+  enabled: false

--- a/hack/helm_vars/postgresql/values.yaml.gotmpl
+++ b/hack/helm_vars/postgresql/values.yaml.gotmpl
@@ -16,6 +16,6 @@ cluster:
       max_connections: "1500"
   initdb:
     database: wire-server
-    owner: postgres
+    owner: dbadmin
 backups:
   enabled: false

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -63,7 +63,7 @@ brig:
           key: "ca.crt"
     {{- end }}
     postgresql:
-      host: "postgresql"
+      host: "postgresql-rw"
       port: "5432"
       user: wire-server
       dbname: wire-server
@@ -288,7 +288,7 @@ galley:
           key: "ca.crt"
     {{- end }}
     postgresql:
-      host: postgresql
+      host: postgresql-rw
       port: "5432"
       user: wire-server
       dbname: wire-server
@@ -641,7 +641,7 @@ background-worker:
       pushBackoffMaxWait: 500000 # 0.5s
       remotesRefreshInterval: 1000000 # 1s
     postgresql:
-      host: "postgresql"
+      host: "postgresql-rw"
       port: "5432"
       user: wire-server
       dbname: wire-server

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -163,40 +163,9 @@ releases:
     namespace: '{{ .Values.namespace2 }}'
     chart: '../.local/charts/cassandra-ephemeral'
 
-  - name: "cnpg-operator-1"
-    namespace: "{{ .Values.namespace1 }}"
-    chart: "cnpg/cloudnative-pg"
-    values:
-      - fullnameOverride: "cnpg-operator-1"
-        config:
-          clusterWide: false
-          data:
-            WATCH_NAMESPACE: "{{ .Values.namespace1 }}"
-
-  - name: "cnpg-operator-2"
-    namespace: "{{ .Values.namespace2 }}"
-    chart: "cnpg/cloudnative-pg"
-    needs:
-      - "{{ .Values.namespace1 }}/cnpg-operator-1"
-    values:
-      - fullnameOverride: "cnpg-operator-2"
-        config:
-          clusterWide: false
-          data:
-            WATCH_NAMESPACE: "{{ .Values.namespace2 }}"
-        crds:
-          create: false
-        webhook:
-          mutating:
-            create: false
-          validating:
-            create: false
-
   - name: "postgresql"
     namespace: "{{ .Values.namespace1 }}"
     chart: "cnpg/cluster"
-    needs:
-      - "{{ .Values.namespace1 }}/cnpg-operator-1"
     values:
       - './helm_vars/postgresql/values.yaml.gotmpl'
       - cluster:
@@ -214,8 +183,6 @@ releases:
   - name: "postgresql"
     namespace: "{{ .Values.namespace2 }}"
     chart: "cnpg/cluster"
-    needs:
-      - "{{ .Values.namespace2 }}/cnpg-operator-2"
     values:
       - './helm_vars/postgresql/values.yaml.gotmpl'
       - cluster:

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -179,6 +179,8 @@ releases:
               - GRANT ALL PRIVILEGES ON DATABASE "dyn-1" TO "wire-server"
               - GRANT ALL PRIVILEGES ON DATABASE "dyn-2" TO "wire-server"
               - GRANT ALL PRIVILEGES ON DATABASE "dyn-3" TO "wire-server"
+            postInitApplicationSQL:
+              - GRANT ALL ON SCHEMA public TO "wire-server"
 
   - name: "postgresql"
     namespace: "{{ .Values.namespace2 }}"
@@ -190,6 +192,8 @@ releases:
             postInitSQL:
               - CREATE ROLE "wire-server" WITH LOGIN PASSWORD 'posty-the-gres'
               - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
+            postInitApplicationSQL:
+              - GRANT ALL ON SCHEMA public TO "wire-server"
 
   - name: 'opensearch-ephemeral'
     namespace: '{{ .Values.namespace1 }}'

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -95,6 +95,9 @@ repositories:
   - name: groundhog2k
     url: https://groundhog2k.github.io/helm-charts
 
+  - name: cnpg
+    url: https://cloudnative-pg.github.io/charts
+
 releases:
   - name: 'fake-aws'
     namespace: '{{ .Values.namespace1 }}'
@@ -160,39 +163,66 @@ releases:
     namespace: '{{ .Values.namespace2 }}'
     chart: '../.local/charts/cassandra-ephemeral'
 
+  - name: "cnpg-operator-1"
+    namespace: "{{ .Values.namespace1 }}"
+    chart: "cnpg/cloudnative-pg"
+    values:
+      - fullnameOverride: "cnpg-operator-1"
+        config:
+          clusterWide: false
+          data:
+            WATCH_NAMESPACE: "{{ .Values.namespace1 }}"
+
+  - name: "cnpg-operator-2"
+    namespace: "{{ .Values.namespace2 }}"
+    chart: "cnpg/cloudnative-pg"
+    needs:
+      - "{{ .Values.namespace1 }}/cnpg-operator-1"
+    values:
+      - fullnameOverride: "cnpg-operator-2"
+        config:
+          clusterWide: false
+          data:
+            WATCH_NAMESPACE: "{{ .Values.namespace2 }}"
+        crds:
+          create: false
+        webhook:
+          mutating:
+            create: false
+          validating:
+            create: false
+
   - name: "postgresql"
     namespace: "{{ .Values.namespace1 }}"
-    chart: "bitnami/postgresql"
+    chart: "cnpg/cluster"
+    needs:
+      - "{{ .Values.namespace1 }}/cnpg-operator-1"
     values:
-      - './helm_vars/bitnami.yaml'
       - './helm_vars/postgresql/values.yaml.gotmpl'
-      - primary:
+      - cluster:
           initdb:
-            scripts:
-              init.sql: |
-                CREATE DATABASE "wire-server";
-                CREATE DATABASE "dyn-1";
-                CREATE DATABASE "dyn-2";
-                CREATE DATABASE "dyn-3";
-
-                GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server";
-                GRANT ALL PRIVILEGES ON DATABASE "dyn-1" TO "wire-server";
-                GRANT ALL PRIVILEGES ON DATABASE "dyn-2" TO "wire-server";
-                GRANT ALL PRIVILEGES ON DATABASE "dyn-3" TO "wire-server";
+            postInitSQL:
+              - CREATE ROLE "wire-server" WITH LOGIN PASSWORD 'posty-the-gres'
+              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
+              - CREATE DATABASE "dyn-1"
+              - CREATE DATABASE "dyn-2"
+              - CREATE DATABASE "dyn-3"
+              - GRANT ALL PRIVILEGES ON DATABASE "dyn-1" TO "wire-server"
+              - GRANT ALL PRIVILEGES ON DATABASE "dyn-2" TO "wire-server"
+              - GRANT ALL PRIVILEGES ON DATABASE "dyn-3" TO "wire-server"
 
   - name: "postgresql"
     namespace: "{{ .Values.namespace2 }}"
-    chart: "bitnami/postgresql"
+    chart: "cnpg/cluster"
+    needs:
+      - "{{ .Values.namespace2 }}/cnpg-operator-2"
     values:
-      - './helm_vars/bitnami.yaml'
       - './helm_vars/postgresql/values.yaml.gotmpl'
-      - primary:
+      - cluster:
           initdb:
-            scripts:
-              init.sql: |
-                CREATE DATABASE "wire-server";
-
-                GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server";
+            postInitSQL:
+              - CREATE ROLE "wire-server" WITH LOGIN PASSWORD 'posty-the-gres'
+              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
 
   - name: 'opensearch-ephemeral'
     namespace: '{{ .Values.namespace1 }}'

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -172,7 +172,6 @@ releases:
           initdb:
             postInitSQL:
               - CREATE ROLE "wire-server" WITH LOGIN PASSWORD 'posty-the-gres'
-              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
               - CREATE DATABASE "dyn-1"
               - CREATE DATABASE "dyn-2"
               - CREATE DATABASE "dyn-3"
@@ -180,6 +179,7 @@ releases:
               - GRANT ALL PRIVILEGES ON DATABASE "dyn-2" TO "wire-server"
               - GRANT ALL PRIVILEGES ON DATABASE "dyn-3" TO "wire-server"
             postInitApplicationSQL:
+              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
               - GRANT ALL ON SCHEMA public TO "wire-server"
 
   - name: "postgresql"
@@ -191,8 +191,8 @@ releases:
           initdb:
             postInitSQL:
               - CREATE ROLE "wire-server" WITH LOGIN PASSWORD 'posty-the-gres'
-              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
             postInitApplicationSQL:
+              - GRANT ALL PRIVILEGES ON DATABASE "wire-server" TO "wire-server"
               - GRANT ALL ON SCHEMA public TO "wire-server"
 
   - name: 'opensearch-ephemeral'


### PR DESCRIPTION
**Nothing to see here, yet. I'm checking how far I get moving to CloudNativePG**

Bitnami PostgreSQL images became unavailable (https://aws.amazon.com/blogs/containers/bitnami-image-removal-from-ecr-public/), so we need to do something else. Platform and SD are using [CloudNativePG](https://cloudnative-pg.io/). Let's see how far we get with that.

For now, this installs one controller per namespace. This could be improved to use a global one in a next step.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26364

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
