### PR TITLE
Expose ibis team billing endpoint for web e2e tests

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -866,7 +866,12 @@ nginx_conf:
       - all
       versioned: false
       strip_version: true
+    - path: /i/team/([^/]*)/billing
+      envs:
+      - staging
+      disable_zauth: true
       basic_auth: true
+      versioned: false
     galeb:
     - path: /consent(.*)
       envs:

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -866,6 +866,7 @@ nginx_conf:
       - all
       versioned: false
       strip_version: true
+      basic_auth: true
     galeb:
     - path: /consent(.*)
       envs:


### PR DESCRIPTION
## Summary

- Add a staging-only nginz route for `/i/team/{id}/billing` (ibis internal upstream)
- Uses the established test endpoint pattern: `envs: staging`, `disable_zauth`, `basic_auth`, `versioned: false`
- Allows web e2e tests to upgrade teams to premium via ibis without a logged-in Wire user
- Leaves the public `/teams/{id}/billing` route unchanged for normal authenticated users

## Test plan

- [ ] Deploy to a staging environment and verify `/i/team/{teamId}/billing` routes to ibis with basic auth
- [ ] Confirm the public `/teams/{teamId}/billing` route still requires zauth
- [ ] Confirm web e2e tests can upgrade a team to premium via the internal endpoint
- [ ] Verify calling feature e2e tests pass with the premium team setup