### PR TITLE
spar-integration: retry transient 5xx on client delete in re-auth test

### DIFF
--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1669,22 +1669,25 @@ specReAuthSsoUserWithPassword =
           newClientVerificationCode = Nothing
         }
 
-    deleteClient :: (MonadIO m, MonadReader TestEnv m) => BrigReq -> UserId -> ClientId -> Maybe Text -> Int -> m ()
-    deleteClient brig u c pw expectedStatus =
-      void $
-        call $
-          delete $
-            brig
-              . paths ["clients", toByteString' c]
-              . zUser u
-              . zConn "conn"
-              . contentJson
-              . body payload
-              . expectStatus ((==) expectedStatus)
+    deleteClient :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => BrigReq -> UserId -> ClientId -> Maybe Text -> Int -> m ()
+    deleteClient brig u c pw expectedStatus = do
+      resp <-
+        retryNUntil transientRetries (\r -> statusCode r `notElem` transientStatuses) $
+          call $
+            delete $
+              brig
+                . paths ["clients", toByteString' c]
+                . zUser u
+                . zConn "conn"
+                . contentJson
+                . body payload
+      liftIO $ statusCode resp `shouldBe` expectedStatus
       where
         payload =
           RequestBodyLBS . encode . object . maybeToList $
             fmap ("password" .=) pw
+        transientStatuses = [500, 502, 503, 504]
+        transientRetries = 10
 
 ----------------------------------------------------------------------
 -- tests for bsi audit


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
