### PR TITLE
integration: fix flaky testTeamAdminCanReplaceMembers await timeout

### DIFF
--- a/integration/test/Test/Channels.hs
+++ b/integration/test/Test/Channels.hs
@@ -24,6 +24,7 @@ import API.Common (randomName)
 import API.Galley
 import API.GalleyInternal hiding (getConversation, setTeamFeatureConfig)
 import qualified API.GalleyInternal as I
+import Control.Monad.Reader (local)
 import GHC.Stack
 import MLS.Util
 import Notifications (isChannelAddPermissionUpdate, isMemberJoinNotif, isWelcomeNotif)
@@ -526,8 +527,11 @@ testTeamAdminCanAddMembersWithoutJoining = do
       selfQid <- self %. "qualified_id"
       filterM (\m -> (/= selfQid) <$> (m %. "qualified_id")) allUsers
 
+setTimeoutTo :: Int -> Env -> Env
+setTimeoutTo tSecs env = env {timeOutSeconds = tSecs}
+
 testTeamAdminCanReplaceMembers :: (HasCallStack) => App ()
-testTeamAdminCanReplaceMembers = do
+testTeamAdminCanReplaceMembers = local (setTimeoutTo 30) do
   (alice, tid, bob : charlie : dylan : emil : fred : guenter : horst : ilona : _) <- createTeam OwnDomain 9
   [bobId, charlieId, dylanId, emilId, fredId, guenterId, horstId, ilonaId] <-
     for [bob, charlie, dylan, emil, fred, guenter, horst, ilona] (%. "id")


### PR DESCRIPTION


## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
