### PR TITLE
[WPB-27227] Include collaborating apps (aka external apps) in "GET /teams/:tid/apps".

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-27227-include-collaborating-apps-_aka-external-apps_-in-_get-_teams__tid_apps_
+++ b/changelog.d/3-bug-fixes/WPB-27227-include-collaborating-apps-_aka-external-apps_-in-_get-_teams__tid_apps_
@@ -1,0 +1,1 @@
+Include collaborating apps (aka external apps) in "GET /teams/:tid/apps".  ([drive-by] move access control for UserSubsystem.GetLocalAppProfiles from brig into wire-subsystems.)

--- a/libs/wire-subsystems/src/Wire/UserSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem.hs
@@ -130,7 +130,7 @@ data UserSubsystem m a where
   -- | Sometimes we don't have any identity of a requesting user, and local profiles are public.
   GetLocalUserProfiles :: Local [UserId] -> UserSubsystem m [UserProfile]
   -- | Get profiles for all app users in a team, touching only the apps table (efficient).
-  GetLocalAppProfiles :: Local TeamId -> UserSubsystem m [UserProfile]
+  GetLocalAppProfiles :: Local UserId -> TeamId -> UserSubsystem m [UserProfile]
   -- | Get the union of all user accounts matching the `GetBy` argument *and* having a non-empty UserIdentity.
   GetAccountsBy :: Local GetBy -> UserSubsystem m [User]
   -- | Get user accounts matching the `[EmailAddress]` argument (accounts with missing

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -148,8 +148,8 @@ runUserSubsystem authInterpreter appInterpreter clientInterpreter =
         getUserProfilesImpl self others
       GetLocalUserProfiles others ->
         getLocalUserProfilesImpl others
-      GetLocalAppProfiles ltid ->
-        getLocalAppProfilesOnlyImpl ltid
+      GetLocalAppProfiles self ltid ->
+        getLocalAppProfilesImpl self ltid
       GetAccountsBy getBy ->
         getAccountsByImpl getBy
       GetAccountsByEmailNoFilter emails ->
@@ -366,22 +366,29 @@ getLocalUserProfilesImpl ::
   Sem r [UserProfile]
 getLocalUserProfilesImpl = getUserProfilesLocalPart Nothing
 
-getLocalAppProfilesOnlyImpl ::
+getLocalAppProfilesImpl ::
   forall r any.
   ( Member AppStore r,
     Member UserStore r,
     Member (Input UserSubsystemConfig) r,
     Member DeleteQueue r,
+    Member (Error UserSubsystemError) r,
     Member Now r,
     Member (Concurrency Unsafe) r,
     Member (Input (Local any)) r,
     Member AppSubsystem r,
     Member TeamSubsystem r
   ) =>
-  Local TeamId ->
+  Local UserId ->
+  TeamId ->
   Sem r [UserProfile]
-getLocalAppProfilesOnlyImpl ltid = do
-  apps <- AppStore.getApps (tUnqualified ltid)
+getLocalAppProfilesImpl self tid = do
+  UserStore.getUserTeam (tUnqualified self) >>= \requestingUserTeam ->
+    unless (requestingUserTeam == Just tid) $
+      throw UserSubsystemProfileNotFound
+
+  let ltid = qualifyAs self tid
+  apps :: [AppStore.StoredApp] <- AppStore.getApps tid
   profiles <- getUserProfilesLocalPart Nothing (ltid $> map (.id) apps)
   let appsMap :: Map UserId AppStore.StoredApp
       appsMap = Map.fromList ((\app -> (app.id, app)) <$> apps)

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -59,6 +59,7 @@ import Wire.API.Federation.API.Brig qualified as FedBrig
 import Wire.API.Federation.Error
 import Wire.API.Routes.FederationDomainConfig
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti (TeamStatus (..))
+import Wire.API.Team.Collaborator
 import Wire.API.Team.Export
 import Wire.API.Team.Feature
 import Wire.API.Team.Member
@@ -96,6 +97,7 @@ import Wire.Sem.Metrics qualified as Metrics
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
 import Wire.StoredUser
+import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamSubsystem
 import Wire.UserGroupStore (UserGroupStore, getUserGroupIdsForUsers)
 import Wire.UserKeyStore
@@ -110,7 +112,8 @@ import Wire.UserSubsystem.UserSubsystemConfig
 import Witherable (wither)
 
 runUserSubsystem ::
-  ( Member AppStore r,
+  ( Member TeamCollaboratorsSubsystem r,
+    Member AppStore r,
     Member UserStore r,
     Member UserKeyStore r,
     Member GalleyAPIAccess r,
@@ -377,6 +380,7 @@ getLocalAppProfilesImpl ::
     Member (Concurrency Unsafe) r,
     Member (Input (Local any)) r,
     Member AppSubsystem r,
+    Member TeamCollaboratorsSubsystem r,
     Member TeamSubsystem r
   ) =>
   Local UserId ->
@@ -400,7 +404,12 @@ getLocalAppProfilesImpl self tid = do
               Just app -> profile {profileApp = Just (storedAppToAppInfo app)}
               Nothing -> profile
 
-  pure (injectPreloadedApp <$> profiles)
+  collaboratingApps :: [UserProfile] <- do
+    allIds <- (.gUser) <$$> getAllTeamCollaborators self tid
+    allProfiles <- getUserProfilesLocalPart (Just self) (qualifyAs self allIds)
+    pure (filter (isJust . (.profileApp)) allProfiles)
+
+  pure ((injectPreloadedApp <$> profiles) <> collaboratingApps)
 
 getUserProfilesFromDomain ::
   ( Member (Error FederationError) r,

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserSubsystem.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/UserSubsystem.hs
@@ -68,7 +68,7 @@ inMemoryUserSubsystemInterpreter =
     GetLocalUserProfiles luids ->
       toProfile . mkUserFromStored testDomain testLocale
         <$$> UserStore.getUsers (tUnqualified luids)
-    GetLocalAppProfiles _ ->
+    GetLocalAppProfiles _ _ ->
       error "GetLocalAppProfiles: implement on demand (userSubsystemInterpreter)"
     GetAccountsBy (tUnqualified -> GetBy NoPendingInvitations True True uids []) ->
       mkUserFromStored testDomain testLocale <$$> UserStore.getUsers uids

--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -59,6 +59,7 @@ import Wire.API.User hiding (DeleteUser)
 import Wire.API.User.IdentityProvider (IdPList (..), team)
 import Wire.API.User.Search
 import Wire.API.UserEvent
+import Wire.AppStore qualified as AppStore
 import Wire.AppSubsystem
 import Wire.AuthenticationSubsystem.Error
 import Wire.ClientSubsystem.Error (ClientError)
@@ -1142,3 +1143,59 @@ spec = describe "UserSubsystem.Interpreter" do
                         contactType = fromMaybe UserTypeRegular searchee.userType
                       }
               pure $ result.searchResults === [expectedContact | fromMaybe True searchee.searchable]
+
+  describe "getLocalAppProfiles" $ do
+    prop "includes apps that are collaborators from other teams" $
+      \(NotPendingStoredUser appUser_)
+       (NotPendingStoredUser ownerA_)
+       (NotPendingStoredUser ownerB_)
+       (teamAId :: TeamId)
+       (teamBId :: TeamId)
+       config ->
+          teamAId /= teamBId ==>
+            let localDomain = Domain "localdomain"
+                ownerA = ownerA_ {teamId = Just teamAId} :: StoredUser
+                ownerB = ownerB_ {teamId = Just teamBId} :: StoredUser
+                teamAOwnerId = toLocalUnsafe localDomain ownerA.id
+                teamBOwnerId = toLocalUnsafe localDomain ownerB.id
+                appUser =
+                  appUser_ {userType = Just UserTypeApp, teamId = Just teamBId} :: StoredUser
+                storedApp =
+                  AppStore.StoredApp
+                    { id = appUser.id,
+                      teamId = teamBId,
+                      meta = mempty,
+                      category = Category "other",
+                      description = unsafeRange "test app",
+                      creator = appUser.id
+                    }
+                collab =
+                  TeamCollaborator
+                    { gUser = appUser.id,
+                      gTeam = teamAId,
+                      gPermissions = mempty
+                    }
+                localBackend =
+                  def
+                    { users = [appUser, ownerA, ownerB],
+                      apps = [storedApp],
+                      teamCollaborators = Map.fromList [(teamAId, [collab])]
+                    }
+                teams =
+                  Map.fromList
+                    [ (teamAId, [mkTeamMember ownerA.id fullPermissions Nothing defUserLegalHoldStatus]),
+                      ( teamBId,
+                        [ mkTeamMember ownerB.id fullPermissions Nothing defUserLegalHoldStatus,
+                          mkTeamMember appUser.id fullPermissions Nothing defUserLegalHoldStatus
+                        ]
+                      )
+                    ]
+                result :: ([UserId], [UserId]) =
+                  runNoFederationStack localBackend teams config $ do
+                    let f tid caller =
+                          qUnqualified . (.profileQualifiedId)
+                            <$$> getLocalAppProfiles caller tid
+                     in (,)
+                          <$> f teamAId teamAOwnerId
+                          <*> f teamBId teamBOwnerId
+             in result === ([appUser.id], [appUser.id])

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1807,12 +1807,7 @@ getApp lusr tid uid = lift . liftSem $ do
 
 getApps :: (_) => Local UserId -> TeamId -> Handler r [UserProfile]
 getApps lusr tid = lift . liftSem $ do
-  -- Check if requesting user is a member of the team
-  requestingUserTeam <- getUserTeam (tUnqualified lusr)
-  unless (requestingUserTeam == Just tid) $
-    throw UserSubsystemProfileNotFound
-
-  getLocalAppProfiles (qualifyAs lusr tid)
+  getLocalAppProfiles lusr tid
 
 putApp :: (_) => Local UserId -> TeamId -> UserId -> Public.PutApp -> Handler r ()
 putApp lusr tid uid put = lift . liftSem $ AppSubsystem.updateApp lusr tid uid put


### PR DESCRIPTION
before:

```
  test/unit/Wire/UserSubsystem/InterpreterSpec.hs:1148:5:
  1) Wire.UserSubsystem.Interpreter.UserSubsystem.Interpreter.getLocalAppProfiles includes apps that are collaborators from other teams
         [...]
         ([],[499980fd-b369-528b-ebc8-a175fa2ebbb6]) /= ([499980fd-b369-528b-ebc8-a175fa2ebbb6],[499980fd-b369-528b-ebc8-a175fa2ebbb6])
```

after:

```
Wire.UserSubsystem.Interpreter
  UserSubsystem.Interpreter
    getLocalAppProfiles
      includes apps that are collaborators from other teams [✔]
        +++ OK, passed 100 tests.
```

https://wearezeta.atlassian.net/browse/WPB-27227

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)