### PR TITLE
WPB-1977 fix: Client cannot login when federator of foreign federated backend is unreachable

### DIFF
--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -258,9 +258,12 @@ listUsersClients usr qualifiedUserIds = do
   submit "POST" (req & addJSONObject ["qualified_users" .= qUsers])
 
 listUsers :: (HasCallStack, MakesValue user, MakesValue qualifiedUserIds) => user -> [qualifiedUserIds] -> App Response
-listUsers usr qualifiedUserIds = do
+listUsers = listUsersVersioned Versioned
+
+listUsersVersioned :: (HasCallStack, MakesValue user, MakesValue qualifiedUserIds) => Versioned -> user -> [qualifiedUserIds] -> App Response
+listUsersVersioned version usr qualifiedUserIds = do
   qUsers <- mapM objQidObject qualifiedUserIds
-  req <- baseRequest usr Brig Versioned $ joinHttpPath ["list-users"]
+  req <- baseRequest usr Brig version $ joinHttpPath ["list-users"]
   submit "POST" (req & addJSONObject ["qualified_ids" .= qUsers])
 
 data SearchContactsCfg = SearchContactsCfg
@@ -789,8 +792,11 @@ getUsersPrekeyBundle caller targetUser = do
 
 -- | https://staging-nginz-https.zinfra.io/v5/api/swagger-ui/#/default/post_users_list_prekeys
 getMultiUserPrekeyBundle :: (HasCallStack, MakesValue caller, ToJSON userClients) => caller -> userClients -> App Response
-getMultiUserPrekeyBundle caller userClients = do
-  req <- baseRequest caller Brig Versioned $ joinHttpPath ["users", "list-prekeys"]
+getMultiUserPrekeyBundle = getMultiUserPrekeyBundleVersioned Versioned
+
+getMultiUserPrekeyBundleVersioned :: (HasCallStack, MakesValue caller, ToJSON userClients) => Versioned -> caller -> userClients -> App Response
+getMultiUserPrekeyBundleVersioned version caller userClients = do
+  req <- baseRequest caller Brig version $ joinHttpPath ["users", "list-prekeys"]
   submit "POST" (addJSON userClients req)
 
 -- | https://staging-nginz-https.zinfra.io/v5/api/swagger-ui/#/default/post_access

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -20,7 +20,9 @@
 module Test.Federation where
 
 import qualified API.Brig as BrigP
+import API.Common
 import API.Galley
+import API.Nginz (login)
 import Control.Lens
 import Control.Monad.Codensity
 import Control.Monad.Reader
@@ -33,6 +35,32 @@ import qualified Proto.Otr_Fields as Proto
 import SetupHelpers
 import Testlib.Prelude
 import Testlib.ResourcePool
+
+testClientLoginWhenRemoteBackendIsOffline :: (HasCallStack) => App ()
+testClientLoginWhenRemoteBackendIsOffline = do
+  resourcePool <- asks (.resourcePool)
+  (admin, _, _) <- createTeam OwnDomain 1
+  email <- admin %. "email"
+  runCodensity (acquireResources 1 resourcePool) $ \[remoteBackend] -> do
+    runCodensity (startDynamicBackend remoteBackend mempty) $ \_ -> do
+      (remoteAdmin, _, _) <- createTeam remoteBackend.berDomain 1
+      connectTwoUsers admin remoteAdmin
+
+      remoteConv <- postConversation remoteAdmin (defProteus {qualifiedUsers = [admin]}) >>= getJSON 201
+      remoteConvId <- objQidObject remoteConv
+
+      bindResponse (listConversations admin [remoteConvId]) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        foundIds <- resp.json %. "found" >>= asList >>= traverse (%. "qualified_id")
+        foundIds `shouldMatchSet` [remoteConvId]
+        resp.json %. "failed" `shouldMatch` ([] :: [Value])
+
+      bindResponse (login OwnDomain email defPassword) $ \resp ->
+        resp.status `shouldMatchInt` 200
+
+    -- Backend B is down here. admin from own domain should still be able to login
+    bindResponse (login OwnDomain email defPassword) $ \resp ->
+      resp.status `shouldMatchInt` 200
 
 testNotificationsForOfflineBackends :: (HasCallStack) => App ()
 testNotificationsForOfflineBackends = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-1977

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
