### PR TITLE
multi-ingress: Remove single IdP special-case

### DIFF
--- a/changelog.d/1-api-changes/multi-ingress-single-idp
+++ b/changelog.d/1-api-changes/multi-ingress-single-idp
@@ -1,0 +1,8 @@
+Previously, `POST /sso/get-by-email` and `GET /sso/initiate-login` endpoints
+treated an IdP as globally configured for all domains when there was only one
+for a team. This led to information leakage and confusion. Now, these endpoints
+always treat IdPs as bound to a domain when multi-ingress is configured. I.e.
+IdP domain and request domain must match, otherwise an error is returned.
+
+To align with the others, this check is also added to the `HEAD
+/sso/initiate-login` pre-check endpoint.

--- a/changelog.d/1-api-changes/multi-ingress-single-idp
+++ b/changelog.d/1-api-changes/multi-ingress-single-idp
@@ -4,5 +4,5 @@ for a team. This led to information leakage and confusion. Now, these endpoints
 always treat IdPs as bound to a domain when multi-ingress is configured. I.e.
 IdP domain and request domain must match, otherwise an error is returned.
 
-To align with the others, this check is also added to the `HEAD
-/sso/initiate-login` pre-check endpoint.
+To align with the others, this check is also added to the `HEAD /sso/initiate-login`
+pre-check endpoint.

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -1305,9 +1305,8 @@ Given an email address, the SSO code is looked up by these criteria:
 - The user must be activated. Either by the activation mail flow or by
   [auto-activation](#validate-saml-emails).
 - The mapping must be unambiguous (there must be exactly one matching IdP).
-  This is the case for:
-  - Teams with exactly one configured IdP
-  - There is an IdP for the given multi-ingress domain
+  In multi-ingress mode, IdPs are always bound to one domain; the request domain
+  must match the IdP's configured domain.
 - The user was created via SCIM
 
 The last condition ensures that team admins cannot get into locked-out

--- a/integration/test/API/Spar.hs
+++ b/integration/test/API/Spar.hs
@@ -239,6 +239,12 @@ initiateSamlLogin = (flip initiateSamlLoginWithZHost) Nothing
 initiateSamlLoginWithZHost :: (HasCallStack, MakesValue domain) => domain -> Maybe String -> String -> App Response
 initiateSamlLoginWithZHost domain mbZHost idpId = initiateSamlLoginWithZHostAndLabel domain mbZHost Nothing idpId --
 
+-- | https://staging-nginz-https.zinfra.io/v16/api/swagger-ui/#/default/auth-req-precheck
+precheckSamlLoginWithZHost :: (HasCallStack, MakesValue domain) => domain -> Maybe String -> String -> App Response
+precheckSamlLoginWithZHost domain mbZHost idpId = do
+  req <- baseRequest domain Spar Versioned $ joinHttpPath ["sso", "initiate-login", idpId]
+  submit "HEAD" (req & maybe id zHost mbZHost)
+
 -- | https://staging-nginz-https.zinfra.io/v15/api/swagger-ui/#/default/auth-req
 initiateSamlLoginWithZHostAndLabel :: (HasCallStack, MakesValue domain) => domain -> Maybe String -> Maybe String -> String -> App Response
 initiateSamlLoginWithZHostAndLabel domain mbZHost mLabel idpId = do

--- a/integration/test/Test/Spar/MultiIngressSSO.hs
+++ b/integration/test/Test/Spar/MultiIngressSSO.hs
@@ -82,33 +82,22 @@ testMultiIngressSSOGeneralIdp = do
       checkSPMetadata domain ernieZHost tid
 
       -- Z-Host set, but IdP has no domain -> failure
-      initiateSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \authnreq -> do
-        authnreq.status `shouldMatchInt` 404
-        authnreq.json %. "label" `shouldMatch` "not-found"
+      initiateSamlLoginWithZHost domain (Just ernieZHost) idpId >>= assertLabel 404 "not-found"
 
-      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
+      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId >>= assertStatus 404
 
       -- When multi-ingress is configured, domain match is mandatory (empty Z-Host is a no-match)
-      initiateSamlLoginWithZHost domain Nothing idpId `bindResponse` \authnreq -> do
-        authnreq.status `shouldMatchInt` 404
-        authnreq.json %. "label" `shouldMatch` "not-found"
+      initiateSamlLoginWithZHost domain Nothing idpId >>= assertLabel 404 "not-found"
 
-      precheckSamlLoginWithZHost domain Nothing idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
+      precheckSamlLoginWithZHost domain Nothing idpId >>= assertStatus 404
 
       -- Kermit's domain is not configured at all
       _kermitEmail <- ("kermit@" <>) <$> randomDomain
-      getSPMetadataWithZHost domain (Just kermitZHost) tid `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
-        resp.json %. "label" `shouldMatch` "not-found"
+      getSPMetadataWithZHost domain (Just kermitZHost) tid >>= assertLabel 404 "not-found"
 
-      initiateSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \authnreq -> do
-        authnreq.status `shouldMatchInt` 404
-        authnreq.json %. "label" `shouldMatch` "not-found"
+      initiateSamlLoginWithZHost domain (Just kermitZHost) idpId >>= assertLabel 404 "not-found"
 
-      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
+      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId >>= assertStatus 404
 
 -- | Test multi-ingress SSO with an IdP that is bound to a domain.
 --
@@ -158,15 +147,14 @@ testMultiIngressSSODomainBoundIdp = do
       checkAuthnRequest domain ernieZHost idpId tid
 
       -- Ernie's precheck succeeds for the correct domain
-      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 200
+      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId >>= assertStatus 200
 
       makeSuccessfulSamlLogin domain ernieZHost tid ernieEmail idpId idpMeta
 
       -- SAML flow cannot be intercepted and redirected to another domain
       finalizeLoginWithWrongZHost ernieZHost bertZHost domain tid ernieEmail (idpId, idpMeta)
         `bindResponse` \resp -> do
-          resp.status `shouldMatchInt` 200
+          assertStatus 200 resp
           let titleName = XML.Name (cs "title") (Just (cs "http://www.w3.org/1999/xhtml")) Nothing
               getRoot :: ByteString -> Maybe XML.Cursor
               getRoot = pure . KXML.parseXml . cs
@@ -177,25 +165,17 @@ testMultiIngressSSODomainBoundIdp = do
       checkSPMetadata domain bertZHost tid
 
       -- Bert cannot initiate a login with an Ernie IdP
-      initiateSamlLoginWithZHost domain (Just bertZHost) idpId `bindResponse` \authnreq -> do
-        authnreq.status `shouldMatchInt` 404
-        authnreq.json %. "label" `shouldMatch` "not-found"
+      initiateSamlLoginWithZHost domain (Just bertZHost) idpId >>= assertLabel 404 "not-found"
 
-      precheckSamlLoginWithZHost domain (Just bertZHost) idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
+      precheckSamlLoginWithZHost domain (Just bertZHost) idpId >>= assertStatus 404
 
       -- Kermit's domain is not configured at all
       _kermitEmail <- ("kermit@" <>) <$> randomDomain
-      getSPMetadataWithZHost domain (Just kermitZHost) tid `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
-        resp.json %. "label" `shouldMatch` "not-found"
+      getSPMetadataWithZHost domain (Just kermitZHost) tid >>= assertLabel 404 "not-found"
 
-      initiateSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \authnreq -> do
-        authnreq.status `shouldMatchInt` 404
-        authnreq.json %. "label" `shouldMatch` "not-found"
+      initiateSamlLoginWithZHost domain (Just kermitZHost) idpId >>= assertLabel 404 "not-found"
 
-      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 404
+      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId >>= assertStatus 404
 
 -- | Check the AuthnRequest by the SP (Wire backend) to be sent to the IdP
 --
@@ -203,7 +183,7 @@ testMultiIngressSSODomainBoundIdp = do
 checkAuthnRequest :: (HasCallStack) => String -> String -> String -> String -> App ()
 checkAuthnRequest domain host idpId tid =
   initiateSamlLoginWithZHost domain (Just host) idpId `bindResponse` \authnreq -> do
-    authnreq.status `shouldMatchInt` 200
+    assertStatus 200 authnreq
 
     let inputName = XML.Name (cs "input") (Just (cs "http://www.w3.org/1999/xhtml")) Nothing
         valueName = XML.Name (cs "value") Nothing Nothing
@@ -230,7 +210,7 @@ checkAuthnRequest domain host idpId tid =
 checkSPMetadata :: (HasCallStack) => String -> String -> String -> App ()
 checkSPMetadata domain host tid =
   getSPMetadataWithZHost domain (Just host) tid `bindResponse` \resp -> do
-    resp.status `shouldMatchInt` 200
+    assertStatus 200 resp
 
     let spSsoDescName = XML.Name (cs "SPSSODescriptor") (Just (cs "urn:oasis:names:tc:SAML:2.0:metadata")) (Just (cs "md"))
         acsName = XML.Name (cs "AssertionConsumerService") (Just (cs "urn:oasis:names:tc:SAML:2.0:metadata")) (Just (cs "md"))
@@ -274,7 +254,7 @@ makeSuccessfulSamlLogin domain host tid email idpId idpMeta = do
   void $ loginWithSamlWithZHost (Just host) domain True tid nameId (idpId, idpMeta)
   activateEmail domain email
   getUsersByEmail domain [email] `bindResponse` \res -> do
-    res.status `shouldMatchInt` 200
+    assertStatus 200 res
     user <- res.json & asList >>= assertOne
     user %. "status" `shouldMatch` "active"
     user %. "email" `shouldMatch` email

--- a/integration/test/Test/Spar/MultiIngressSSO.hs
+++ b/integration/test/Test/Spar/MultiIngressSSO.hs
@@ -37,32 +37,12 @@ import qualified Text.XML.DSig as SAML
 
 -- | Test multi-ingress SSO with an IdP that is not bound to a domain.
 --
--- The IdP is created via a non-multi-ingress way/domain. It is valid for all
--- domains - no matter if they are configured as multi-ingress domains or not.
--- However, the SP must be consistent in the communication: If the SAML login
--- flow was started on one domain, it must return to exactly this domain.
+-- In this case NO SSO login can happen as a redirect to a common IdP would
+-- leak information about relationships to a common backend. Also, in reality
+-- it is very hard (to impossible for some IdPs) to find a valid and sound
+-- configuration for multiple domains at IdP SaaS.
 testMultiIngressSSOGeneralIdp :: (HasCallStack) => App ()
-testMultiIngressSSOGeneralIdp = multiIngressSSOCommonTest (const . registerTestIdPWithMetaWithPrivateCreds)
-
--- | Test multi-ingress SSO with an IdP that is bound to a domain.
---
--- The IdP is created on a multi-ingress domain. The details of managing
--- multi-ingress IdPs are covered in `Test.Spar.MultiIngressIdp`. Here we want
--- to test that logins are possible with such an IdP, ensuring we haven't
--- broken basic functionality.
-testMultiIngressSSODomainBoundIdp :: (HasCallStack) => App ()
-testMultiIngressSSODomainBoundIdp = multiIngressSSOCommonTest registerTestIdPWithMetaWithPrivateCredsForZHost
-
-multiIngressSSOCommonTest ::
-  (HasCallStack) =>
-  ( forall owner.
-    (HasCallStack, MakesValue owner) =>
-    owner ->
-    Maybe String ->
-    App (Response, (SAML.IdPMetadata, SAML.SignPrivCreds))
-  ) ->
-  App ()
-multiIngressSSOCommonTest registerTestIdPWithMetaWithPrivateCredsFn = do
+testMultiIngressSSOGeneralIdp = do
   let ernieZHost = "nginz-https.ernie.example.com"
       bertZHost = "nginz-https.bert.example.com"
       kermitZHost = "nginz-https.kermit.example.com"
@@ -95,33 +75,30 @@ multiIngressSSOCommonTest registerTestIdPWithMetaWithPrivateCredsFn = do
       (owner, tid, _) <- createTeam domain 1
       void $ setTeamFeatureStatus owner tid "sso" "enabled"
 
-      (idp, idpMeta) <- registerTestIdPWithMetaWithPrivateCredsFn owner (Just ernieZHost)
+      (idp, _idpMeta) <- registerTestIdPWithMetaWithPrivateCreds owner
       idpId <- asString $ idp.json %. "id"
 
-      ernieEmail <- ("ernie@" <>) <$> randomDomain
+      _ernieEmail <- ("ernie@" <>) <$> randomDomain
       checkSPMetadata domain ernieZHost tid
-      checkAuthnRequest domain ernieZHost idpId tid
 
-      finalizeLoginWithWrongZHost bertZHost ernieZHost domain tid ernieEmail (idpId, idpMeta) `bindResponse` \resp -> do
-        resp.status `shouldMatchInt` 200
+      -- Z-Host set, but IdP has no domain -> failure
+      initiateSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \authnreq -> do
+        authnreq.status `shouldMatchInt` 404
+        authnreq.json %. "label" `shouldMatch` "not-found"
 
-        let titleName = XML.Name (cs "title") (Just (cs "http://www.w3.org/1999/xhtml")) Nothing
-            getRoot :: ByteString -> Maybe XML.Cursor
-            getRoot = pure . KXML.parseXml . cs
+      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 404
 
-        ((getRoot >=> KXML.findElement titleName >=> KXML.getContent) resp.body)
-          `shouldMatch` (Just "wire:sso:error:forbidden")
+      -- When multi-ingress is configured, domain match is mandatory (empty Z-Host is a no-match)
+      initiateSamlLoginWithZHost domain Nothing idpId `bindResponse` \authnreq -> do
+        authnreq.status `shouldMatchInt` 404
+        authnreq.json %. "label" `shouldMatch` "not-found"
 
-      makeSuccessfulSamlLogin domain ernieZHost tid ernieEmail idpId idpMeta
+      precheckSamlLoginWithZHost domain Nothing idpId `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 404
 
-      bertEmail <- ("bert@" <>) <$> randomDomain
-      checkSPMetadata domain bertZHost tid
-      checkAuthnRequest domain bertZHost idpId tid
-
-      makeSuccessfulSamlLogin domain bertZHost tid bertEmail idpId idpMeta
-
-      -- Kermit's domain is not configured
-      kermitEmail <- ("kermit@" <>) <$> randomDomain
+      -- Kermit's domain is not configured at all
+      _kermitEmail <- ("kermit@" <>) <$> randomDomain
       getSPMetadataWithZHost domain (Just kermitZHost) tid `bindResponse` \resp -> do
         resp.status `shouldMatchInt` 404
         resp.json %. "label" `shouldMatch` "not-found"
@@ -130,7 +107,94 @@ multiIngressSSOCommonTest registerTestIdPWithMetaWithPrivateCredsFn = do
         authnreq.status `shouldMatchInt` 404
         authnreq.json %. "label" `shouldMatch` "not-found"
 
-      finalizeLoginWithWrongZHost bertZHost kermitZHost domain tid kermitEmail (idpId, idpMeta) `bindResponse` \resp -> do
+      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 404
+
+-- | Test multi-ingress SSO with an IdP that is bound to a domain.
+--
+-- The IdP is created on a multi-ingress domain. The details of managing
+-- multi-ingress IdPs are covered in `Test.Spar.MultiIngressIdp`. Here we want
+-- to test that logins are possible with such an IdP, but only if the request's
+-- and IdP's domains match.
+testMultiIngressSSODomainBoundIdp :: (HasCallStack) => App ()
+testMultiIngressSSODomainBoundIdp = do
+  let ernieZHost = "nginz-https.ernie.example.com"
+      bertZHost = "nginz-https.bert.example.com"
+      kermitZHost = "nginz-https.kermit.example.com"
+
+  withModifiedBackend
+    def
+      { sparCfg =
+          removeField "saml.spSsoUri"
+            >=> removeField "saml.spAppUri"
+            >=> removeField "saml.contacts"
+            >=> setField
+              "saml.spDomainConfigs"
+              ( object
+                  [ ernieZHost
+                      .= object
+                        [ "spAppUri" .= "https://webapp.ernie.example.com",
+                          "spSsoUri" .= "https://nginz-https.ernie.example.com/sso",
+                          "contacts" .= [object ["type" .= "ContactTechnical"]]
+                        ],
+                    bertZHost
+                      .= object
+                        [ "spAppUri" .= "https://webapp.bert.example.com",
+                          "spSsoUri" .= "https://nginz-https.bert.example.com/sso",
+                          "contacts" .= [object ["type" .= "ContactTechnical"]]
+                        ]
+                  ]
+              )
+      }
+    $ \domain -> do
+      (owner, tid, _) <- createTeam domain 1
+      void $ setTeamFeatureStatus owner tid "sso" "enabled"
+
+      (idp, idpMeta) <- registerTestIdPWithMetaWithPrivateCredsForZHost owner (Just ernieZHost)
+      idpId <- asString $ idp.json %. "id"
+
+      ernieEmail <- ("ernie@" <>) <$> randomDomain
+      checkSPMetadata domain ernieZHost tid
+      checkAuthnRequest domain ernieZHost idpId tid
+
+      -- Ernie's precheck succeeds for the correct domain
+      precheckSamlLoginWithZHost domain (Just ernieZHost) idpId `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 200
+
+      makeSuccessfulSamlLogin domain ernieZHost tid ernieEmail idpId idpMeta
+
+      -- SAML flow cannot be intercepted and redirected to another domain
+      finalizeLoginWithWrongZHost ernieZHost bertZHost domain tid ernieEmail (idpId, idpMeta)
+        `bindResponse` \resp -> do
+          resp.status `shouldMatchInt` 200
+          let titleName = XML.Name (cs "title") (Just (cs "http://www.w3.org/1999/xhtml")) Nothing
+              getRoot :: ByteString -> Maybe XML.Cursor
+              getRoot = pure . KXML.parseXml . cs
+          ((getRoot >=> KXML.findElement titleName >=> KXML.getContent) resp.body)
+            `shouldMatch` Just "wire:sso:error:forbidden"
+
+      _bertEmail <- ("bert@" <>) <$> randomDomain
+      checkSPMetadata domain bertZHost tid
+
+      -- Bert cannot initiate a login with an Ernie IdP
+      initiateSamlLoginWithZHost domain (Just bertZHost) idpId `bindResponse` \authnreq -> do
+        authnreq.status `shouldMatchInt` 404
+        authnreq.json %. "label" `shouldMatch` "not-found"
+
+      precheckSamlLoginWithZHost domain (Just bertZHost) idpId `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 404
+
+      -- Kermit's domain is not configured at all
+      _kermitEmail <- ("kermit@" <>) <$> randomDomain
+      getSPMetadataWithZHost domain (Just kermitZHost) tid `bindResponse` \resp -> do
+        resp.status `shouldMatchInt` 404
+        resp.json %. "label" `shouldMatch` "not-found"
+
+      initiateSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \authnreq -> do
+        authnreq.status `shouldMatchInt` 404
+        authnreq.json %. "label" `shouldMatch` "not-found"
+
+      precheckSamlLoginWithZHost domain (Just kermitZHost) idpId `bindResponse` \resp -> do
         resp.status `shouldMatchInt` 404
 
 -- | Check the AuthnRequest by the SP (Wire backend) to be sent to the IdP

--- a/integration/test/Test/Spar/MultiIngressSSO.hs
+++ b/integration/test/Test/Spar/MultiIngressSSO.hs
@@ -177,12 +177,82 @@ testMultiIngressSSODomainBoundIdp = do
 
       precheckSamlLoginWithZHost domain (Just kermitZHost) idpId >>= assertStatus 404
 
+-- | Test that without multi-ingress configuration, endpoints are domain-agnostic.
+--
+-- In the standard (non-multi-ingress) case, SAML endpoints work regardless of
+-- which domain (Z-Host) is used or if no Z-Host is specified.
+testSsoWithoutMultiIngress :: (HasCallStack) => App ()
+testSsoWithoutMultiIngress = do
+  let host1 = "nginz-https.host1.example.com"
+      host2 = "nginz-https.host2.example.com"
+      spHost = "nginz-https.example.com"
+
+  withModifiedBackend
+    def
+      { sparCfg =
+          setField "saml.spSsoUri" ("https://" <> spHost <> "/sso")
+            >=> setField "saml.spAppUri" ("https://" <> spHost <> "/")
+            >=> setField "saml.contacts" [object ["type" .= "ContactTechnical"]]
+      }
+    $ \domain -> do
+      (owner, tid, _) <- createTeam domain 1
+      void $ setTeamFeatureStatus owner tid "sso" "enabled"
+
+      -- Create both types of IdPs
+      idpGeneral <- registerTestIdPWithMetaWithPrivateCreds owner
+      idpZHost1 <- registerTestIdPWithMetaWithPrivateCredsForZHost owner (Just host1)
+      idpZHost2 <- registerTestIdPWithMetaWithPrivateCredsForZHost owner (Just host2)
+
+      forM_
+        [idpGeneral, idpZHost1, idpZHost2]
+        $ \(idp, idpMeta) -> do
+          idpId <- asString $ idp.json %. "id"
+
+          -- Precheck succeeds from any domain
+          precheckSamlLoginWithZHost domain (Just host1) idpId >>= assertStatus 200
+          precheckSamlLoginWithZHost domain (Just host2) idpId >>= assertStatus 200
+          precheckSamlLoginWithZHost domain Nothing idpId >>= assertStatus 200
+
+          -- SP metadata is accessible from any domain
+          getSPMetadataWithZHost domain (Just host1) tid >>= assertStatus 200
+          getSPMetadataWithZHost domain (Just host2) tid >>= assertStatus 200
+          getSPMetadataWithZHost domain Nothing tid >>= assertStatus 200
+
+          -- AuthnRequest Issuer is same regardless of Z-Host (domain-agnostic)
+          checkAuthnRequestBase domain (Just host1) spHost idpId tid
+          checkAuthnRequestBase domain (Just host2) spHost idpId tid
+          checkAuthnRequestBase domain Nothing spHost idpId tid
+
+          -- Authentication request can be initiated from any domain
+          initiateSamlLoginWithZHost domain (Just host1) idpId >>= assertStatus 200
+          initiateSamlLoginWithZHost domain (Just host2) idpId >>= assertStatus 200
+          initiateSamlLoginWithZHost domain Nothing idpId >>= assertStatus 200
+
+          -- SAML login
+          email1 <- ("user1@" <>) <$> randomDomain
+          makeSuccessfulSamlLogin domain host1 tid email1 idpId idpMeta
+
+          email2 <- ("user2@" <>) <$> randomDomain
+          makeSuccessfulSamlLogin domain host2 tid email2 idpId idpMeta
+
+          email3 <- ("user3@" <>) <$> randomDomain
+          let nameId3 = fromRight (error "could not create name id") $ SAML.emailNameID (cs email3)
+          void $ loginWithSamlWithZHost Nothing domain True tid nameId3 (idpId, idpMeta)
+
 -- | Check the AuthnRequest by the SP (Wire backend) to be sent to the IdP
 --
 -- Most important: The @Issuer@ must fit to the multi-ingress domain (@host@).
-checkAuthnRequest :: (HasCallStack) => String -> String -> String -> String -> App ()
-checkAuthnRequest domain host idpId tid =
-  initiateSamlLoginWithZHost domain (Just host) idpId `bindResponse` \authnreq -> do
+checkAuthnRequest :: (HasCallStack, MakesValue domain) => domain -> String -> String -> String -> App ()
+checkAuthnRequest domain host idpId tid = checkAuthnRequestBase domain (Just host) host idpId tid
+
+-- | Check the AuthnRequest by the SP (Wire backend) to be sent to the IdP
+--
+-- Compares the Issuer in the request against an expected target host URL. This
+-- allows testing that requests to different hosts produce different (or same)
+-- Issuer URLs.
+checkAuthnRequestBase :: (HasCallStack, MakesValue domain) => domain -> Maybe String -> String -> String -> String -> App ()
+checkAuthnRequestBase domain mbRequestHost targetHost idpId tid =
+  initiateSamlLoginWithZHost domain mbRequestHost idpId `bindResponse` \authnreq -> do
     assertStatus 200 authnreq
 
     let inputName = XML.Name (cs "input") (Just (cs "http://www.w3.org/1999/xhtml")) Nothing
@@ -192,7 +262,7 @@ checkAuthnRequest domain host idpId tid =
         decodeBase64 :: T.Text -> Maybe ByteString
         decodeBase64 = either (const Nothing) Just . Data.ByteString.Base64.decode . cs
 
-        targetSPUrl = T.pack ("https://" <> host <> "/sso/finalize-login/" <> tid)
+        targetSPUrl = T.pack ("https://" <> targetHost <> "/sso/finalize-login/" <> tid)
 
         getIssuerUrl :: ByteString -> Maybe T.Text
         getIssuerUrl =
@@ -207,7 +277,7 @@ checkAuthnRequest domain host idpId tid =
     getIssuerUrl authnreq.body `shouldMatch` targetSPUrl
 
 -- | Check the metadata of the ServiceProvider (i.e. of the Wire backend on multi-ingress domain @host@)
-checkSPMetadata :: (HasCallStack) => String -> String -> String -> App ()
+checkSPMetadata :: (HasCallStack, MakesValue domain) => domain -> String -> String -> App ()
 checkSPMetadata domain host tid =
   getSPMetadataWithZHost domain (Just host) tid `bindResponse` \resp -> do
     assertStatus 200 resp

--- a/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
@@ -144,6 +144,7 @@ type APIAuthReqPrecheck =
         :> QueryParam "error_redirect" URI.URI
         :> QueryParam "label" CookieLabel
         :> Capture "idp" SAML.IdPId
+        :> ZHostOpt
         :> CheckOK '[PlainText] NoContent
     )
 

--- a/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
@@ -55,8 +55,7 @@ interpretIdPSubsystem enableIdPByEmailDiscovery = interpret $ \case
 --  - Get their team
 --  - Lookup the team's IdP matching the domain
 --
---  If any of these steps fail, we return `Nothing` - except when the team has
---  only exactly one IdP configured; then we consider this as default.
+--  If any of these steps fail, we return `Nothing`.
 --
 --  In case we find more than one user for an email address, we throw an
 --  exception as this "should never happen".
@@ -99,7 +98,7 @@ getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
                 case mbTeam of
                   Just team -> do
                     idps <- getConfigsByTeam team
-                    selectIdP idps
+                    findIdPByDomain idps
                   Nothing -> pure Nothing
               else pure Nothing
           tooManyUsers -> do
@@ -112,20 +111,12 @@ getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
     userIdToText :: Qualified UserId -> Text
     userIdToText uid = idToText (qUnqualified uid) <> "@" <> domainText (qDomain uid)
 
-    selectIdP :: (Member (Logger (Log.Msg -> Log.Msg)) r) => [IP.IdP] -> Sem r (Maybe SAML.IdPId)
-    selectIdP idps = case idps of
-      -- No IdPs: no match
-      [] -> pure Nothing
-      -- Exactly one IdP: always return it
-      [idp] -> (pure . pure) (idp ^. SAML.idpId)
-      -- Multiple IdPs: find by domain if host provided
-      _idps' -> findIdPByDomain idps
-
     isScimOrSsoUser :: User -> Bool
     isScimOrSsoUser user =
       userManagedBy user == ManagedByScim && isJust (userSSOId user)
 
     findIdPByDomain :: (Member (Logger (Log.Msg -> Log.Msg)) r) => [IP.IdP] -> Sem r (Maybe SAML.IdPId)
+    findIdPByDomain [] = pure Nothing
     findIdPByDomain idps = do
       let matches :: [SAML.IdPId] =
             SAML._idpId

--- a/libs/wire-subsystems/test/unit/Wire/IdPSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/IdPSubsystem/InterpreterSpec.hs
@@ -113,7 +113,7 @@ brigAPIAccessMockFn expectedEmail resUser uids handles emails havePending =
 spec :: Spec
 spec = describe "IdPSubsystem.Interpreter" $ do
   describe "getSsoCodeByEmail" $ do
-    prop "returns IdP for SCIM user with single IdP" $ \(teamMember :: TeamMember) user userRef email teamId mbDomain -> do
+    prop "returns IdP for SCIM user with single IdP only if the domain fits" $ \(teamMember :: TeamMember) user userRef email teamId mbDomain -> do
       idp <- generate $ do
         -- Generate IdPs with and without fitting domain
         idp' <- arbitrary <&> SAML.idpExtraInfo . domain .~ mbDomain
@@ -142,7 +142,12 @@ spec = describe "IdPSubsystem.Interpreter" $ do
               (brigAPIAccessMockFn email userWithEmail)
               (getSsoCodeByEmail mbDomain email)
 
-      result `shouldBe` Right (Just idp._idpId)
+          expectedResult =
+            if (idp ^. SAML.idpExtraInfo . domain) == mbDomain
+              then Right (Just idp._idpId)
+              else Right Nothing
+
+      result `shouldBe` expectedResult
       expectedSevereLogs logs mempty
 
     prop "finds IdP for SCIM user by domain" $ \(teamMember :: TeamMember) user idp userRef email teamId dom otherIdPs ->

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# HLINT ignore "Use $>" #-}
 -- Disabling to stop warnings on HasCallStack
@@ -226,8 +227,8 @@ apiSSO ::
 apiSSO opts =
   Named @"sso-metadata" (getMetadata Nothing)
     :<|> Named @"sso-team-metadata" (\mbHost tid -> getMetadata (Just tid) mbHost)
-    :<|> Named @"auth-req-precheck" authreqPrecheck
-    :<|> Named @"auth-req" (authreq (maxttlAuthreqDiffTime opts))
+    :<|> Named @"auth-req-precheck" (authreqPrecheck opts.saml)
+    :<|> Named @"auth-req" (authreq opts.saml (maxttlAuthreqDiffTime opts))
     :<|> Named @"auth-resp-legacy" (authresp Nothing)
     :<|> Named @"auth-resp" (authresp . Just)
     :<|> Named @"sso-settings" ssoSettings
@@ -315,23 +316,28 @@ getMetadata mbTid mbHost = do
 
 authreqPrecheck ::
   ( Member IdPConfigStore r,
-    Member (Error SparError) r
+    Member (Error SparError) r,
+    Member (Logger (Msg -> Msg)) r
   ) =>
+  SAML.Config ->
   Maybe URI.URI ->
   Maybe URI.URI ->
   Maybe CookieLabel ->
   SAML.IdPId ->
+  Maybe Text ->
   Sem r NoContent
-authreqPrecheck msucc merr mlabel idpid =
-  validateAuthreqParams msucc merr mlabel
-    *> IdPConfigStore.getConfig idpid
-      $> NoContent
+authreqPrecheck samlConfig msucc merr mlabel idpid mbHost =
+  validateAuthreqParams msucc merr mlabel *> do
+    idp <- IdPConfigStore.getConfig idpid
+    checkMultiIngressDomain samlConfig mbHost idp
+    pure NoContent
 
 authreq ::
   forall r.
   ( Member Random r,
     Member (Input Opts) r,
     Member (Logger String) r,
+    Member (Logger (Msg -> Msg)) r,
     Member AssIDStore r,
     Member VerdictFormatStore r,
     Member AReqIDStore r,
@@ -340,6 +346,7 @@ authreq ::
     Member (Error SparError) r,
     Member IdPConfigStore r
   ) =>
+  SAML.Config ->
   NominalDiffTime ->
   Maybe URI.URI ->
   Maybe URI.URI ->
@@ -347,10 +354,12 @@ authreq ::
   SAML.IdPId ->
   Maybe Text ->
   Sem r (SAML.FormRedirect SAML.AuthnRequest)
-authreq authreqttl msucc merr mlabel idpid mbHost = do
+authreq samlConfig authreqttl msucc merr mlabel idpid mbHost = do
   vformat <- validateAuthreqParams msucc merr mlabel
   form@(SAML.FormRedirect _ ((^. SAML.rqID) -> reqid)) <- do
     idp :: IdP <- IdPConfigStore.getConfig idpid
+
+    checkMultiIngressDomain samlConfig mbHost idp
 
     let err :: Sem r any
         err = throwSparSem (SparSPNotFound "")
@@ -365,6 +374,31 @@ authreq authreqttl msucc merr mlabel idpid mbHost = do
     SAML2.authReq authreqttl iss idpid
   VerdictFormatStore.store authreqttl reqid vformat
   pure form
+
+checkMultiIngressDomain ::
+  ( Member (Logger (Msg -> Msg)) r,
+    Member (Error SparError) r
+  ) =>
+  SAML.Config ->
+  Maybe Text ->
+  IdP ->
+  Sem r ()
+checkMultiIngressDomain samlConfig mbHost idp = when (SAML.isMultiIngressConfig samlConfig) $ do
+  let idpDomain = idp._idpExtraInfo._domain
+  case (idpDomain, mbHost) of
+    (Just expectedDomain, Just host)
+      | host == expectedDomain -> pure ()
+    _ -> do
+      let idpIdTxt = idpIdToText idp._idpId
+      Logger.debug $
+        Log.msg ("Multi-ingress domain guard rejected IdP access" :: ByteString)
+          . Log.field "idp" idpIdTxt
+          . Log.field "idp_domain" (fromMaybe "none" idpDomain)
+          . Log.field "request_host" (fromMaybe "none" mbHost)
+      throwSparSem (SparIdPNotFound idpIdTxt)
+
+idpIdToText :: SAML.IdPId -> T.Text
+idpIdToText = T.pack . UUID.toString . SAML.fromIdPId
 
 redirectURLMaxLength :: Int
 redirectURLMaxLength = 140
@@ -536,7 +570,7 @@ idpGetRaw zusr idpid = do
   _ <- authorizeIdP zusr idp
   IdPRawMetadataStore.get idpid >>= \case
     Just txt -> pure $ RawIdPMetadata txt
-    Nothing -> throwSparSem $ SparIdPNotFound (T.pack $ show idpid)
+    Nothing -> throwSparSem $ SparIdPNotFound (idpIdToText idpid)
 
 idpGetAll ::
   ( Member Random r,


### PR DESCRIPTION
Previously, `POST /sso/get-by-email` and `GET /sso/initiate-login` endpoints
treated an IdP as globally configured for all domains when there was only one
for a team. This led to information leakage and confusion, raising "Why do I endup at another domain's IdP when I'm on this one?" questions. Now, these endpoints
always treat IdPs as bound to a domain when multi-ingress is configured. I.e.
IdP domain and request domain must match, otherwise an error is returned.

The error resembles what would be returned if the IdP wouldn't exist.

To align with the others, this check is also added to the `HEAD /sso/initiate-login` pre-check endpoint.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26244

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] ~~Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)~~ (Breaking behaviour, but currently no-one is using multi-ingress in prod)
