### PR TITLE
[WPB-25521] Fix update / delete collaborator routes

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-25521-finish-collaborator-crud-api
+++ b/changelog.d/3-bug-fixes/WPB-25521-finish-collaborator-crud-api
@@ -1,0 +1,1 @@
+Fix nginz routes for delete / update collaborator.  Move collaborator CRUD api to galley.

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -446,12 +446,6 @@ nginx_conf:
     - path: /search
       envs:
       - all
-    - path: /teams/([^/]*)/collaborators$
-      envs:
-      - all
-    - path: /teams/([^/]*)/collaborators/([^/]*)
-      envs:
-      - all
     - path: /teams/([^/]*)/apps$
       envs:
       - all
@@ -683,6 +677,12 @@ nginx_conf:
       envs:
       - all
     - path: /teams/([^/]*)/channels/search$
+      envs:
+      - all
+    - path: /teams/([^/]*)/collaborators$
+      envs:
+      - all
+    - path: /teams/([^/]*)/collaborators/([^/]*)
       envs:
       - all
     - path: /teams/([^/]*)/members(.*)

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -1218,22 +1218,6 @@ removeUserFromGroup user gid uid = do
   req <- baseRequest user Brig Versioned $ joinHttpPath ["user-groups", gid, "users", uid]
   submit "DELETE" req
 
-addTeamCollaborator :: (MakesValue owner, MakesValue collaborator, HasCallStack) => owner -> String -> collaborator -> [String] -> App Response
-addTeamCollaborator owner tid collaborator permissions = do
-  req <- baseRequest owner Brig Versioned $ joinHttpPath ["teams", tid, "collaborators"]
-  (_, collabId) <- objQid collaborator
-  submit "POST" $
-    req
-      & addJSONObject
-        [ "user" .= collabId,
-          "permissions" .= permissions
-        ]
-
-getAllTeamCollaborators :: (MakesValue owner) => owner -> String -> App Response
-getAllTeamCollaborators owner tid = do
-  req <- baseRequest owner Brig Versioned $ joinHttpPath ["teams", tid, "collaborators"]
-  submit "GET" req
-
 data NewApp = NewApp
   { name :: String,
     assets :: Maybe [Value],

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -967,6 +967,22 @@ resetConversation user groupId epoch = do
   let payload = object ["group_id" .= groupId, "epoch" .= epoch]
   submit "POST" $ req & addJSON payload
 
+addTeamCollaborator :: (MakesValue owner, MakesValue collaborator, HasCallStack) => owner -> String -> collaborator -> [String] -> App Response
+addTeamCollaborator owner tid collaborator permissions = do
+  req <- baseRequest owner Galley Versioned $ joinHttpPath ["teams", tid, "collaborators"]
+  (_, collabId) <- objQid collaborator
+  submit "POST"
+    $ req
+    & addJSONObject
+      [ "user" .= collabId,
+        "permissions" .= permissions
+      ]
+
+getAllTeamCollaborators :: (MakesValue owner) => owner -> String -> App Response
+getAllTeamCollaborators owner tid = do
+  req <- baseRequest owner Galley Versioned $ joinHttpPath ["teams", tid, "collaborators"]
+  submit "GET" req
+
 updateTeamCollaborator :: (MakesValue owner, MakesValue collaborator, HasCallStack) => owner -> String -> collaborator -> [String] -> App Response
 updateTeamCollaborator owner tid collaborator permissions = do
   (_, collabId) <- objQid collaborator

--- a/integration/test/Test/TeamCollaborators.hs
+++ b/integration/test/Test/TeamCollaborators.hs
@@ -17,7 +17,6 @@
 
 module Test.TeamCollaborators where
 
-import API.Brig
 import API.Galley
 import qualified API.GalleyInternal as Internal
 import Data.Tuple.Extra

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -70,7 +70,6 @@ import Wire.API.Routes.QualifiedCapture
 import Wire.API.Routes.Version
 import Wire.API.Routes.Versioned
 import Wire.API.SystemSettings
-import Wire.API.Team.Collaborator
 import Wire.API.Team.Invitation
 import Wire.API.Team.Size
 import Wire.API.User hiding (NoIdentity)
@@ -2096,27 +2095,6 @@ type TeamsAPI =
                :> "accept"
                :> ReqBody '[JSON] AcceptTeamInvitation
                :> MultiVerb 'POST '[JSON] '[RespondEmpty 200 "Team invitation accepted."] ()
-           )
-    :<|> Named
-           "add-team-collaborator"
-           ( Summary "Add a collaborator to the team."
-               :> From 'V10
-               :> ZLocalUser
-               :> "teams"
-               :> Capture "tid" TeamId
-               :> "collaborators"
-               :> ReqBody '[JSON] NewTeamCollaborator
-               :> MultiVerb1 'POST '[JSON] (RespondEmpty 200 "")
-           )
-    :<|> Named
-           "get-team-collaborators"
-           ( Summary "Get all collaborators of the team."
-               :> From 'V10
-               :> ZLocalUser
-               :> "teams"
-               :> Capture "tid" TeamId
-               :> "collaborators"
-               :> MultiVerb1 'GET '[JSON] (Respond 200 "Return collaborators" [TeamCollaborator])
            )
 
 type SystemSettingsAPI =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamMember.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamMember.hs
@@ -210,6 +210,27 @@ type TeamMemberAPI =
                     CSV
            )
     :<|> Named
+           "add-team-collaborator"
+           ( Summary "Add a collaborator to the team."
+               :> From 'V10
+               :> ZLocalUser
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "collaborators"
+               :> ReqBody '[JSON] NewTeamCollaborator
+               :> MultiVerb1 'POST '[JSON] (RespondEmpty 200 "")
+           )
+    :<|> Named
+           "get-team-collaborators"
+           ( Summary "Get all collaborators of the team."
+               :> From 'V10
+               :> ZLocalUser
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "collaborators"
+               :> MultiVerb1 'GET '[JSON] (Respond 200 "Return collaborators" [TeamCollaborator])
+           )
+    :<|> Named
            "update-team-collaborator"
            ( Summary "Update a collaborator permissions from the team."
                :> From 'V13

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -192,7 +192,6 @@ import Wire.Sem.Paging.Cassandra
 import Wire.Sem.Random (Random)
 import Wire.SessionStore (SessionStore)
 import Wire.SparAPIAccess
-import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamInvitationSubsystem
 import Wire.TeamSubsystem (TeamSubsystem)
 import Wire.TeamSubsystem qualified as TeamSubsystem
@@ -416,7 +415,6 @@ servantSitemap ::
     Member CryptoSign r,
     Member Random r,
     Member UserGroupSubsystem r,
-    Member TeamCollaboratorsSubsystem r,
     Member TeamSubsystem r,
     Member AppSubsystem r,
     Member ClientStore r,

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -115,8 +115,6 @@ servantAPI =
     :<|> Named @"head-team-invitations" (lift . liftSem . headInvitationByEmail)
     :<|> Named @"get-team-size" (\uid tid -> lift . liftSem $ teamSizePublic uid tid)
     :<|> Named @"accept-team-invitation" (\luid req -> lift $ liftSem $ acceptTeamInvitation luid req.password req.code)
-    :<|> Named @"add-team-collaborator" (\zuid tid (NewTeamCollaborator uid perms) -> lift . liftSem $ createTeamCollaborator zuid uid tid perms)
-    :<|> Named @"get-team-collaborators" (\zuid tid -> lift . liftSem $ getAllTeamCollaborators zuid tid)
 
 teamSizePublic ::
   ( Member (Error UserSubsystemError) r,

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -62,7 +62,6 @@ import Wire.API.Routes.Internal.Galley.TeamsIntra qualified as Team
 import Wire.API.Routes.Named
 import Wire.API.Routes.Public.Brig (TeamsAPI)
 import Wire.API.Team
-import Wire.API.Team.Collaborator
 import Wire.API.Team.Invitation
 import Wire.API.Team.Invitation qualified as Public (Invitation (..))
 import Wire.API.Team.Member (teamMembers)
@@ -81,7 +80,6 @@ import Wire.IndexedUserStore (IndexedUserStore, getTeamSize)
 import Wire.InvitationStore (InvitationStore (..), PaginatedResult (..), StoredInvitation (..))
 import Wire.InvitationStore qualified as Store
 import Wire.Sem.Concurrency
-import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamInvitationSubsystem
 import Wire.TeamInvitationSubsystem.Interpreter (toInvitation)
 import Wire.TeamSubsystem (TeamSubsystem)
@@ -101,7 +99,6 @@ servantAPI ::
     Member (Input (Local ())) r,
     Member (Error UserSubsystemError) r,
     Member IndexedUserStore r,
-    Member TeamCollaboratorsSubsystem r,
     Member TeamSubsystem r
   ) =>
   ServerT TeamsAPI (Handler r)

--- a/services/galley/src/Galley/API/Public/TeamMember.hs
+++ b/services/galley/src/Galley/API/Public/TeamMember.hs
@@ -22,6 +22,8 @@ import Galley.API.Teams.Export qualified as Export
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.TeamMember
+import Wire.API.Team.Collaborator
+import Wire.TeamCollaboratorsSubsystem
 
 teamMemberAPI :: API TeamMemberAPI GalleyEffects
 teamMemberAPI =
@@ -33,5 +35,8 @@ teamMemberAPI =
     <@> mkNamedAPI @"delete-non-binding-team-member" deleteNonBindingTeamMember
     <@> mkNamedAPI @"update-team-member" updateTeamMember
     <@> mkNamedAPI @"get-team-members-csv" Export.getTeamMembersCSV
+    <@> mkNamedAPI @"add-team-collaborator"
+      (\zuid tid (NewTeamCollaborator uid perms) -> createTeamCollaborator zuid uid tid perms)
+    <@> mkNamedAPI @"get-team-collaborators" getAllTeamCollaborators
     <@> mkNamedAPI @"update-team-collaborator" updateTeamCollaborator
     <@> mkNamedAPI @"remove-team-collaborator" removeTeamCollaborator

--- a/services/nginz/integration-test/conf/nginz/nginx.conf
+++ b/services/nginz/integration-test/conf/nginz/nginx.conf
@@ -416,11 +416,6 @@ http {
       proxy_pass http://brig;
     }
 
-    location ~* ^(/v[0-9]+)?/teams/([^/]*)/collaborators$ {
-      include common_response_with_zauth.conf;
-      proxy_pass http://brig;
-    }
-
     location ~* ^(/v[0-9]+)?/teams/([^/]*)/apps {
       include common_response_with_zauth.conf;
       proxy_pass http://brig;
@@ -444,6 +439,16 @@ http {
     }
 
     # Galley Endpoints
+
+    location ~* ^(/v[0-9]+)?/teams/([^/]*)/collaborators$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
+
+    location ~* ^(/v[0-9]+)?/teams/([^/]*)/collaborators/([^/]*)$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
 
     location ~* ^(/v[0-9]+)?/legalhold/conversations/(.*)$ {
       include common_response_with_zauth.conf;


### PR DESCRIPTION
The CRUD api was smeared over brig and galley: update / delete were hosted on galley, create and get on brig.  nginx was routing everything to galley, so update / delete were invisible.  This PR moves everything to galley (collaborators only work in teams, and teams are galley). 

https://wearezeta.atlassian.net/browse/WPB-25521

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)