### PR TITLE
WPB-26419: Changed the `backgroundEffects` feature flag to be disabled by default

### DIFF
--- a/changelog.d/2-features/WPB-26419
+++ b/changelog.d/2-features/WPB-26419
@@ -1,0 +1,1 @@
+Changed the `backgroundEffects` team feature flag to be disabled by default (still unlocked).

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -266,7 +266,7 @@ The feature status for individual teams can be changed via the public API (if th
 
 ### Background Effects
 
-The `backgroundEffects` feature flag controls whether background effects are available in meetings. It is enabled and unlocked by default. If you want a different configuration, use the following syntax: 
+The `backgroundEffects` feature flag controls whether background effects are available in meetings. It is disabled and unlocked by default. If you want a different configuration, use the following syntax: 
 ```yaml
 backgroundEffects:
   defaults:

--- a/integration/test/Test/FeatureFlags/Util.hs
+++ b/integration/test/Test/FeatureFlags/Util.hs
@@ -243,7 +243,7 @@ defAllFeatures =
           ],
       "meetings" .= enabled,
       "meetingsPremium" .= disabledLocked,
-      "backgroundEffects" .= enabled,
+      "backgroundEffects" .= disabled,
       "preventAdminlessGroups"
         .= object
           [ "lockStatus" .= "unlocked",
@@ -445,7 +445,7 @@ defAllConfiguredFeatures =
           ),
       "meetings" .= defaults enabled,
       "meetingsPremium" .= defaults disabledLocked,
-      "backgroundEffects" .= defaults enabled
+      "backgroundEffects" .= defaults disabled
     ]
   where
     defaults x = object ["defaults" .= x]

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -2222,7 +2222,7 @@ instance ToSchema BackgroundEffectsConfig where
   schema = object objectSchema
 
 instance Default (LockableFeature BackgroundEffectsConfig) where
-  def = defUnlockedFeature
+  def = defUnlockedFeature {status = FeatureStatusDisabled}
 
 instance IsFeatureConfig BackgroundEffectsConfig where
   type FeatureSymbol BackgroundEffectsConfig = "backgroundEffects"


### PR DESCRIPTION
Changed the `backgroundEffects` team feature flag to be **disabled** (still **unlocked**) by default.

Previously it was enabled and unlocked by default.

Closes https://wearezeta.atlassian.net/browse/WPB-26419