### PR TITLE
make multi-ingress domains case agnostic

### DIFF
--- a/changelog.d/5-internal/zhost-domain
+++ b/changelog.d/5-internal/zhost-domain
@@ -1,0 +1,4 @@
+The `Z-Host` header has been treated as domain, but used as `Text`.
+De-serializing and thus using it as `Domain` increases type-safety and ensures
+domain related semantics; e.g. case insensitivity in equality checks.
+This solves a `FUTUREWORK` remark which was around for quite some time.

--- a/integration/test/Test/Migration/ConversationCodes.hs
+++ b/integration/test/Test/Migration/ConversationCodes.hs
@@ -10,10 +10,11 @@ import Test.Migration.Util (waitForMigration)
 import Testlib.Prelude
 import Testlib.ResourcePool
 
-testConversationCodesMigration :: (HasCallStack) => TaggedBool "has-password" -> App ()
-testConversationCodesMigration (TaggedBool hasPassword) = do
+testConversationCodesMigration :: (HasCallStack) => TaggedBool "has-password" -> TaggedBool "with-zHost" -> App ()
+testConversationCodesMigration (TaggedBool hasPassword) (TaggedBool withZhost) = do
   resourcePool <- asks (.resourcePool)
   let pw = if hasPassword then Just "funky password" else Nothing
+      mbZHost = if withZhost then Just "zhost.example.com" else Nothing
 
   runCodensity (acquireResources 1 resourcePool) $ \[backend] -> do
     let domain = backend.berDomain
@@ -34,10 +35,10 @@ testConversationCodesMigration (TaggedBool hasPassword) = do
       code2 <- genCode admin conv2 pw
       codeB <- genCode admin convB pw
       -- joining works
-      checkJoinAndGet admin m1 conv1 code1 pw
-      checkJoinAndGet admin m1 conv2 code2 pw
+      checkJoinAndGet admin m1 conv1 code1 mbZHost
+      checkJoinAndGet admin m1 conv2 code2 mbZHost
       -- deletion works
-      checkDelete admin m1 convA codeA pw
+      checkDelete admin m1 convA codeA mbZHost
       pure (code2, codeB)
 
     (code3, codeC) <- runCodensity (startDynamicBackend backend (conf "migration-to-postgresql" True)) $ \_ -> do
@@ -45,12 +46,12 @@ testConversationCodesMigration (TaggedBool hasPassword) = do
       code3 <- genCode admin conv3 pw
       codeC <- genCode admin convC pw
       -- joining works
-      checkJoinAndGet admin m2 conv1 code1 pw
-      checkJoinAndGet admin m2 conv2 code2 pw
-      checkJoinAndGet admin m2 conv3 code3 pw
+      checkJoinAndGet admin m2 conv1 code1 mbZHost
+      checkJoinAndGet admin m2 conv2 code2 mbZHost
+      checkJoinAndGet admin m2 conv3 code3 mbZHost
       -- deletion works
-      checkNoCode admin m1 convA codeA pw
-      checkDelete admin m1 convB codeB pw
+      checkNoCode admin m1 convA codeA mbZHost
+      checkDelete admin m1 convB codeB mbZHost
       waitForMigration domain counterName
       pure (code3, codeC)
 
@@ -59,40 +60,40 @@ testConversationCodesMigration (TaggedBool hasPassword) = do
       code4 <- genCode admin conv4 pw
       codeD <- genCode admin convD pw
       -- joining works
-      checkJoinAndGet admin m3 conv1 code1 pw
-      checkJoinAndGet admin m3 conv2 code2 pw
-      checkJoinAndGet admin m3 conv3 code3 pw
-      checkJoinAndGet admin m3 conv4 code4 pw
+      checkJoinAndGet admin m3 conv1 code1 mbZHost
+      checkJoinAndGet admin m3 conv2 code2 mbZHost
+      checkJoinAndGet admin m3 conv3 code3 mbZHost
+      checkJoinAndGet admin m3 conv4 code4 mbZHost
       -- deletion works
-      checkNoCode admin m1 convA codeA pw
-      checkNoCode admin m1 convB codeB pw
-      checkDelete admin m1 convC codeC pw
+      checkNoCode admin m1 convA codeA mbZHost
+      checkNoCode admin m1 convB codeB mbZHost
+      checkDelete admin m1 convC codeC mbZHost
       pure (code4, codeD)
 
     runCodensity (startDynamicBackend backend (conf "postgresql" False)) $ \_ -> do
       -- code generation works
       code5 <- genCode admin conv5 pw
       -- joining works
-      checkJoinAndGet admin m4 conv1 code1 pw
-      checkJoinAndGet admin m4 conv2 code2 pw
-      checkJoinAndGet admin m4 conv3 code3 pw
-      checkJoinAndGet admin m4 conv4 code4 pw
-      checkJoinAndGet admin m4 conv5 code5 pw
+      checkJoinAndGet admin m4 conv1 code1 mbZHost
+      checkJoinAndGet admin m4 conv2 code2 mbZHost
+      checkJoinAndGet admin m4 conv3 code3 mbZHost
+      checkJoinAndGet admin m4 conv4 code4 mbZHost
+      checkJoinAndGet admin m4 conv5 code5 mbZHost
       -- deletion works
-      checkNoCode admin m1 convA codeA pw
-      checkNoCode admin m1 convB codeB pw
-      checkNoCode admin m1 convC codeC pw
-      checkDelete admin m1 convD codeD pw
-      checkDelete admin m1 conv5 code5 pw
+      checkNoCode admin m1 convA codeA mbZHost
+      checkNoCode admin m1 convB codeB mbZHost
+      checkNoCode admin m1 convC codeC mbZHost
+      checkDelete admin m1 convD codeD mbZHost
+      checkDelete admin m1 conv5 code5 mbZHost
   where
-    checkJoinAndGet admin user conv code pw = do
+    checkJoinAndGet admin user conv code mbZHost = do
       joinWithCode user conv code
-      getCode admin conv pw `shouldMatch` code
-    checkDelete admin user conv (k, v) pw = do
+      getCode admin conv mbZHost `shouldMatch` code
+    checkDelete admin user conv (k, v) mbZHost = do
       assertSuccess =<< deleteConversationCode admin conv
-      checkNoCode admin user conv (k, v) pw
-    checkNoCode admin user conv (k, v) pw = do
-      assertStatus 404 =<< getConversationCode admin conv pw
+      checkNoCode admin user conv (k, v) mbZHost
+    checkNoCode admin user conv (k, v) mbZHost = do
+      assertStatus 404 =<< getConversationCode admin conv mbZHost
       bindResponse (getJoinCodeConv user k v) $ \res -> do
         res.status `shouldMatchInt` 404
         res.json %. "label" `shouldMatch` "no-conversation-code"
@@ -145,21 +146,21 @@ genCode user conv pw =
     pure (k, v)
 
 getCode :: (HasCallStack, MakesValue user, MakesValue conv) => user -> conv -> Maybe String -> App (String, String)
-getCode user conv pw =
-  bindResponse (getConversationCode user conv pw) $ \res -> do
+getCode user conv mbZHost =
+  bindResponse (getConversationCode user conv mbZHost) $ \res -> do
     payload <- getJSON 200 res
     k <- payload %. "key" & asString
     v <- payload %. "code" & asString
     pure (k, v)
 
 waitForCodeToExpire :: (MakesValue user, MakesValue conv) => user -> conv -> Maybe String -> App ()
-waitForCodeToExpire user conv pw = do
-  res <- getConversationCode user conv pw
+waitForCodeToExpire user conv mbZHost = do
+  res <- getConversationCode user conv mbZHost
   if res.status == 404
     then pure ()
     else do
       liftIO $ threadDelay 100_000
-      waitForCodeToExpire user conv pw
+      waitForCodeToExpire user conv mbZHost
 
 joinWithCode :: (HasCallStack, MakesValue user) => user -> Value -> (String, String) -> App ()
 joinWithCode user conv (k, v) =

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -132,6 +132,9 @@ instance Arbitrary Domain where
   arbitrary =
     either (error . ("arbitrary @Domain: " <>)) id . mkDomain . getDomainText <$> arbitrary
 
+instance QC.CoArbitrary Domain where
+  coarbitrary d = QC.coarbitrary (Text.unpack (domainText d))
+
 -- | only for QuickCheck
 newtype DomainText = DomainText {getDomainText :: Text}
   deriving (Eq, Show)

--- a/libs/wire-api/src/Wire/API/Routes/Public.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public.hs
@@ -227,7 +227,7 @@ instance (HasLink api) => HasLink (ZHostOpt :> api) where
   type MkLink (ZHostOpt :> api) a = MkLink api a
   toLink toA _ = toLink toA (Proxy :: Proxy api)
 
-type ZHostValue = Text -- FUTUREWORK: use Data.Domain.Domain here instead of Text?
+type ZHostValue = Domain
 
 type ZOptHostHeader =
   Header' '[Servant.Optional, Strict] "Z-Host" ZHostValue
@@ -281,7 +281,7 @@ instance
   ) =>
   HasServer (ZHostOpt :> api) ctx
   where
-  type ServerT (ZHostOpt :> api) m = Maybe Text -> ServerT api m
+  type ServerT (ZHostOpt :> api) m = Maybe ZHostValue -> ServerT api m
   route ::
     Proxy (ZHostOpt :> api) ->
     Context ctx ->

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/IdP.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/IdP.hs
@@ -1,5 +1,6 @@
 module Test.Wire.API.Golden.Manual.IdP where
 
+import Data.Domain (Domain (..))
 import Data.Id
 import Data.List.NonEmpty
 import Data.UUID
@@ -114,7 +115,7 @@ testObject_IdP_1 =
               ],
             _replacedBy = Just (IdPId {fromIdPId = (fromJust . Data.UUID.fromString) "fc5f3bf8-c296-69e7-27fd-70d483740fe4"}),
             _handle = IdPHandle {unIdPHandle = "614c0bb0-1b33-98b6-8600-a1b290bbe1d7"},
-            _domain = Just "wire.com"
+            _domain = Just (Domain "wire.com")
           }
     }
 

--- a/libs/wire-subsystems/src/Wire/CodeStore.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore.hs
@@ -20,6 +20,7 @@
 module Wire.CodeStore where
 
 import Data.Code
+import Data.Domain (Domain)
 import Data.Misc
 import Imports
 import Polysemy
@@ -32,6 +33,6 @@ data CodeStore m a where
   DeleteCode :: Key -> CodeStore m ()
   MakeKey :: CodeReferent -> CodeStore m Key
   GenerateCode :: CodeReferent -> Timeout -> CodeStore m Code
-  GetConversationCodeURI :: Maybe Text -> CodeStore m (Maybe HttpsUrl)
+  GetConversationCodeURI :: Maybe Domain -> CodeStore m (Maybe HttpsUrl)
 
 makeSem ''CodeStore

--- a/libs/wire-subsystems/src/Wire/CodeStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Cassandra.hs
@@ -22,7 +22,7 @@ where
 
 import Cassandra
 import Data.Code
-import Data.Domain (domainText)
+import Data.Domain (Domain)
 import Data.Id
 import Data.Map qualified as Map
 import Data.Misc (HttpsUrl)
@@ -40,7 +40,7 @@ import Wire.Util (embedClientInput)
 interpretCodeStoreToCassandra ::
   ( Member (Embed IO) r,
     Member (Input ClientState) r,
-    Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r,
+    Member (Input (Either HttpsUrl (Map Domain HttpsUrl))) r,
     Member (ErrorS 'CodeStoreNotFound) r
   ) =>
   Sem (CodeStore ': r) a ->
@@ -61,7 +61,7 @@ interpretCodeStoreToCassandra = interpret $ \case
       Left uri -> pure (Just uri)
       Right map' ->
         case mbHost of
-          Just host -> pure (Map.lookup (domainText host) map')
+          Just host -> pure (Map.lookup host map')
           Nothing -> pure Nothing
 
 -- | Insert a conversation code

--- a/libs/wire-subsystems/src/Wire/CodeStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Cassandra.hs
@@ -22,6 +22,7 @@ where
 
 import Cassandra
 import Data.Code
+import Data.Domain (domainText)
 import Data.Id
 import Data.Map qualified as Map
 import Data.Misc (HttpsUrl)
@@ -60,7 +61,7 @@ interpretCodeStoreToCassandra = interpret $ \case
       Left uri -> pure (Just uri)
       Right map' ->
         case mbHost of
-          Just host -> pure (Map.lookup host map')
+          Just host -> pure (Map.lookup (domainText host) map')
           Nothing -> pure Nothing
 
 -- | Insert a conversation code

--- a/libs/wire-subsystems/src/Wire/CodeStore/DualWrite.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/DualWrite.hs
@@ -21,6 +21,7 @@ module Wire.CodeStore.DualWrite
 where
 
 import Cassandra (ClientState)
+import Data.Domain (Domain)
 import Data.Misc
 import Imports
 import Polysemy
@@ -37,7 +38,7 @@ import Wire.Postgres (PGConstraints)
 -- | Cassandra is the source of truth during migration; writes are mirrored to Postgres.
 interpretCodeStoreToCassandraAndPostgres ::
   ( Member (Input ClientState) r,
-    Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r,
+    Member (Input (Either HttpsUrl (Map Domain HttpsUrl))) r,
     Member (ErrorS 'CodeStoreNotFound) r,
     PGConstraints r
   ) =>

--- a/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
@@ -23,6 +23,7 @@ import Data.Code (Key, Value)
 import Data.Conduit
 import Data.Conduit.List qualified as C
 import Data.IORef qualified as IORef
+import Data.Domain (Domain)
 import Data.Id (ConvId)
 import Data.Misc (HttpsUrl)
 import Data.Text qualified as T
@@ -55,7 +56,7 @@ type EffectStack =
   [ State Int,
     Input ClientState,
     Input Hasql.Pool,
-    Input (Either HttpsUrl (Map Text HttpsUrl)),
+    Input (Either HttpsUrl (Map Domain HttpsUrl)),
     Resource,
     Async,
     Race,
@@ -100,7 +101,7 @@ interpreter cassClient pgPool logger name =
 
 migrateAllCodes ::
   ( Member (Input Hasql.Pool) r,
-    Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r,
+    Member (Input (Either HttpsUrl (Map Domain HttpsUrl))) r,
     Member (Embed IO) r,
     Member (Input ClientState) r,
     Member TinyLog r,
@@ -119,7 +120,7 @@ migrateAllCodes migOpts migCounter migDuration = do
     .| C.mapM_ (traverse_ (\row@(key, _, _, _, _) -> handleErrors (toByteString' key) (migrateCodeRow migOpts migCounter migDuration row)))
 
 migrateCodeRow ::
-  ( Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r,
+  ( Member (Input (Either HttpsUrl (Map Domain HttpsUrl))) r,
     PGConstraints r,
     Member TinyLog r,
     Member Resource r,

--- a/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Migration.hs
@@ -22,8 +22,8 @@ import Data.ByteString.Conversion
 import Data.Code (Key, Value)
 import Data.Conduit
 import Data.Conduit.List qualified as C
-import Data.IORef qualified as IORef
 import Data.Domain (Domain)
+import Data.IORef qualified as IORef
 import Data.Id (ConvId)
 import Data.Misc (HttpsUrl)
 import Data.Text qualified as T

--- a/libs/wire-subsystems/src/Wire/CodeStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Postgres.hs
@@ -21,6 +21,7 @@ module Wire.CodeStore.Postgres
 where
 
 import Data.Code
+import Data.Domain (domainText)
 import Data.Id
 import Data.Map qualified as Map
 import Data.Misc (HttpsUrl)
@@ -57,7 +58,7 @@ interpretCodeStoreToPostgres = interpret $ \case
     convCodeURI <- input
     pure $ case convCodeURI of
       Left uri -> Just uri
-      Right map' -> mbHost >>= flip Map.lookup map'
+      Right map' -> (domainText <$> mbHost) >>= flip Map.lookup map'
 
 insertCode :: (PGConstraints r) => Code -> Maybe Password -> Sem r ()
 insertCode c password = do

--- a/libs/wire-subsystems/src/Wire/CodeStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/CodeStore/Postgres.hs
@@ -21,7 +21,7 @@ module Wire.CodeStore.Postgres
 where
 
 import Data.Code
-import Data.Domain (domainText)
+import Data.Domain (Domain)
 import Data.Id
 import Data.Map qualified as Map
 import Data.Misc (HttpsUrl)
@@ -39,7 +39,7 @@ import Wire.Postgres
 
 interpretCodeStoreToPostgres ::
   ( PGConstraints r,
-    Member (Input (Either HttpsUrl (Map Text HttpsUrl))) r
+    Member (Input (Either HttpsUrl (Map Domain HttpsUrl))) r
   ) =>
   Sem (CodeStore ': r) a ->
   Sem r a
@@ -58,7 +58,7 @@ interpretCodeStoreToPostgres = interpret $ \case
     convCodeURI <- input
     pure $ case convCodeURI of
       Left uri -> Just uri
-      Right map' -> (domainText <$> mbHost) >>= flip Map.lookup map'
+      Right map' -> mbHost >>= flip Map.lookup map'
 
 insertCode :: (PGConstraints r) => Code -> Maybe Password -> Sem r ()
 insertCode c password = do

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
@@ -449,7 +449,7 @@ data ConversationSubsystem m a where
     ConvId ->
     ConversationSubsystem m (LockableFeature GuestLinksConfig)
   GetCode ::
-    Maybe Text ->
+    Maybe ZHostValue ->
     Local UserId ->
     ConvId ->
     ConversationSubsystem m ConversationCodeInfo

--- a/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/IdPSubsystem/Interpreter.hs
@@ -16,6 +16,7 @@ import Polysemy
 import Polysemy.Error
 import SAML2.WebSSO qualified as SAML
 import System.Logger.Message qualified as Log
+import Wire.API.Routes.Public (ZHostValue)
 import Wire.API.User
 import Wire.API.User.IdentityProvider qualified as IP
 import Wire.BrigAPIAccess
@@ -82,7 +83,7 @@ getSsoCodeByEmailImpl ::
     Member GalleyAPIAccess r,
     Member IdPConfigStore r
   ) =>
-  Bool -> Maybe Text -> EmailAddress -> Sem r (Maybe SAML.IdPId)
+  Bool -> Maybe ZHostValue -> EmailAddress -> Sem r (Maybe SAML.IdPId)
 getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
   do
     if not enableIdPByEmailDiscovery
@@ -124,6 +125,6 @@ getSsoCodeByEmailImpl enableIdPByEmailDiscovery mbHost email =
       when (length matches > 1) $
         Logger.warn $
           Log.msg @Text "Found more than one IdP config for domain"
-            . Log.field "domain" (fromMaybe "None" mbHost)
+            . Log.field "domain" (maybe "None" domainText mbHost)
             . Log.field "idpIds" (intercalate "," $ (UUID.toString . SAML.fromIdPId) <$> matches)
       pure $ listToMaybe matches

--- a/libs/wire-subsystems/src/Wire/Options/Galley.hs
+++ b/libs/wire-subsystems/src/Wire/Options/Galley.hs
@@ -138,7 +138,7 @@ data Settings = Settings
     --
     -- multiIngress and conversationCodeURI are mutually exclusive. One of
     -- both options need to be configured.
-    _multiIngress :: Maybe (Map Text HttpsUrl),
+    _multiIngress :: Maybe (Map Domain HttpsUrl),
     -- | Throttling: limits to concurrent deletion events
     _concurrentDeletionEvents :: !(Maybe Int),
     -- | Throttling: delay between sending events upon team deletion
@@ -243,7 +243,7 @@ deriveFromJSON toOptionFieldName ''Opts
 
 makeLenses ''Opts
 
-conversationCodeURISettings :: (Applicative m) => Opts -> m (Either HttpsUrl (Map Text HttpsUrl))
+conversationCodeURISettings :: (Applicative m) => Opts -> m (Either HttpsUrl (Map Domain HttpsUrl))
 conversationCodeURISettings opts =
   case (opts._settings._conversationCodeURI, opts._settings._multiIngress) of
     (Nothing, Nothing) -> error errMsg

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -108,7 +108,7 @@ data Env = Env
     guestLinkTTLSeconds :: !(Maybe GuestLinkTTLSeconds),
     passwordHashingOptions :: !PasswordHashingOptions,
     checkGroupInfo :: !(Maybe Bool),
-    convCodeURI :: Either HttpsUrl (Map Text HttpsUrl),
+    convCodeURI :: Either HttpsUrl (Map Domain HttpsUrl),
     passwordHashingRateLimitEnv :: RateLimitEnv
   }
 

--- a/services/background-worker/src/Wire/Effects.hs
+++ b/services/background-worker/src/Wire/Effects.hs
@@ -27,6 +27,7 @@ import Control.Monad.Catch
 import Control.Retry
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Domain (Domain)
 import Data.Id
 import Data.Misc
 import Data.Qualified
@@ -222,7 +223,7 @@ type BackgroundWorkerEffects =
      Input (Maybe GuestLinkTTLSeconds),
      Input (Maybe GroupInfoCheckEnabled),
      Input IntraListing,
-     Input (Either HttpsUrl (Map Text HttpsUrl)),
+     Input (Either HttpsUrl (Map Domain HttpsUrl)),
      Input ExposeInvitationURLsAllowlist,
      Input LegalHoldEnv,
      Input ClientState,
@@ -307,7 +308,7 @@ runBackgroundWorkerEffects env extEnv requestId mJobId =
     . runInputConst @ClientState env.cassandraGalley
     . runInputConst @LegalHoldEnv legalHoldEnv
     . runInputConst @ExposeInvitationURLsAllowlist (ExposeInvitationURLsAllowlist $ fromMaybe [] env.exposeInvitationURLsTeamAllowlist)
-    . runInputConst @(Either HttpsUrl (Map Text HttpsUrl)) env.convCodeURI
+    . runInputConst @(Either HttpsUrl (Map Domain HttpsUrl)) env.convCodeURI
     . runInputConst @IntraListing (IntraListing env.intraListing)
     . runInputConst @(Maybe GroupInfoCheckEnabled) (GroupInfoCheckEnabled <$> env.checkGroupInfo)
     . runInputConst @(Maybe GuestLinkTTLSeconds) env.guestLinkTTLSeconds

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -30,7 +30,7 @@ import Control.Monad.Trans.Except (throwE)
 import Data.ByteString.Builder
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
-import Data.Domain
+import Data.Domain (domainText)
 import Data.Id
 import Data.Kind
 import Data.Qualified
@@ -45,6 +45,7 @@ import Wire.API.Asset
 import Wire.API.Routes.AssetBody
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Named
+import Wire.API.Routes.Public (ZHostValue)
 import Wire.API.Routes.Public.Cargohold
 import Wire.API.User (AccountStatus (..), User (userStatus, userTeam))
 
@@ -192,7 +193,7 @@ downloadAssetV3 ::
   AssetKey ->
   Maybe AssetToken ->
   Maybe AssetToken ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Handler (Maybe (AssetLocation Absolute))
 downloadAssetV3 usr key tok1 tok2 mbHostHeader = do
   AssetLocation <$$> V3.download (mkPrincipal usr) key (tok1 <|> tok2) mbHostHeader
@@ -203,7 +204,7 @@ downloadAssetV4 ::
   Qualified AssetKey ->
   Maybe AssetToken ->
   Maybe AssetToken ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Handler (Maybe LocalOrRemoteAsset)
 downloadAssetV4 usr qkey tok1 tok2 mbHostHeader =
   let tok = tok1 <|> tok2

--- a/services/cargohold/src/CargoHold/API/V3.hs
+++ b/services/cargohold/src/CargoHold/API/V3.hs
@@ -52,6 +52,7 @@ import Data.ByteString.Conversion (toByteString')
 import qualified Data.CaseInsensitive as CI
 import Data.Conduit
 import qualified Data.Conduit.Attoparsec as Conduit
+import Data.Domain (Domain)
 import Data.Id
 import qualified Data.List as List
 import Data.Qualified
@@ -122,13 +123,13 @@ updateToken own key tok = do
 randToken :: (MonadIO m) => m V3.AssetToken
 randToken = liftIO $ V3.AssetToken . Ascii.encodeBase64Url <$> getRandomBytes 16
 
-download :: V3.Principal -> V3.AssetKey -> Maybe V3.AssetToken -> Maybe Text -> Handler (Maybe URI)
+download :: V3.Principal -> V3.AssetKey -> Maybe V3.AssetToken -> Maybe Domain -> Handler (Maybe URI)
 download own key tok mbHost = runMaybeT $ do
   qown <- lift $ qualifyLocal own
   meta <- checkMetadata (tUntagged qown) key tok
   lift $ genSignedURL (Just $ tUntagged qown) (Just meta) (S3.mkKey key) mbHost
 
-downloadUnsafe :: V3.AssetKey -> Maybe Text -> Handler URI
+downloadUnsafe :: V3.AssetKey -> Maybe Domain -> Handler URI
 downloadUnsafe key mbHost = do
   meta <- S3.getMetadataV3 key
   genSignedURL Nothing meta (S3.mkKey key) mbHost

--- a/services/cargohold/src/CargoHold/App.hs
+++ b/services/cargohold/src/CargoHold/App.hs
@@ -57,6 +57,7 @@ import Control.Error (ExceptT, runExceptT)
 import Control.Exception (catch, throwIO)
 import Control.Lens (lensField, lensRules, makeLensesWith, non, (.~), (?~), (^.))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Data.Domain (Domain)
 import Data.Id
 import qualified Data.Map as Map
 import Data.Qualified
@@ -87,7 +88,7 @@ data Env = Env
     requestId :: RequestId,
     options :: Opt.Opts,
     localUnit :: Local (),
-    multiIngress :: Map String AWS.Env
+    multiIngress :: Map Domain AWS.Env
   }
 
 makeLensesWith (lensRules & lensField .~ suffixNamer) ''Env
@@ -103,7 +104,7 @@ newEnv opts = do
   let localDomain = toLocalUnsafe opts.settings.federationDomain ()
   pure $ Env awsEnv logger httpMgr http2Mgr (RequestId defRequestId) opts localDomain multiIngressAWS
   where
-    initMultiIngressAWS :: Logger -> Manager -> IO (Map String AWS.Env)
+    initMultiIngressAWS :: Logger -> Manager -> IO (Map Domain AWS.Env)
     initMultiIngressAWS logger httpMgr =
       Map.fromList
         <$> mapM

--- a/services/cargohold/src/CargoHold/Options.hs
+++ b/services/cargohold/src/CargoHold/Options.hs
@@ -105,7 +105,7 @@ data AWSOpts = AWSOpts
     -- otherwise a 404 is retuned. This option is only useful
     -- in the context of multi-ingress setups where one backend / deployment is
     -- reachable under several domains.
-    multiIngress :: !(Maybe (Map String AWSEndpoint))
+    multiIngress :: !(Maybe (Map Domain AWSEndpoint))
   }
   deriving (Show, Generic)
 

--- a/services/cargohold/src/CargoHold/S3.hs
+++ b/services/cargohold/src/CargoHold/S3.hs
@@ -62,6 +62,7 @@ import Data.ByteString.Lazy (fromStrict)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
 import Data.Conduit.Binary
+import Data.Domain (Domain, domainText)
 import qualified Data.HashMap.Lazy as HML
 import Data.Id
 import Data.Qualified (Qualified)
@@ -273,7 +274,7 @@ updateMetadataV3 (s3Key . mkKey -> key) meta = do
 -- `Map` with the @Z-Host@ header's value as key. Otherwise (the default case
 -- that applies to most deployments), use the default AWS environment; i.e. the
 -- environment with @aws.s3DownloadEndpoint@.
-signedURL :: (ToByteString p) => p -> Maybe Text -> Handler URI
+signedURL :: (ToByteString p) => p -> Maybe Domain -> Handler URI
 signedURL path mbHost = do
   e <- awsEnvForHost
   now <- liftIO getCurrentTime
@@ -299,7 +300,7 @@ signedURL path mbHost = do
         then asks (.aws)
         else awsEnvForHost' mbHost multiIngressConf
       where
-        awsEnvForHost' :: Maybe Text -> Map String AWS.Env -> Handler AWS.Env
+        awsEnvForHost' :: Maybe Domain -> Map Domain AWS.Env -> Handler AWS.Env
         awsEnvForHost' Nothing _ = do
           Log.debug $
             msg (val "awsEnvForHost - multiIngress configured, but no Z-Host header provided.")
@@ -307,19 +308,19 @@ signedURL path mbHost = do
         awsEnvForHost' (Just host) multiIngressConf = do
           Log.debug $
             "host"
-              .= host
+              .= domainText host
               ~~ msg (val "awsEnvForHost - Looking up multiIngress config.")
-          case multiIngressConf ^. at (Text.unpack host) of
+          case multiIngressConf ^. at host of
             Nothing -> do
               Log.debug $
                 "host"
-                  .= host
+                  .= domainText host
                   ~~ msg (val "awsEnvForHost - multiIngress lookup failed, no config for provided Z-Host header.")
               throwE noMatchingAssetEndpoint
             Just hostAwsEnv -> do
               Log.debug $
                 "host"
-                  .= host
+                  .= domainText host
                   ~~ "s3DownloadEndpoint"
                     .= show hostAwsEnv.amazonkaDownloadEndpoint
                   ~~ msg (val "awsEnvForHost - multiIngress lookup succeed, using specific AWS env.")

--- a/services/cargohold/src/CargoHold/Util.hs
+++ b/services/cargohold/src/CargoHold/Util.hs
@@ -26,11 +26,12 @@ import CargoHold.S3 (S3AssetMeta)
 import qualified CargoHold.S3 as S3
 import qualified CargoHold.Types as V3
 import Data.ByteString.Conversion
+import Data.Domain (Domain)
 import Data.Qualified (Qualified)
 import Imports
 import URI.ByteString hiding (urlEncode)
 
-genSignedURL :: (ToByteString p) => Maybe (Qualified V3.Principal) -> Maybe S3AssetMeta -> p -> Maybe Text -> Handler URI
+genSignedURL :: (ToByteString p) => Maybe (Qualified V3.Principal) -> Maybe S3AssetMeta -> p -> Maybe Domain -> Handler URI
 genSignedURL quid mMeta path mbHost = do
   uri <-
     asks (.aws.cloudFront) >>= \case

--- a/services/cargohold/test/integration/App.hs
+++ b/services/cargohold/test/integration/App.hs
@@ -26,7 +26,7 @@ import Control.Exception
 import Control.Lens
 import Data.ByteString.Conversion
 import Data.Domain (mkDomain)
-import qualified Data.Domain as Data.Domain
+import qualified Data.Domain
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import Imports

--- a/services/cargohold/test/integration/App.hs
+++ b/services/cargohold/test/integration/App.hs
@@ -25,6 +25,8 @@ import CargoHold.Options as Opts
 import Control.Exception
 import Control.Lens
 import Data.ByteString.Conversion
+import Data.Domain (mkDomain)
+import qualified Data.Domain as Data.Domain
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import Imports
@@ -68,10 +70,10 @@ testMultiIngressCloudFrontFails = do
           privateKey = "any/path"
         }
 
-multiIngressMap :: Map String AWSEndpoint
+multiIngressMap :: Map Data.Domain.Domain AWSEndpoint
 multiIngressMap =
   Map.singleton
-    "red.example.com"
+    (either (error . show) id $ mkDomain "red.example.com")
     (toAWSEndpoint "http://s3-download.red.example.com")
 
 toAWSEndpoint :: ByteString -> AWSEndpoint

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -47,6 +47,7 @@ import Cassandra hiding (Set)
 import Cassandra.Util (initCassandraForService)
 import Control.Error hiding (err)
 import Control.Lens hiding ((.=))
+import Data.Domain (Domain)
 import Data.Id
 import Data.Misc
 import Data.Qualified
@@ -236,7 +237,7 @@ type GalleyEffects =
      Input (Maybe (MLSKeysByPurpose MLSPrivateKeys)),
      Input (Maybe GroupInfoCheckEnabled),
      Input Opts,
-     Input (Either HttpsUrl (Map Text HttpsUrl)),
+     Input (Either HttpsUrl (Map Domain HttpsUrl)),
      Now,
      GE.Queue DeleteItem,
      Error Meeting.MeetingError,
@@ -294,7 +295,7 @@ type GalleyEffects =
    ]
 
 -- Define some invariants for the options used
-validateOptions :: Opts -> IO (Either HttpsUrl (Map Text HttpsUrl))
+validateOptions :: Opts -> IO (Either HttpsUrl (Map Domain HttpsUrl))
 validateOptions o = do
   let settings' = view settings o
       optFanoutLimit = fromIntegral . fromRange $ currentFanoutLimit settings'._maxTeamSize settings'._maxFanoutSize

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -45,6 +45,7 @@ where
 
 import Cassandra
 import Control.Lens hiding ((.=))
+import Data.Domain (Domain)
 import Data.Id
 import Data.Misc (HttpsUrl)
 import Data.Time.Clock.DiffTime (millisecondsToDiffTime)
@@ -85,7 +86,7 @@ data Env = Env
     _aEnv :: Maybe Aws.Env,
     _mlsKeys :: Maybe (MLSKeysByPurpose MLSPrivateKeys),
     _rabbitmqChannel :: Maybe (MVar Q.Channel),
-    _convCodeURI :: Either HttpsUrl (Map Text HttpsUrl),
+    _convCodeURI :: Either HttpsUrl (Map Domain HttpsUrl),
     _passwordHashingRateLimitEnv :: RateLimitEnv
   }
 

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -390,8 +390,8 @@ checkMultiIngressDomain samlConfig mbHost idp = when (SAML.isMultiIngressConfig 
       Logger.debug $
         Log.msg ("Multi-ingress domain guard rejected IdP access" :: ByteString)
           . Log.field "idp" idpIdTxt
-          . Log.field "idp_domain" (fromMaybe "none" (domainText <$> idpDomain))
-          . Log.field "request_host" (fromMaybe "none" (domainText <$> mbHost))
+          . Log.field "idp_domain" (fromMaybe "None" (domainText <$> idpDomain))
+          . Log.field "request_host" (fromMaybe "None" (domainText <$> mbHost))
       throwSparSem (SparIdPNotFound idpIdTxt)
 
 idpIdToText :: SAML.IdPId -> T.Text

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -61,7 +61,7 @@ import Control.Lens hiding ((.=))
 import qualified Data.ByteString as SBS
 import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Conversion
-import Data.Domain
+import Data.Domain (Domain, domainText)
 import Data.HavePendingInvitations
 import Data.Id
 import Data.List.NonEmpty (NonEmpty)
@@ -295,22 +295,20 @@ getMetadata ::
     Member (Error SparError) r
   ) =>
   Maybe TeamId ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Sem r SAML.SPMetadata
 getMetadata mbTid mbHost = do
   let err :: Sem r any
       err = throwSparSem (SparSPNotFound "")
 
-  mbHostDom <- (\host -> mkDomain host & either (const err) pure) `mapM` mbHost
-
   let iss :: Sem r SAML.Issuer
-      iss = SamlProtocolSettings.spIssuer mbTid mbHostDom >>= maybe err pure
+      iss = SamlProtocolSettings.spIssuer mbTid mbHost >>= maybe err pure
 
       rsp :: Sem r URI.URI
-      rsp = SamlProtocolSettings.responseURI mbTid mbHostDom >>= maybe err pure
+      rsp = SamlProtocolSettings.responseURI mbTid mbHost >>= maybe err pure
 
       contactList :: Sem r [SAML.ContactPerson]
-      contactList = SamlProtocolSettings.contactPersons mbHostDom
+      contactList = SamlProtocolSettings.contactPersons mbHost
 
   SAML2.meta appName iss rsp contactList
 
@@ -324,7 +322,7 @@ authreqPrecheck ::
   Maybe URI.URI ->
   Maybe CookieLabel ->
   SAML.IdPId ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Sem r NoContent
 authreqPrecheck samlConfig msucc merr mlabel idpid mbHost =
   validateAuthreqParams msucc merr mlabel *> do
@@ -352,7 +350,7 @@ authreq ::
   Maybe URI.URI ->
   Maybe CookieLabel ->
   SAML.IdPId ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Sem r (SAML.FormRedirect SAML.AuthnRequest)
 authreq samlConfig authreqttl msucc merr mlabel idpid mbHost = do
   vformat <- validateAuthreqParams msucc merr mlabel
@@ -363,14 +361,13 @@ authreq samlConfig authreqttl msucc merr mlabel idpid mbHost = do
 
     let err :: Sem r any
         err = throwSparSem (SparSPNotFound "")
-    mbHostDom <- (\host -> mkDomain host & either (const err) pure) `mapM` mbHost
 
     let mbtid :: Maybe TeamId
         mbtid = case fromMaybe defWireIdPAPIVersion (idp ^. SAML.idpExtraInfo . apiVersion) of
           WireIdPAPIV1 -> Nothing
           WireIdPAPIV2 -> Just $ idp ^. SAML.idpExtraInfo . team
         iss :: Sem r SAML.Issuer
-        iss = SamlProtocolSettings.spIssuer mbtid mbHostDom >>= maybe err pure
+        iss = SamlProtocolSettings.spIssuer mbtid mbHost >>= maybe err pure
     SAML2.authReq authreqttl iss idpid
   VerdictFormatStore.store authreqttl reqid vformat
   pure form
@@ -380,7 +377,7 @@ checkMultiIngressDomain ::
     Member (Error SparError) r
   ) =>
   SAML.Config ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   IdP ->
   Sem r ()
 checkMultiIngressDomain samlConfig mbHost idp = when (SAML.isMultiIngressConfig samlConfig) $ do
@@ -393,8 +390,8 @@ checkMultiIngressDomain samlConfig mbHost idp = when (SAML.isMultiIngressConfig 
       Logger.debug $
         Log.msg ("Multi-ingress domain guard rejected IdP access" :: ByteString)
           . Log.field "idp" idpIdTxt
-          . Log.field "idp_domain" (fromMaybe "none" idpDomain)
-          . Log.field "request_host" (fromMaybe "none" mbHost)
+          . Log.field "idp_domain" (fromMaybe "none" (domainText <$> idpDomain))
+          . Log.field "request_host" (fromMaybe "none" (domainText <$> mbHost))
       throwSparSem (SparIdPNotFound idpIdTxt)
 
 idpIdToText :: SAML.IdPId -> T.Text
@@ -439,19 +436,17 @@ authresp ::
   ) =>
   Maybe TeamId ->
   SAML.AuthnResponseBody ->
-  Maybe Text ->
+  Maybe ZHostValue ->
   Sem r Void
 authresp mbtid arbody mbHost = do
   let err :: Sem r any
       err = throwSparSem (SparSPNotFound "")
 
-  mbHostDom <- (\host -> mkDomain host & either (const err) pure) `mapM` mbHost
-
   let iss :: Sem r SAML.Issuer
-      iss = SamlProtocolSettings.spIssuer mbtid mbHostDom >>= maybe err pure
+      iss = SamlProtocolSettings.spIssuer mbtid mbHost >>= maybe err pure
 
       rsp :: Sem r URI.URI
-      rsp = SamlProtocolSettings.responseURI mbtid mbHostDom >>= maybe err pure
+      rsp = SamlProtocolSettings.responseURI mbtid mbHost >>= maybe err pure
 
   logErrors $ SAML2.authResp mbtid iss rsp go arbody
   where
@@ -766,7 +761,7 @@ logIdPAction msg idp zUser additionalFields =
       . Log.field "team" (idp ^. SAML.idpExtraInfo . team . to idToText)
       . Log.field "idpId" (idp ^. SAML.idpId . to SAML.fromIdPId . to UUID.toString)
       . Log.field "issuer" (idp ^. SAML.idpMetadata . SAML.edIssuer . SAML.fromIssuer . to URI.serializeURIRef')
-      . Log.field "domain" (idp ^. SAML.idpExtraInfo . domain . to (fromMaybe "None"))
+      . Log.field "domain" (idp ^. SAML.idpExtraInfo . domain . to (maybe "None" domainText))
       . Log.field "user" (maybe "None" idToText zUser)
       . Log.field "certificates" (idp ^. SAML.idpMetadata . SAML.edCertAuthnResponse . to (intercalate ";; " . map certToString . toList))
       . Log.field "idp-endpoint" (idp ^. SAML.idpMetadata . SAML.edRequestURI . to URI.serializeURIRef')
@@ -774,7 +769,7 @@ logIdPAction msg idp zUser additionalFields =
 
 -- | Only return a ZHost when multi-ingress is configured and the host value is a configured domain
 filterMultiIngressZHost :: Either SAML.MultiIngressDomainConfig (Map Domain SAML.MultiIngressDomainConfig) -> Maybe ZHostValue -> Maybe ZHostValue
-filterMultiIngressZHost (Right domainMap) (Just zHost) | (Domain zHost) `Map.member` domainMap = Just zHost
+filterMultiIngressZHost (Right domainMap) (Just zHost) | zHost `Map.member` domainMap = Just zHost
 filterMultiIngressZHost _ _ = Nothing
 
 idpCreateV7 ::
@@ -1017,7 +1012,7 @@ idpUpdateXML samlConfig mbZUsr mDomain raw idpmeta idpid mHandle = withDebugLog 
                 (idp ^. SAML.idpMetadata . SAML.edIssuer . SAML.fromIssuer)
               . logChangeableScalar
                 "domain"
-                (fromMaybe "None")
+                (maybe "None" domainText)
                 (previousIdP ^. SAML.idpExtraInfo . domain)
                 (idp ^. SAML.idpExtraInfo . domain)
               . Log.field "user" (idToText zUsr)

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -390,8 +390,8 @@ checkMultiIngressDomain samlConfig mbHost idp = when (SAML.isMultiIngressConfig 
       Logger.debug $
         Log.msg ("Multi-ingress domain guard rejected IdP access" :: ByteString)
           . Log.field "idp" idpIdTxt
-          . Log.field "idp_domain" (fromMaybe "None" (domainText <$> idpDomain))
-          . Log.field "request_host" (fromMaybe "None" (domainText <$> mbHost))
+          . Log.field "idp_domain" (maybe "None" domainText idpDomain)
+          . Log.field "request_host" (maybe "None" domainText mbHost)
       throwSparSem (SparIdPNotFound idpIdTxt)
 
 idpIdToText :: SAML.IdPId -> T.Text

--- a/services/spar/test/Test/Spar/Saml/IdPSpec.hs
+++ b/services/spar/test/Test/Spar/Saml/IdPSpec.hs
@@ -94,13 +94,13 @@ spec =
             _cfgSPPort = 8081,
             _cfgDomainConfigs = Left anyMultiIngressDomainCfg
           }
-      host = Just "backend.example.com"
+      host = either (error . show) Just $ mkDomain "backend.example.com"
       miHost1AsText = "backend-1.example.com"
       miDomain1 = either (error . show) id $ mkDomain miHost1AsText
-      miHost1 = Just miHost1AsText
+      miHost1 = Just miDomain1
       miHost2AsText = "backend-2.example.com"
       miDomain2 = either (error . show) id $ mkDomain miHost2AsText
-      miHost2 = Just miHost2AsText
+      miHost2 = Just miDomain2
       multiIngressSamlConfig =
         Config
           { -- The log level only matters for log output, not production.


### PR DESCRIPTION
The `Z-Host` header has been treated as domain, but used as `Text`. De-serializing and thus using it as `Domain` increases type-safety and ensures domain related semantics; e.g. case insensitivity in equality checks.
This solves a `FUTUREWORK` remark which was around for quite some time.

`CodeStore` `GetConversationCodeURI` interpreters only do a state map lookup with this domain value, so this is not a database migration case.

Do we change the API? Not really, as this is not client facing: `Z-Host` is set by nginx to `$host`.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26670

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
