### PR TITLE
WPB-25544 fix: stealth users are searchable via federated search

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-25544
+++ b/changelog.d/3-bug-fixes/WPB-25544
@@ -1,0 +1,1 @@
+Users marked non-searchable are no longer returned across federation.

--- a/integration/test/Test/Search.hs
+++ b/integration/test/Test/Search.hs
@@ -578,6 +578,29 @@ testUserSearchable = do
         docs <- resp.json %. "documents" >>= asList
         f docs
 
+testStealthUsersWithFederation :: App ()
+testStealthUsersWithFederation = do
+  ownDomain <- asString OwnDomain
+  otherDomain <- asString OtherDomain
+  void $ BrigI.createFedConn OwnDomain (BrigI.FedConn otherDomain "full_search" Nothing)
+  void $ BrigI.createFedConn OtherDomain (BrigI.FedConn ownDomain "full_search" Nothing)
+
+  (searcher, _, _) <- createTeam OwnDomain 1
+  (owner, tid, searchee : _) <- createTeam OtherDomain 2
+  searcheeId <- objId searchee
+  let searchTerm = "stealth-federation-user"
+
+  assertSuccess =<< GalleyI.setTeamFeatureStatus OtherDomain tid "searchVisibilityInbound" "enabled"
+  BrigP.putSelf searchee (def {BrigP.name = Just searchTerm}) >>= assertSuccess
+  BrigI.refreshIndex OtherDomain
+
+  assertCanFind searcher searchee searchTerm OtherDomain
+
+  BrigP.setUserSearchable owner searcheeId False >>= assertSuccess
+  BrigI.refreshIndex OtherDomain
+
+  assertCannotFind searcher searchee searchTerm OtherDomain
+
 testSuspendedUserSearch :: (HasCallStack) => App ()
 testSuspendedUserSearch = do
   [searcher, searchee] <- replicateM 2 $ randomUser OwnDomain def

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -157,7 +157,12 @@ mkUserQuery setting q =
     ( ES.Filter
         . ES.QueryBoolQuery
         $ boolQuery
-          { ES.boolQueryMustNotMatch = maybeToList $ matchSelf setting,
+          { ES.boolQueryMustNotMatch =
+              maybeToList (matchSelf setting)
+                <>
+                -- Federated search must respect the same "searchable" flag as
+                -- local contact search.
+                [ES.TermQuery (ES.Term "searchable" "false") Nothing],
             ES.boolQueryMustMatch =
               [ restrictSearchSpaceByTeam setting,
                 restrictSearchSpaceByUserType setting.types,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-25544

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
