### PR TITLE
integration: Move test to target push to a specific client from gundeck-integration

### DIFF
--- a/integration/test/Test/Notifications.hs
+++ b/integration/test/Test/Notifications.hs
@@ -193,3 +193,32 @@ testGetServerTime = do
       r.status `shouldMatchInt` 200
       r.json %. "time" & asString
   void $ assertJust ("expected ISO 8601 format, but got: " <> formattedTimestampStr) $ iso8601ParseM @Maybe @UTCTime formattedTimestampStr
+
+testTargetClientPush :: (HasCallStack) => App ()
+testTargetClientPush = do
+  user <- randomUserId OwnDomain
+  userId <- user %. "id" & asString
+  cid1 <- randomClientId
+  connId1 <- randomConnId
+  cid2 <- randomClientId
+  connId2 <- randomConnId
+  let push c =
+        object
+          [ "recipients"
+              .= [ object
+                     [ "user_id" .= userId,
+                       "route" .= "any",
+                       "clients" .= [c]
+                     ]
+                 ],
+            "payload" .= [object ["client" .= c]]
+          ]
+  withWebSockets [(user, connId1, cid1), (user, connId2, cid2)] $ \[ws1, ws2] -> do
+    postPush user [push cid1, push cid2] >>= assertSuccess
+    forConcurrently_ [(cid1, ws1), (cid2, ws2)] $ \(cid, ws) -> do
+      ev <- awaitAnyEvent 2 ws
+      ev %. "payload" `shouldMatch` [object ["client" .= cid]]
+      assertNoEvent 2 ws
+      -- Also check the notification stream
+      lastNotif <- getLastNotification user def {client = Just cid} >>= getJSON 200
+      lastNotif %. "payload" `shouldMatch` [object ["client" .= cid]]

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -77,7 +77,6 @@ tests s =
           test s "Single user push" singleUserPush,
           test s "Single user push with large message" singleUserPushLargeMessage,
           test s "Send a push, ensure origin does not receive it" sendSingleUserNoPiggyback,
-          test s "Targeted push by client" targetClientPush,
           test s "Store notifications even when redis is down" storeNotificationsEvenWhenRedisIsDown
         ],
       testGroup
@@ -269,45 +268,6 @@ sendMultipleUsers = do
     pload = NonEmpty.singleton pevent
     pevent = KeyMap.fromList ["foo" .= (42 :: Int)]
     push u us = newPush (Just u) (toRecipients us) pload & pushOriginConnection ?~ ConnId "dev"
-
-targetClientPush :: TestM ()
-targetClientPush = do
-  ca <- view tsCannon
-  uid <- randomId
-  cid1 <- randomClientId
-  cid2 <- randomClientId
-  let ca1 = CannonR (runCannonR ca . queryItem "client" (toByteString' cid1))
-  let ca2 = CannonR (runCannonR ca . queryItem "client" (toByteString' cid2))
-  c1 <- connectUser ca1 uid =<< randomConnId
-  c2 <- connectUser ca2 uid =<< randomConnId
-  -- Push only to the first client
-  sendPush (push uid cid1)
-  liftIO $ do
-    e1 <- waitForMessage c1
-    e2 <- waitForMessage c2
-    assertBool "No push message received" (isJust e1)
-    assertBool "Unexpected push message received" (isNothing e2)
-  -- Push only to the second client
-  sendPush (push uid cid2)
-  liftIO $ do
-    e1 <- waitForMessage c1
-    e2 <- waitForMessage c2
-    assertBool "Unexpected push message received" (isNothing e1)
-    assertBool "No push message received" (isJust e2)
-  -- Check the notification stream
-  ns1 <- listNotifications uid (Just cid1)
-  ns2 <- listNotifications uid (Just cid2)
-  liftIO . forM_ [(ns1, cid1), (ns2, cid2)] $ \(ns, c) -> do
-    assertEqual "Not exactly 1 notification" 1 (length ns)
-    let p = view queuedNotificationPayload (Prelude.head ns)
-    assertEqual "Wrong events in notification" (pload c) p
-  where
-    pevent c = KeyMap.fromList ["foo" .= clientToText c]
-    pload c = NonEmpty.singleton $ pevent c
-    rcpt u c =
-      recipient u RouteAny
-        & recipientClients .~ RecipientClientsSome (NonEmpty.singleton c)
-    push u c = newPush (Just u) (Set.singleton (rcpt u c)) (pload c)
 
 storeNotificationsEvenWhenRedisIsDown :: TestM ()
 storeNotificationsEvenWhenRedisIsDown = do


### PR DESCRIPTION
The test in gundeck-integration is flaky.

https://wearezeta.atlassian.net/browse/WPB-26766

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
