### PR TITLE
Fix CSP header omitting for versioned SAML endpoints

### DIFF
--- a/changelog.d/3-bug-fixes/multi-ingress-saml-csp
+++ b/changelog.d/3-bug-fixes/multi-ingress-saml-csp
@@ -1,0 +1,1 @@
+Fix CSP headers for SAML endpoints. These were falsely emitted for *versioned* SAML endpoints.

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -7,19 +7,33 @@ metadata:
     {{- if not (hasPrefix "nginx" .Values.config.ingressClass) }}
         {{ fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}
     {{- end }}
-    {{/* We need to add CSP headers here for webapp, team-settings and
-    account-pages requests, because they cannot do it on their own in the
-    multi-ingress case.
-    SAML SSO endpoints are a special case: They do not provide CSP headers in
-    the single-ingress implementation (because of their javascript form
-    submitting logic), so we skip them here as well.
+    {{/* In the non-multi-ingress (default) case, frontend apps (webapp,
+    account-pages, team-settings) set CSP headers on their own. Implementing
+    this for multi-ingress would have been much work (due to some framework
+    specifics). Thus, we are setting an approximation of the webapp's CSP
+    headers here. The SAML flow would be broken by setting these headers, so we
+    leave them out for it. This is fine, because in the default case they
+    aren't set for any backend API endpoint as well.
+
+    How would the SAML flow be broken?
+    `sso/initiate-login` returns HTML of the form:
+
+    ```
+    <body onload="document.forms[0].submit()">
+      <form action="https://<IDP-ENDPOINT>">
+    ```
+
+    This conflicts at least with the `form-action 'self'` (i.e. no foreign form
+    target) and `script-src-attr 'none'` (no script attributes) rules.
+
+    `/sso/finalize-login` uses similar strategies.
+
+    Why support versioned and unversioned endpoints?
+    `/sso/initiate-login` is already in versioned use via Kalium.
+    `/sso/finalize-login` is at the time of writing also used in Kalium,
+    however not versioned. Though, because it is technically possible to use
+    the endpoint versioned as well, it cannot hurt to be prepared for this.
     */}}
-    # In the non-multi-ingress (default) case, frontend apps (webapp,
-    # account-pages, team-settings) set CSP headers on their own. Implementing
-    # this for multi-ingress would have been much work. Thus, we are setting an
-    # approximation here. The SAML flow would be broken by setting these
-    # headers, so we leave them out. This is fine, because in the default case
-    # they aren't set as well.
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon.ico$") {
         set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     aren't set for any backend API endpoint as well.
 
     How would the SAML flow be broken?
-    `sso/initiate-login` returns HTML of the form:
+    `/sso/initiate-login` returns HTML of the form:
 
     ```
     <body onload="document.forms[0].submit()">

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -14,6 +14,12 @@ metadata:
     the single-ingress implementation (because of their javascript form
     submitting logic), so we skip them here as well.
     */}}
+    # In the non-multi-ingress (default) case, frontend apps (webapp,
+    # account-pages, team-settings) set CSP headers on their own. Implementing
+    # this for multi-ingress would have been much work. Thus, we are setting an
+    # approximation here. The SAML flow would be broken by setting these
+    # headers, so we leave them out. This is fine, because in the default case
+    # they aren't set as well.
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon.ico$") {
         set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     submitting logic), so we skip them here as well.
     */}}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($uri !~ "(^/sso/finalize-login(/[a-zA-Z0-9-]*)?$)|(^/sso/initiate-login(/[a-zA-Z0-9-]*)?$)|(^/favicon.ico$)") {
+      if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon.ico$") {
         set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
         {{if .Values.websockets.enabled}}
         set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -35,7 +35,7 @@ metadata:
     the endpoint versioned as well, it cannot hurt to be prepared for this.
     */}}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon.ico$") {
+      if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon\.ico$") {
         set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
         {{if .Values.websockets.enabled}}
         set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";


### PR DESCRIPTION
The prior URL regex was intended to cover SAML endpoints, but did not cover the version path segment.

The expected behaviour is that - in the multi-ingress case - we omit CSP headers for the SAML endpoints. This implicitly resembles the non-multi-ingress case.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
