### PR TITLE
fix `/sso/get-by-email` rate limiting

### DIFF
--- a/changelog.d/3-bug-fixes/fix-sso-get-by-email-rate-limiting
+++ b/changelog.d/3-bug-fixes/fix-sso-get-by-email-rate-limiting
@@ -1,0 +1,5 @@
+Reorder SSO nginx locations to enforce correct rate limiting:
+`/sso/get-by-email` needs to appear before `/sso` in nginx's config, because
+regex locations are matched in order (first-match), not by specificity. In
+previous order `/sso` caught before `/sso/get-by-email` applied the specific
+5r/m rate limit, leaving it on the generic 50r/s limit.

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -816,6 +816,12 @@ nginx_conf:
       allow_credentials: true
       specific_user_rate_limit: reqs_per_addr_sso
       specific_user_rate_limit_burst: "10"
+    - path: /sso/get-by-email$
+      envs:
+      - all
+      disable_zauth: true
+      specific_user_rate_limit: reqs_per_addr_sso_get_by_email
+      specific_user_rate_limit_burst: "15"
     - path: /sso
       envs:
       - all
@@ -829,12 +835,6 @@ nginx_conf:
       allow_credentials: true
       specific_user_rate_limit: reqs_per_addr_sso
       specific_user_rate_limit_burst: "10"
-    - path: /sso/get-by-email$
-      envs:
-      - all
-      disable_zauth: true
-      specific_user_rate_limit: reqs_per_addr_sso_get_by_email
-      specific_user_rate_limit_burst: "15"
     - path: /scim
       envs:
       - all


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-server/pull/5212#issuecomment-4980788663

The changelog explains this fix.

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
