### PR TITLE
Add optional OpenTelemetry (OTEL) configuration for services

### DIFF
--- a/charts/wire-server/templates/background-worker/deployment.yaml
+++ b/charts/wire-server/templates/background-worker/deployment.yaml
@@ -118,6 +118,18 @@ spec:
               secretKeyRef:
                 name: background-worker
                 key: rabbitmqPassword
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: background-worker
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           startupProbe:
             httpGet:
               scheme: HTTP

--- a/charts/wire-server/templates/brig/deployment.yaml
+++ b/charts/wire-server/templates/brig/deployment.yaml
@@ -157,6 +157,18 @@ spec:
               secretKeyRef:
                 name: brig
                 key: rabbitmqPassword
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: brig
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           ports:
             - containerPort: {{ .Values.brig.service.internalPort }}
           startupProbe:

--- a/charts/wire-server/templates/cargohold/deployment.yaml
+++ b/charts/wire-server/templates/cargohold/deployment.yaml
@@ -90,6 +90,18 @@ spec:
             value: {{ join "," .noProxyList | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: cargohold
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           ports:
             - containerPort: {{ .Values.cargohold.service.internalPort }}
           livenessProbe:

--- a/charts/wire-server/templates/galley/deployment.yaml
+++ b/charts/wire-server/templates/galley/deployment.yaml
@@ -127,6 +127,18 @@ spec:
                 name: galley
                 key: rabbitmqPassword
           {{- end }}
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: galley
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           ports:
             - containerPort: {{ .Values.galley.service.internalPort }}
           livenessProbe:

--- a/charts/wire-server/templates/gundeck/deployment.yaml
+++ b/charts/wire-server/templates/gundeck/deployment.yaml
@@ -160,6 +160,18 @@ spec:
             value: {{ join "," .noProxyList | quote }}
           {{- end }}
           {{- end }} 
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: gundeck
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           ports:
             - containerPort: {{ .Values.gundeck.service.internalPort }}
           livenessProbe:

--- a/charts/wire-server/templates/spar/deployment.yaml
+++ b/charts/wire-server/templates/spar/deployment.yaml
@@ -78,6 +78,18 @@ spec:
             value: {{ join "," .noProxyList | quote }}
           {{- end }}
           {{- end }} 
+          {{- if .Values.otel.enabled }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ .Values.otel.endpoint | quote }}
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: {{ .Values.otel.protocol | quote }}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.otel.insecure | toString | quote }}
+          - name: OTEL_SERVICE_NAME
+            value: spar
+          - name: OTEL_TRACES_EXPORTER
+            value: otlp
+          {{- end }}
           ports:
             - containerPort: {{ .Values.spar.service.internalPort }}
           livenessProbe:

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -13,6 +13,14 @@ tags:
   integration: false
   proxy: false
 
+# OpenTelemetry configuration for services.
+# Set enabled: true to inject OTEL_* environment variables into service pods.
+otel:
+  enabled: false
+  endpoint: http://otel-collector:4318
+  protocol: http/protobuf
+  insecure: true
+
 galley:
   replicaCount: 3
   image:


### PR DESCRIPTION
## Summary

Adds optional OpenTelemetry (OTEL) configuration to the wire-server Helm chart.

- New top-level `otel` config block in `charts/wire-server/values.yaml`:

  ```yaml
  otel:
    enabled: false
    endpoint: http://otel-collector:4318
    protocol: http/protobuf
    insecure: true
  ```

- When `otel.enabled` is `true`, the following env vars are injected into the service pods (`brig`, `galley`, `gundeck`, `cargohold`, `spar`, `background-worker`):
  - `OTEL_EXPORTER_OTLP_ENDPOINT`
  - `OTEL_EXPORTER_OTLP_PROTOCOL`
  - `OTEL_EXPORTER_OTLP_INSECURE`
  - `OTEL_SERVICE_NAME` (per service)
  - `OTEL_TRACES_EXPORTER=otlp`
- Defaults to disabled, so behaviour is unchanged unless explicitly enabled.

## Notes

- No changelog entry added yet.

