### PR TITLE
Sync meeting conversation name on title update

### DIFF
--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
@@ -341,6 +341,11 @@ data ConversationSubsystem m a where
   InternalDeleteLocalConversation ::
     Local ConvId ->
     ConversationSubsystem m ()
+  InternalRenameConversation ::
+    Local UserId ->
+    Local ConvId ->
+    ConversationRename ->
+    ConversationSubsystem m ()
   GetMLSPublicKeys ::
     Maybe MLSPublicKeyFormat ->
     ConversationSubsystem m (MLSKeysByPurpose (MLSKeys SomeKey))

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Interpreter.hs
@@ -211,6 +211,10 @@ interpretConversationSubsystem = interpret $ \case
     mapErrors $ Update.deleteLocalConversation lusr con lcnv
   InternalDeleteLocalConversation lcnv ->
     mapErrors $ Action.updateLocalConversationDeleteUnchecked lcnv
+  InternalRenameConversation lusr lcnv rename ->
+    mapErrors $
+      void $
+        Action.updateLocalConversationRename lcnv (tUntagged lusr) Nothing rename
   GetMLSPublicKeys fmt ->
     mapErrors $ MLS.getMLSPublicKeys fmt
   ResetMLSConversation lusr reset ->

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -233,7 +233,8 @@ updateMeetingImpl zUser meetingId update validityPeriod = do
           update.endTime
           update.recurrence
     conv <- MaybeT $ getMeetingConversationOrFail meetingId updatedMeeting.conversationId
-    pure $ storedMeetingToMeetingWithConversation zUser conv updatedMeeting
+    syncedConv <- lift $ syncMeetingConversationTitle zUser conv update.title
+    pure $ storedMeetingToMeetingWithConversation zUser syncedConv updatedMeeting
 
 deleteMeetingImpl ::
   ( Member Store.MeetingsStore r,
@@ -323,6 +324,21 @@ getMeetingConversationOrFail meetingId convId = do
           . Log.field "conversationId" (toByteString' convId)
           . Log.field "meetingId" (toByteString' (qUnqualified meetingId))
       pure Nothing
+
+syncMeetingConversationTitle ::
+  ( Member ConversationSubsystem r
+  ) =>
+  Local UserId ->
+  StoredConversation ->
+  Maybe (Range 1 256 Text) ->
+  Sem r StoredConversation
+syncMeetingConversationTitle zUser conv mNewTitle =
+  case mNewTitle of
+    Just newTitle | conv.metadata.cnvmName /= Just newTitle -> do
+      let lConvId = qualifyAs zUser conv.id_
+      ConversationSubsystem.internalRenameConversation zUser lConvId (ConversationRename newTitle)
+      fromMaybe conv <$> ConversationSubsystem.internalGetConversation conv.id_
+    _ -> pure conv
 
 -- Helper function to convert StoredMeeting to API.Meeting
 storedMeetingToMeeting :: Domain -> Store.StoredMeeting -> API.Meeting

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -40,7 +40,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (NonNegative, counterexample, getNonNegative, ioProperty, (.&&.), (===), (==>))
 import Text.Email.Parser (unsafeEmailAddress)
-import Wire.API.Conversation (Access (InviteAccess, PrivateAccess), Conversation (metadata, qualifiedId), ConversationMetadata (cnvmAccess))
+import Wire.API.Conversation (Access (InviteAccess, PrivateAccess), Conversation (metadata, qualifiedId), ConversationMetadata (cnvmAccess), cnvName)
 import Wire.API.Error (ErrorS)
 import Wire.API.Error.Galley (GalleyError (TeamMemberNotFound, TeamNotFound))
 import Wire.API.Meeting qualified as API
@@ -509,6 +509,28 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         updateMeeting zUser1 meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
 
       result `shouldBe` Right Nothing
+
+    it "syncs conversation name when meeting title is updated" $ do
+      let newMeeting =
+            API.NewMeeting
+              { title = fromJust $ checked "Original Meeting",
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
+                recurrence = Nothing,
+                invitedEmails = []
+              }
+          updatedTitle = fromJust $ checked "Renamed Meeting"
+
+      result <- runTestStack now gen Map.empty teamConfig $ do
+        meeting <- createMeeting zUser1 newMeeting
+        updateMeeting zUser1 meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just updatedTitle) Nothing)
+
+      case result of
+        Left err -> fail $ "Error: " <> show err
+        Right Nothing -> fail "Expected Just meeting, got Nothing"
+        Right (Just updated) -> do
+          updated.meeting.title `shouldBe` updatedTitle
+          cnvName updated.conversation `shouldBe` Just updatedTitle
 
     prop "applies valid update, preserves unchanged fields" $ \(update :: API.UpdateMeeting) ->
       let baseMeeting =


### PR DESCRIPTION
## Summary

- Add `InternalRenameConversation` to the conversation subsystem for server-side renames without a client connection id
- When a meeting title is updated via `PUT /meetings`, rename the linked MLS meeting conversation if its stored name differs
- Add a unit test asserting the returned `MeetingWithConversation` includes the updated conversation name

## Context

Meeting creation already sets `newConvName = Just newMeeting.title` on the underlying conversation. Title updates previously only changed the `meetings` table, leaving `cnvmName` stale on the conversation. Web clients can rely on conversation metadata and rename events once this is deployed.

## Test plan

- [ ] `cabal test wire-subsystems:unit-tests --test-options='--match=MeetingsSubsystem.Interpreter'`
- [ ] Update a meeting title and verify `GET /conversations/:id` returns the new name
- [ ] Verify conversation rename notifications are emitted to members