### PR TITLE
WPB-26626: Split create-group-conversation at V16 for GroupConvTypeLegacy

### DIFF
--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -77,6 +77,7 @@ module Wire.API.Conversation
     toLegacyConversationMetadata,
     toLegacyMLSOne2OneConversation,
     toLegacyCreateGroupOwnConversation,
+    toLegacyCreateGroupConversation,
     isMeetingConversation,
     NewOne2OneConv (..),
     ConvTeamInfo (..),
@@ -1433,6 +1434,15 @@ toLegacyCreateGroupOwnConversation ::
   CreateGroupOwnConversation GroupConvTypeLegacy
 toLegacyCreateGroupOwnConversation cgoc =
   cgoc {cgcConversation = toLegacyOwnConversation cgoc.cgcConversation}
+
+toLegacyCreateGroupConversation ::
+  CreateGroupConversation GroupConvType ->
+  CreateGroupConversation GroupConvTypeLegacy
+toLegacyCreateGroupConversation cgc =
+  CreateGroupConversation
+    { conversation = toLegacyConversation cgc.conversation,
+      failedToAdd = cgc.failedToAdd
+    }
 
 isMeetingConversation :: OwnConversation GroupConvType -> Bool
 isMeetingConversation conv = conv.cnvMetadata.cnvmGroupConvType == Just MeetingConversation

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -500,9 +500,41 @@ type ConversationAPI =
                :> ConversationVerb 'V6 GroupConvTypeLegacy (CreateGroupOwnConversation GroupConvTypeLegacy)
            )
     :<|> Named
-           "create-group-conversation"
+           "create-group-conversation@v15"
            ( Summary "Create a new conversation"
                :> From 'V10
+               :> Until 'V16
+               :> CanThrow 'ConvAccessDenied
+               :> CanThrow 'MLSNonEmptyMemberList
+               :> CanThrow 'MLSNotEnabled
+               :> CanThrow 'NotConnected
+               :> CanThrow 'NotATeamMember
+               :> CanThrow OperationDenied
+               :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
+               :> CanThrow 'NotAnMlsConversation
+               :> CanThrow 'ChannelsNotEnabled
+               :> CanThrow 'HistoryNotSupported
+               :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
+               :> ZLocalUser
+               :> ZOptConn
+               :> "conversations"
+               :> ReqBody '[Servant.JSON] NewConv
+               :> MultiVerb
+                    'POST
+                    '[JSON]
+                    '[ WithHeaders
+                         ConversationHeaders
+                         (CreateGroupConversation GroupConvTypeLegacy)
+                         (Respond 201 "Conversation created" (CreateGroupConversation GroupConvTypeLegacy))
+                     ]
+                    (CreateGroupConversation GroupConvTypeLegacy)
+           )
+    :<|> Named
+           "create-group-conversation"
+           ( Summary "Create a new conversation"
+               :> From 'V16
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'MLSNonEmptyMemberList
                :> CanThrow 'MLSNotEnabled

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -51,6 +51,7 @@ conversationAPI =
     <@> mkNamedAPI @"create-group-conversation@v3" (\lusr conn nc -> toLegacyOwnConversation <$$> createLegacyGroupConversation lusr conn nc)
     <@> mkNamedAPI @"create-group-conversation@v5" (\lusr conn nc -> toLegacyCGRV9 <$> createGroupOwnConversation lusr conn nc)
     <@> mkNamedAPI @"create-group-conversation@v9" (\lusr conn nc -> toLegacyCGRV9 <$> createGroupOwnConversation lusr conn nc)
+    <@> mkNamedAPI @"create-group-conversation@v15" (\lusr conn nc -> toLegacyCreateGroupConversation <$> createGroupConversation lusr conn nc)
     <@> mkNamedAPI @"create-group-conversation" createGroupConversation
     <@> mkNamedAPI @"create-self-conversation@v2" (\lusr -> toLegacyOwnConversation <$$> createProteusSelfConversation lusr)
     <@> mkNamedAPI @"create-self-conversation@v5" (\lusr -> toLegacyOwnConversation <$$> createProteusSelfConversation lusr)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-26626

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html) 