### PR TITLE
fix(meetings): grant InviteAccess on meeting conversations for MLS adds

### DIFF
--- a/changelog.d/3-bug-fixes/meeting-conversation-invite-access
+++ b/changelog.d/3-bug-fixes/meeting-conversation-invite-access
@@ -1,0 +1,4 @@
+Fix MLS participant adds on meeting conversations by granting `InviteAccess`
+alongside `PrivateAccess` when creating the underlying conversation. Without
+`InviteAccess`, Galley rejects member joins after MLS commits with 403
+`access-denied`.

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -9,6 +9,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock
 import qualified Data.Time.Format as Time
+import MLS.Util
 import SetupHelpers
 import System.Timeout (timeout)
 import Testlib.Prelude
@@ -56,6 +57,37 @@ testMeetingCreate = do
 
   fetchedMeeting <- getJSON 200 r2
   fetchedMeeting %. "title" `shouldMatch` ("Team Standup" :: String)
+
+-- Regression: meeting conversations must grant InviteAccess so that MLS
+-- commits adding participants succeed. Without InviteAccess, Galley rejects
+-- the join in performConversationJoin (ensureAccess conv InviteAccess) with
+-- 403 access-denied.
+testMeetingMLSAddParticipant :: (HasCallStack) => App ()
+testMeetingMLSAddParticipant = do
+  (alice, _tid, [bob]) <- createTeam OwnDomain 2
+  alice1 <- createMLSClient def alice
+  bob1 <- createMLSClient def bob
+  _ <- uploadNewKeyPackage def bob1
+  now <- liftIO getCurrentTime
+  let startTime = addUTCTime 3600 now
+      endTime = addUTCTime 7200 now
+      newMeeting = defaultMeetingJson "MLS Meeting" startTime endTime []
+
+  meeting <- postMeetings alice newMeeting >>= getJSON 201
+  convQid <- meeting %. "qualified_conversation"
+
+  conv <- getConversation alice convQid >>= getJSON 200
+  convId <- objConvId conv
+  createGroup def alice1 convId
+
+  -- Before the fix, this add commit fails with 403 access-denied at the
+  -- server (getJSON 201 below throws). After the fix it succeeds.
+  void $ createAddCommit alice1 convId [bob] >>= sendAndConsumeCommitBundle
+
+  bindResponse (getConversation alice convQid) $ \res -> do
+    res.status `shouldMatchInt` 200
+    (length <$> (res.json %. "members.others" & asList)) `shouldMatchInt` 1
+    res.json %. "members.others.0.qualified_id" `shouldMatch` objQidObject bob
 
 testMeetingGetNotFound :: (HasCallStack) => App ()
 testMeetingGetNotFound = do

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -130,7 +130,9 @@ createMeetingImpl zUser newMeeting = do
           { newConvUsers = [],
             newConvQualifiedUsers = [],
             newConvName = Just newMeeting.title,
-            newConvAccess = Set.singleton PrivateAccess,
+            -- InviteAccess is required so MLS commits can add participants via
+            -- performConversationJoin (ensureAccess conv InviteAccess).
+            newConvAccess = Set.fromList [PrivateAccess, InviteAccess],
             newConvAccessRoles = Nothing,
             newConvTeam = ConvTeamInfo <$> conversationTeamId,
             newConvMessageTimer = Nothing,

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -56,7 +56,6 @@ import Wire.MockInterpreters
 import Wire.Sem.Now (Now)
 import Wire.Sem.Random (Random)
 import Wire.StoredConversation
-import Wire.StoredConversation (convAccess)
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem.GalleyAPI
 

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -39,6 +39,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (counterexample, ioProperty, (.&&.), (===), (==>))
 import Text.Email.Parser (unsafeEmailAddress)
+import Wire.API.Conversation (Access (InviteAccess, PrivateAccess))
 import Wire.API.Error (ErrorS)
 import Wire.API.Error.Galley (GalleyError (TeamMemberNotFound, TeamNotFound))
 import Wire.API.Meeting qualified as API
@@ -55,6 +56,7 @@ import Wire.MockInterpreters
 import Wire.Sem.Now (Now)
 import Wire.Sem.Random (Random)
 import Wire.StoredConversation
+import Wire.StoredConversation (convAccess)
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem.GalleyAPI
 
@@ -149,6 +151,30 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       Right (meeting, fetched) -> do
         meeting.title `shouldBe` fromJust (checked "Test Meeting")
         fetched `shouldBe` Just meeting
+
+  it "creates meeting conversation with invite access for MLS participant adds" $ do
+    let now = UTCTime (fromGregorian 2026 1 1) 0
+        gen = mkStdGen 42
+        uid = Id $ read "00000000-0000-0000-0000-000000000001"
+        zUser = toLocalUnsafe (Domain "wire.com") uid
+        newMeeting =
+          API.NewMeeting
+            { title = fromJust $ checked "Access Meeting",
+              startTime = addUTCTime 3600 now,
+              endTime = addUTCTime 7200 now,
+              recurrence = Nothing,
+              invitedEmails = []
+            }
+
+    result <- runTestStack now gen Map.empty def $ do
+      (_meeting, conv) <- createMeeting zUser newMeeting
+      pure (convAccess conv)
+
+    case result of
+      Left err -> fail $ "Error: " <> show err
+      Right access -> do
+        PrivateAccess `elem` access `shouldBe` True
+        InviteAccess `elem` access `shouldBe` True
 
   it "fails to create a meeting if end time is before start time" $ do
     let now = UTCTime (fromGregorian 2026 1 1) 0

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ConversationSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ConversationSubsystem.hs
@@ -55,7 +55,7 @@ inMemoryConversationSubsystemInterpreter = interpretH $ \case
                 Public.ConversationMetadata
                   { cnvmType = Public.RegularConv,
                     cnvmCreator = Just (tUnqualified lusr),
-                    cnvmAccess = [],
+                    cnvmAccess = Set.toList newConv.newConvAccess,
                     cnvmAccessRoles = def,
                     cnvmName = fromRange <$> newConv.newConvName,
                     cnvmMessageTimer = newConv.newConvMessageTimer,


### PR DESCRIPTION
Meeting conversations were created with PrivateAccess only. Galley requires InviteAccess in performConversationJoin, so MLS commits that add participants returned 403 access-denied after creator-only establish succeeded.

Keep PrivateAccess and add InviteAccess, matching other private group convs.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
