### PR TITLE
WPB-26773: reject meetings with start time in the past

### DIFF
--- a/changelog.d/1-api-changes/wpb-26773-meeting-start-not-past
+++ b/changelog.d/1-api-changes/wpb-26773-meeting-start-not-past
@@ -1,0 +1,1 @@
+Reject meeting creation and update when the start time is in the past (with a 60-second tolerance for clock skew). Previously, meetings could be created with arbitrary past start times.

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -162,6 +162,17 @@ testMeetingsConfigDisabledBlocksCreate = do
 
   postMeetings owner newMeeting >>= assertLabel 403 "invalid-op"
 
+-- Test that creating a meeting with a start time in the past is rejected
+testMeetingCreatePastStartTime :: (HasCallStack) => App ()
+testMeetingCreatePastStartTime = do
+  (owner, _tid, _members) <- createTeam OwnDomain 1
+  now <- liftIO getCurrentTime
+  let startTime = addUTCTime (negate 3600) now
+      endTime = addUTCTime 3600 now
+      newMeeting = defaultMeetingJson "Past Meeting" startTime endTime []
+
+  postMeetings owner newMeeting >>= assertLabel 403 "invalid-op"
+
 testMeetingRecurrence :: (HasCallStack) => App ()
 testMeetingRecurrence = do
   (owner, _tid, _members) <- createTeam OwnDomain 1
@@ -473,15 +484,15 @@ testMeetingCleanup = do
     -- 2 minutes timeout
     (owner, _tid, _members) <- createTeam OwnDomain 1
     now <- liftIO getCurrentTime
-    -- Create a meeting that ends now.
+    -- Create a meeting that starts now and ends 1s later.
     -- Configured retention is 0.0014 hours (~5 seconds).
     -- cutoffTime will be now' - 5s.
     -- We need end_date < cutoffTime.
-    -- If we wait 6 seconds, now' = now + 6s.
-    -- cutoffTime = now + 6s - 5s = now + 1s.
-    -- end_date (now) < cutoffTime (now + 1s).
-    let startTime = addUTCTime (negate 3600) now
-        endTime = now
+    -- If we wait 7 seconds, now' = now + 7s.
+    -- cutoffTime = now + 7s - 5s = now + 2s.
+    -- end_date (now + 1s) < cutoffTime (now + 2s).
+    let startTime = now
+        endTime = addUTCTime 1 now
         newMeeting = defaultMeetingJson "Cleanup Test" startTime endTime []
 
     r1 <- postMeetings owner newMeeting
@@ -489,8 +500,8 @@ testMeetingCleanup = do
     meeting <- getJSON 201 r1
     (meetingId, domain) <- getMeetingIdAndDomain meeting
 
-    -- Wait 6 seconds to ensure meeting is old enough
-    liftIO $ threadDelay 6_000_000
+    -- Wait 7 seconds to ensure meeting is old enough
+    liftIO $ threadDelay 7_000_000
 
     -- Wait for cleanup job to run
     waitForCleanupJob OwnDomain
@@ -538,9 +549,9 @@ testMeetingExpiration :: (HasCallStack) => App ()
 testMeetingExpiration = do
   (owner, _tid, _members) <- createTeam OwnDomain 1
   now <- liftIO getCurrentTime
-  let startTime = addUTCTime (negate 3600) now
+  let startTime = now
       -- meetingValidityPeriodSeconds is configured to 5 seconds in galley.integration.yaml
-      endTime = now
+      endTime = addUTCTime 1 now
       newMeeting = defaultMeetingJson "Expiring Meeting" startTime endTime []
 
   r1 <- postMeetings owner newMeeting
@@ -548,11 +559,11 @@ testMeetingExpiration = do
   meeting <- getJSON 201 r1
   (meetingId, domain) <- getMeetingIdAndDomain meeting
 
-  -- Check it is accessible immediately (endDate = now, so valid until now + 5s)
+  -- Check it is accessible immediately (endTime = now+1, well within the 5s validity)
   getMeeting owner domain meetingId >>= assertStatus 200
 
-  -- Wait 6 seconds
-  liftIO $ threadDelay 6_000_000
+  -- Wait 7 seconds so endTime (now+1) is past the validity cutoff (now+7-5 = now+2)
+  liftIO $ threadDelay 7_000_000
 
   -- Check it is expired
   getMeeting owner domain meetingId >>= assertStatus 404
@@ -564,11 +575,11 @@ testMeetingListRecurringNotExpired :: (HasCallStack) => App ()
 testMeetingListRecurringNotExpired = do
   (owner, _tid, _members) <- createTeam OwnDomain 1
   now <- liftIO getCurrentTime
-  -- endTime = now: it only becomes "past" after the threadDelay below;
-  -- the recurrence window stays open for 30 days.
+  -- startTime = now, endTime = now+1: the slot only becomes "past" after the
+  -- threadDelay below; the recurrence window stays open for 30 days.
   -- meetingValidityPeriodSeconds is 5s in galley.integration.yaml.
-  let startTime = addUTCTime (negate 3600) now
-      endTime = now
+  let startTime = now
+      endTime = addUTCTime 1 now
       recurrenceUntil = Time.formatTime Time.defaultTimeLocale "%FT%TZ" $ addUTCTime (30 * nominalDay) now
       recurrence =
         object
@@ -588,8 +599,8 @@ testMeetingListRecurringNotExpired = do
   meeting <- postMeetings owner newMeeting >>= getJSON 201
   (meetingId, domain) <- getMeetingIdAndDomain meeting
 
-  -- Wait beyond the validity period so a non-recurring meeting would expire.
-  liftIO $ threadDelay 6_000_000
+  -- Wait 7s beyond the validity period so a non-recurring meeting would expire.
+  liftIO $ threadDelay 7_000_000
 
   -- Still accessible directly.
   getMeeting owner domain meetingId >>= assertStatus 200

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -17,6 +17,7 @@
 
 module Wire.MeetingsSubsystem.Interpreter
   ( interpretMeetingsSubsystem,
+    startTimeTolerance,
     MeetingError (..),
   )
 where
@@ -59,8 +60,11 @@ data MeetingError = InvalidTimes | EmptyUpdate | MeetingsFeatureDisabled
   deriving stock (Eq, Show)
 
 -- | Tolerance applied when validating that a meeting's start time is not in
--- the past. Absorbs minor clock skew between client and server (matches the
--- 60s precedent used by SAML2).
+-- the past. The check always uses the server's clock ('Now.get') as the
+-- reference; the client's clock is never trusted. The tolerance only absorbs
+-- minor clock skew between client and server and the network/processing delay
+-- between the client sending the request and the server observing it (matches
+-- the 60s precedent used by SAML2).
 startTimeTolerance :: NominalDiffTime
 startTimeTolerance = 60
 

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -58,6 +58,12 @@ import Wire.TeamSubsystem qualified as TeamSubsystem
 data MeetingError = InvalidTimes | EmptyUpdate | MeetingsFeatureDisabled
   deriving stock (Eq, Show)
 
+-- | Tolerance applied when validating that a meeting's start time is not in
+-- the past. Absorbs minor clock skew between client and server (matches the
+-- 60s precedent used by SAML2).
+startTimeTolerance :: NominalDiffTime
+startTimeTolerance = 60
+
 -- | Whether a meeting is still alive at the given cutoff. A meeting is alive
 -- when its 'Store.effectiveEndTime' is at or after the cutoff, or 'Nothing'
 -- (open-ended recurrence, which never expires).
@@ -115,6 +121,7 @@ createMeetingImpl ::
     Member ConversationSubsystem r,
     Member TeamSubsystem r,
     Member FeaturesConfigSubsystem r,
+    Member Now r,
     Member (Error MeetingError) r
   ) =>
   Local UserId ->
@@ -126,6 +133,10 @@ createMeetingImpl zUser newMeeting = do
   checkMeetingsEnabled conversationTeamId
   -- Validate that endTime > startTime
   when (newMeeting.endTime <= newMeeting.startTime) $
+    throw InvalidTimes
+  -- Validate that startTime is not in the past (within tolerance)
+  now <- Now.get
+  when (newMeeting.startTime < addUTCTime (negate startTimeTolerance) now) $
     throw InvalidTimes
 
   -- Determine trial status: personal users (no team) create trial meetings.
@@ -202,6 +213,11 @@ updateMeetingImpl zUser meetingId update validityPeriod = do
     when (fromMaybe meeting.startTime update.startTime >= fromMaybe meeting.endTime update.endTime) $
       lift $
         throw InvalidTimes
+    -- Validate that the updated start time (if provided) is not in the past
+    for_ update.startTime $ \t ->
+      when (t < addUTCTime (negate startTimeTolerance) now) $
+        lift $
+          throw InvalidTimes
 
     guard $ meeting.creator == tUnqualified zUser
     updatedMeeting <-

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -219,12 +219,12 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         gen = mkStdGen 42
         uid = Id $ read "00000000-0000-0000-0000-000000000001"
         zUser = toLocalUnsafe (Domain "wire.com") uid
-        -- Exactly `startTimeTolerance` in the past: the check is strict (`<`),
+        -- Exactly `expectedStartTimeTolerance` in the past: the check is strict (`<`),
         -- so the boundary itself is still accepted.
         newMeeting =
           API.NewMeeting
             { title = fromJust $ checked "Boundary Meeting",
-              startTime = addUTCTime (negate startTimeTolerance) now,
+              startTime = addUTCTime (negate expectedStartTimeTolerance) now,
               endTime = addUTCTime 3600 now,
               recurrence = Nothing,
               invitedEmails = []
@@ -242,7 +242,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         newMeeting =
           API.NewMeeting
             { title = fromJust $ checked "Just Past Boundary Meeting",
-              startTime = addUTCTime (negate (startTimeTolerance + 1)) now,
+              startTime = addUTCTime (negate (expectedStartTimeTolerance + 1)) now,
               endTime = addUTCTime 3600 now,
               recurrence = Nothing,
               invitedEmails = []
@@ -277,7 +277,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         getMeeting zUser1 meeting.meeting.id
 
       result `shouldBe` Right Nothing
@@ -471,7 +471,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         updateMeeting zUser1 meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing)
 
       result `shouldBe` Right Nothing
@@ -611,7 +611,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         deleteMeeting zUser1 testConnId meeting.meeting.id
 
       result `shouldBe` Right False
@@ -710,7 +710,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         addInvitedEmails zUser1 meeting.meeting.id [email1]
 
       result `shouldBe` Right False
@@ -837,7 +837,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         removeInvitedEmails zUser1 meeting.meeting.id [email1]
 
       result `shouldBe` Right False
@@ -964,7 +964,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
-        passTime 11000
+        passTime validityWindow
         replaceInvitedEmails zUser1 meeting.meeting.id [email2]
 
       result `shouldBe` Right False
@@ -1035,7 +1035,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           getMeeting zUser meeting.meeting.id
       case result of
         Left err -> fail $ "Error: " <> show err
@@ -1046,7 +1046,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           _meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           listMeetings zUser
       case result of
         Left err -> fail $ "Error: " <> show err
@@ -1056,7 +1056,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           updateMeeting zUser meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
       fmap isJust result `shouldBe` Right True
 
@@ -1064,7 +1064,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           addInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
@@ -1072,7 +1072,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           deleteMeeting zUser (ConnId "test-conv") meeting.meeting.id
       result `shouldBe` Right True
 
@@ -1080,7 +1080,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           removeInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
@@ -1088,7 +1088,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
-          passTime 11000
+          passTime validityWindow
           replaceInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
@@ -1096,7 +1096,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting openEndedRecurrence)
-          passTime 11000
+          passTime validityWindow
           getMeeting zUser meeting.meeting.id
       fmap isJust result `shouldBe` Right True
 
@@ -1105,7 +1105,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         runTestStack now gen Map.empty teamConfig $ do
           recurring <- createMeeting zUser (futureMeeting boundedRecurrence)
           _plain <- createMeeting zUser (futureMeeting Nothing)
-          passTime 11000
+          passTime validityWindow
           -- cutoff is past the endTime (now+7200) so the non-recurring
           -- meeting is picked up, but well before the recurrence window.
           deleted <- cleanupOldMeetings (addUTCTime 7300 now) 100
@@ -1122,10 +1122,10 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (futureMeeting openEndedRecurrence)
-          passTime 11000
+          passTime validityWindow
           -- Even with a cutoff well past the endTime, open-ended
           -- recurrence is never picked up.
-          deleted <- cleanupOldMeetings (addUTCTime 11000 now) 100
+          deleted <- cleanupOldMeetings (addUTCTime validityWindow now) 100
           remaining <- getMeeting zUser meeting.meeting.id
           pure (deleted, fmap (.id) remaining, meeting.meeting.id)
       case result of
@@ -1302,3 +1302,11 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
               replaceInvitedEmails zUserTeam meeting.meeting.id [unsafeEmailAddress "test" "example.com"]
 
           result2 `shouldBe` Left MeetingsFeatureDisabled
+
+-- | Synchronize with 'Wire.MeetingsSubsystem.Interpreter.startTimeTolerance'
+expectedStartTimeTolerance :: NominalDiffTime
+expectedStartTimeTolerance = 60
+
+-- | Validity window, beyond this one-time meeting belong to the past
+validityWindow :: NominalDiffTime
+validityWindow = 11000

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -214,16 +214,17 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
     result `shouldBe` Left InvalidTimes
 
-  it "creates a meeting if start time is within the grace period" $ do
+  it "accepts a meeting whose start time is exactly at the tolerance boundary" $ do
     let now = UTCTime (fromGregorian 2026 1 1) 0
         gen = mkStdGen 42
         uid = Id $ read "00000000-0000-0000-0000-000000000001"
         zUser = toLocalUnsafe (Domain "wire.com") uid
-        -- 30s in the past is within the 60s tolerance
+        -- Exactly `startTimeTolerance` in the past: the check is strict (`<`),
+        -- so the boundary itself is still accepted.
         newMeeting =
           API.NewMeeting
-            { title = fromJust $ checked "Grace Meeting",
-              startTime = addUTCTime (negate 30) now,
+            { title = fromJust $ checked "Boundary Meeting",
+              startTime = addUTCTime (negate startTimeTolerance) now,
               endTime = addUTCTime 3600 now,
               recurrence = Nothing,
               invitedEmails = []
@@ -231,6 +232,24 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
     result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
     result `shouldSatisfy` isRight
+
+  it "rejects a meeting whose start time is just past the tolerance boundary" $ do
+    let now = UTCTime (fromGregorian 2026 1 1) 0
+        gen = mkStdGen 42
+        uid = Id $ read "00000000-0000-0000-0000-000000000001"
+        zUser = toLocalUnsafe (Domain "wire.com") uid
+        -- One second past the tolerance boundary.
+        newMeeting =
+          API.NewMeeting
+            { title = fromJust $ checked "Just Past Boundary Meeting",
+              startTime = addUTCTime (negate (startTimeTolerance + 1)) now,
+              endTime = addUTCTime 3600 now,
+              recurrence = Nothing,
+              invitedEmails = []
+            }
+
+    result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
+    result `shouldBe` Left InvalidTimes
 
   describe "getMeeting access control" $ do
     let now = UTCTime (fromGregorian 2026 1 1) 0

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -38,7 +38,7 @@ import Polysemy.TinyLog (TinyLog)
 import System.Random (StdGen, mkStdGen)
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (counterexample, ioProperty, (.&&.), (===), (==>))
+import Test.QuickCheck (NonNegative, counterexample, getNonNegative, ioProperty, (.&&.), (===), (==>))
 import Text.Email.Parser (unsafeEmailAddress)
 import Wire.API.Conversation (Access (InviteAccess, PrivateAccess), Conversation (metadata, qualifiedId), ConversationMetadata (cnvmAccess))
 import Wire.API.Error (ErrorS)
@@ -197,6 +197,41 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
     result `shouldBe` Left InvalidTimes
 
+  it "fails to create a meeting if start time is in the past" $ do
+    let now = UTCTime (fromGregorian 2026 1 1) 0
+        gen = mkStdGen 42
+        uid = Id $ read "00000000-0000-0000-0000-000000000001"
+        zUser = toLocalUnsafe (Domain "wire.com") uid
+        newMeeting =
+          API.NewMeeting
+            { title = fromJust $ checked "Past Meeting",
+              startTime = addUTCTime (negate 3600) now,
+              endTime = addUTCTime 3600 now,
+              recurrence = Nothing,
+              invitedEmails = []
+            }
+
+    result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
+    result `shouldBe` Left InvalidTimes
+
+  it "creates a meeting if start time is within the grace period" $ do
+    let now = UTCTime (fromGregorian 2026 1 1) 0
+        gen = mkStdGen 42
+        uid = Id $ read "00000000-0000-0000-0000-000000000001"
+        zUser = toLocalUnsafe (Domain "wire.com") uid
+        -- 30s in the past is within the 60s tolerance
+        newMeeting =
+          API.NewMeeting
+            { title = fromJust $ checked "Grace Meeting",
+              startTime = addUTCTime (negate 30) now,
+              endTime = addUTCTime 3600 now,
+              recurrence = Nothing,
+              invitedEmails = []
+            }
+
+    result <- runTestStack now gen Map.empty def $ createMeeting zUser newMeeting
+    result `shouldSatisfy` isRight
+
   describe "getMeeting access control" $ do
     let now = UTCTime (fromGregorian 2026 1 1) 0
         gen = mkStdGen 42
@@ -215,14 +250,15 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       let newMeeting =
             API.NewMeeting
               { title = fromJust $ checked "Past Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = []
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         getMeeting zUser1 meeting.meeting.id
 
       result `shouldBe` Right Nothing
@@ -381,18 +417,42 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result `shouldBe` Left InvalidTimes
 
-    it "returns Nothing for expired meeting" $ do
+    it "throws InvalidTimes when updating startTime to the past" $ do
       let newMeeting =
             API.NewMeeting
-              { title = fromJust $ checked "Expired Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+              { title = fromJust $ checked "Original Meeting",
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = []
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        let update =
+              API.UpdateMeeting
+                { startTime = Just (addUTCTime (negate 3600) now),
+                  endTime = Nothing,
+                  title = Nothing,
+                  recurrence = Nothing
+                }
+        updateMeeting zUser1 meeting.meeting.id update
+
+      result `shouldBe` Left InvalidTimes
+
+    it "returns Nothing for expired meeting" $ do
+      let newMeeting =
+            API.NewMeeting
+              { title = fromJust $ checked "Expired Meeting",
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
+                recurrence = Nothing,
+                invitedEmails = []
+              }
+
+      result <- runTestStack now gen Map.empty teamConfig $ do
+        meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         updateMeeting zUser1 meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing)
 
       result `shouldBe` Right Nothing
@@ -440,15 +500,24 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 recurrence = Nothing,
                 invitedEmails = []
               }
-          effectiveStart = fromMaybe baseMeeting.startTime update.startTime
-          effectiveEnd = fromMaybe baseMeeting.endTime update.endTime
-          isNotEmpty = update /= API.UpdateMeeting Nothing Nothing Nothing Nothing
+          -- Clamp the updated start time so it is not in the past (within
+          -- tolerance). This avoids discarding QuickCheck-generated updates
+          -- whose arbitrary UTCTime is far from `now`.
+          sanitizedUpdate =
+            API.UpdateMeeting
+              (fmap (max (addUTCTime (negate 60) now)) update.startTime)
+              update.endTime
+              update.title
+              update.recurrence
+          effectiveStart = fromMaybe baseMeeting.startTime sanitizedUpdate.startTime
+          effectiveEnd = fromMaybe baseMeeting.endTime sanitizedUpdate.endTime
+          isNotEmpty = sanitizedUpdate /= API.UpdateMeeting Nothing Nothing Nothing Nothing
           hasValidTimes = effectiveStart < effectiveEnd
        in isNotEmpty && hasValidTimes ==>
             ioProperty $ do
               result <- runTestStack now gen Map.empty teamConfig $ do
                 meeting <- createMeeting zUser1 baseMeeting
-                updated <- updateMeeting zUser1 meeting.meeting.id update
+                updated <- updateMeeting zUser1 meeting.meeting.id sanitizedUpdate
                 pure (meeting.meeting.conversationId, updated)
               case result of
                 Left err ->
@@ -457,10 +526,10 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                   pure $ counterexample "Expected Just meeting, got Nothing" False
                 Right (convId, Just m) ->
                   pure $
-                    m.meeting.title === fromMaybe baseMeeting.title update.title
+                    m.meeting.title === fromMaybe baseMeeting.title sanitizedUpdate.title
                       .&&. m.meeting.startTime === effectiveStart
                       .&&. m.meeting.endTime === effectiveEnd
-                      .&&. m.meeting.recurrence === fromMaybe baseMeeting.recurrence update.recurrence
+                      .&&. m.meeting.recurrence === fromMaybe baseMeeting.recurrence sanitizedUpdate.recurrence
                       .&&. m.meeting.conversationId === convId
 
   describe "deleteMeeting" $ do
@@ -515,14 +584,15 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       let newMeeting =
             API.NewMeeting
               { title = fromJust $ checked "Expired Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = []
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         deleteMeeting zUser1 testConnId meeting.meeting.id
 
       result `shouldBe` Right False
@@ -613,14 +683,15 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       let newMeeting =
             API.NewMeeting
               { title = fromJust $ checked "Expired Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = []
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         addInvitedEmails zUser1 meeting.meeting.id [email1]
 
       result `shouldBe` Right False
@@ -739,14 +810,15 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       let newMeeting =
             API.NewMeeting
               { title = fromJust $ checked "Expired Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = [email1]
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         removeInvitedEmails zUser1 meeting.meeting.id [email1]
 
       result `shouldBe` Right False
@@ -865,14 +937,15 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       let newMeeting =
             API.NewMeeting
               { title = fromJust $ checked "Expired Meeting",
-                startTime = addUTCTime (-7200) now,
-                endTime = addUTCTime (-5000) now,
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
                 recurrence = Nothing,
                 invitedEmails = [email1]
               }
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 newMeeting
+        passTime 11000
         replaceInvitedEmails zUser1 meeting.meeting.id [email2]
 
       result `shouldBe` Right False
@@ -913,12 +986,14 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         teamConfig =
           npUpdate @MeetingsConfig (LockableFeature FeatureStatusEnabled LockStatusUnlocked def) $
             def
-        -- endTime (now-5000) is well past the validity cutoff (now-3600).
-        expiredNewMeeting r =
+        -- Meetings are created with future times. We then advance the mock
+        -- clock past the validity window (11000s) so that the original slot
+        -- has passed, while the recurrence window stays open.
+        futureMeeting r =
           API.NewMeeting
             { title = fromJust $ checked "Recurring Meeting",
-              startTime = addUTCTime (-7200) now,
-              endTime = addUTCTime (-5000) now,
+              startTime = addUTCTime 3600 now,
+              endTime = addUTCTime 7200 now,
               recurrence = r,
               invitedEmails = []
             }
@@ -940,7 +1015,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     it "getMeeting returns a recurring meeting whose slot passed but window is open" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           getMeeting zUser meeting.meeting.id
       case result of
         Left err -> fail $ "Error: " <> show err
@@ -950,7 +1026,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     it "listMeetings includes a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          _meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          _meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           listMeetings zUser
       case result of
         Left err -> fail $ "Error: " <> show err
@@ -959,51 +1036,60 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     it "updateMeeting succeeds on a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           updateMeeting zUser meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
       fmap isJust result `shouldBe` Right True
 
     it "addInvitedEmails succeeds on a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           addInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
     it "deleteMeeting succeeds on a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           deleteMeeting zUser (ConnId "test-conv") meeting.meeting.id
       result `shouldBe` Right True
 
     it "removeInvitedEmails succeeds on a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           removeInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
     it "replaceInvitedEmails succeeds on a recurring meeting whose slot passed" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting boundedRecurrence)
+          passTime 11000
           replaceInvitedEmails zUser meeting.meeting.id [unsafeEmailAddress "user" "example.com"]
       result `shouldBe` Right True
 
     it "getMeeting returns an open-ended recurring meeting indefinitely" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting openEndedRecurrence)
+          meeting <- createMeeting zUser (futureMeeting openEndedRecurrence)
+          passTime 11000
           getMeeting zUser meeting.meeting.id
       fmap isJust result `shouldBe` Right True
 
     it "cleanupOldMeetings skips recurring meetings whose window is still open" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          recurring <- createMeeting zUser (expiredNewMeeting boundedRecurrence)
-          _plain <- createMeeting zUser (expiredNewMeeting Nothing)
-          deleted <- cleanupOldMeetings (addUTCTime (negate 1) now) 100
+          recurring <- createMeeting zUser (futureMeeting boundedRecurrence)
+          _plain <- createMeeting zUser (futureMeeting Nothing)
+          passTime 11000
+          -- cutoff is past the endTime (now+7200) so the non-recurring
+          -- meeting is picked up, but well before the recurrence window.
+          deleted <- cleanupOldMeetings (addUTCTime 7300 now) 100
           remaining <- getMeeting zUser recurring.meeting.id
           pure (deleted, fmap (.id) remaining, recurring.meeting.id)
       case result of
@@ -1016,8 +1102,11 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
     it "cleanupOldMeetings never picks up open-ended recurring meetings" $ do
       result <-
         runTestStack now gen Map.empty teamConfig $ do
-          meeting <- createMeeting zUser (expiredNewMeeting openEndedRecurrence)
-          deleted <- cleanupOldMeetings now 100
+          meeting <- createMeeting zUser (futureMeeting openEndedRecurrence)
+          passTime 11000
+          -- Even with a cutoff well past the endTime, open-ended
+          -- recurrence is never picked up.
+          deleted <- cleanupOldMeetings (addUTCTime 11000 now) 100
           remaining <- getMeeting zUser meeting.meeting.id
           pure (deleted, fmap (.id) remaining, meeting.meeting.id)
       case result of
@@ -1027,9 +1116,9 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
           remainingId `shouldBe` Just meetingId
 
     prop "aliveness follows effectiveEndTime across get/list/cleanup" $
-      \(recurrence :: Maybe API.Recurrence) (endOffset :: Int) ->
-        let endTime = addUTCTime (fromIntegral endOffset) now
-            startTime = addUTCTime (negate 3600) endTime
+      \(recurrence :: Maybe API.Recurrence) (advance :: NonNegative Int) ->
+        let startTime = addUTCTime 3600 now
+            endTime = addUTCTime 7200 now
             nm =
               API.NewMeeting
                 { title = fromJust $ checked "Recurring Meeting",
@@ -1038,13 +1127,16 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                   recurrence = recurrence,
                   invitedEmails = []
                 }
+            advanceTime = fromIntegral (getNonNegative advance) :: NominalDiffTime
+            -- After advancing the clock, the validity cutoff moves forward.
+            cutoff = addUTCTime (advanceTime - 3600) now
             effEnd = maybe (Just endTime) (\r -> max endTime <$> r.until) recurrence
-            cutoff = addUTCTime (negate 3600) now
             alive = maybe True (>= cutoff) effEnd
          in ioProperty $ do
               result <-
                 runTestStack now gen Map.empty teamConfig $ do
                   meeting <- createMeeting zUser nm
+                  passTime advanceTime
                   fetched <- isJust <$> getMeeting zUser meeting.meeting.id
                   listedCount <- length <$> listMeetings zUser
                   deleted <- cleanupOldMeetings cutoff 100


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-26773

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
