### PR TITLE
WPB-25033: throw ConversationSubsystemError constructors directly in ConversationSubsystem

### DIFF
--- a/changelog.d/5-internal/WPB-25033
+++ b/changelog.d/5-internal/WPB-25033
@@ -1,0 +1,11 @@
+Galley conversation subsystem: throw `ConversationSubsystemError` constructors
+directly instead of relying on `mapErrors` for a set of standalone exceptions
+(`ChannelsNotEnabled`, `NotAnMlsConversation`, `MLSNonEmptyMemberList`,
+`NoBindingTeamMembers`, `BroadcastLimitExceeded`,
+`MLSFederatedOne2OneNotSupported`, `CreateConversationCodeConflict`,
+`InvalidTarget`, `MLSClientMismatch`, `MLSInvalidLeafNodeIndex`,
+`MLSUnsupportedProposal`, `MLSFederatedResetNotSupported`,
+`InvalidConversationPassword`, `AdminlessConversation`). The corresponding
+`ErrorS`/`Error` entries and `mapError` lines are removed from
+`Wire.ConversationSubsystem.Errors`. No API, schema, or config change; the
+mapped error responses are observationally identical.

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Create.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Create.hs
@@ -45,6 +45,7 @@ import Wire.BackendNotificationQueueAccess (BackendNotificationQueueAccess)
 import Wire.BrigAPIAccess
 import Wire.ConversationStore (ConversationStore)
 import Wire.ConversationSubsystem.CreateInternal
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.Util
 import Wire.FeaturesConfigSubsystem
 import Wire.FederationAPIAccess (FederationAPIAccess)
@@ -70,10 +71,8 @@ createLegacyGroupConversation ::
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NotConnected) r,
     Member (ErrorS 'MLSNotEnabled) r,
-    Member (ErrorS 'MLSNonEmptyMemberList) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
-    Member (ErrorS 'ChannelsNotEnabled) r,
-    Member (ErrorS 'NotAnMlsConversation) r,
     Member (ErrorS HistoryNotSupported) r,
     Member (Input ConversationSubsystemConfig) r,
     Member LegalHoldStore r,
@@ -108,10 +107,8 @@ createGroupOwnConversation ::
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NotConnected) r,
     Member (ErrorS 'MLSNotEnabled) r,
-    Member (ErrorS 'MLSNonEmptyMemberList) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
-    Member (ErrorS 'ChannelsNotEnabled) r,
-    Member (ErrorS 'NotAnMlsConversation) r,
     Member (ErrorS HistoryNotSupported) r,
     Member (Input ConversationSubsystemConfig) r,
     Member LegalHoldStore r,
@@ -151,10 +148,8 @@ createGroupConversation ::
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NotConnected) r,
     Member (ErrorS 'MLSNotEnabled) r,
-    Member (ErrorS 'MLSNonEmptyMemberList) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
-    Member (ErrorS 'ChannelsNotEnabled) r,
-    Member (ErrorS 'NotAnMlsConversation) r,
     Member (ErrorS HistoryNotSupported) r,
     Member (Input ConversationSubsystemConfig) r,
     Member LegalHoldStore r,
@@ -210,7 +205,7 @@ createOne2OneConversation ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NonBindingTeam) r,
-    Member (ErrorS 'NoBindingTeamMembers) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'NotConnected) r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/CreateInternal.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/CreateInternal.hs
@@ -64,6 +64,7 @@ import Wire.BackendNotificationQueueAccess (BackendNotificationQueueAccess)
 import Wire.BrigAPIAccess
 import Wire.ConversationStore (ConversationStore)
 import Wire.ConversationStore qualified as ConvStore
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.One2One
 import Wire.ConversationSubsystem.Util
 import Wire.FeaturesConfigSubsystem
@@ -94,10 +95,8 @@ createGroupConversationGeneric ::
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NotConnected) r,
     Member (ErrorS 'MLSNotEnabled) r,
-    Member (ErrorS 'MLSNonEmptyMemberList) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
-    Member (ErrorS 'ChannelsNotEnabled) r,
-    Member (ErrorS 'NotAnMlsConversation) r,
     Member (ErrorS HistoryNotSupported) r,
     Member (Input ConversationSubsystemConfig) r,
     Member LegalHoldStore r,
@@ -142,7 +141,7 @@ createOne2OneConversationLogic ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NonBindingTeam) r,
-    Member (ErrorS 'NoBindingTeamMembers) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'NotConnected) r,
@@ -308,8 +307,7 @@ checkCreateConvPermissions ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member (ErrorS 'NotConnected) r,
-    Member (ErrorS 'ChannelsNotEnabled) r,
-    Member (ErrorS 'NotAnMlsConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member TeamStore r,
     Member FeaturesConfigSubsystem r,
     Member TeamCollaboratorsSubsystem r,
@@ -356,16 +354,15 @@ checkCreateConvPermissions lusr newConv (Just tinfo) allUsers = do
       ( Member (ErrorS OperationDenied) r,
         Member FeaturesConfigSubsystem r,
         Member (ErrorS 'NotATeamMember) r,
-        Member (ErrorS 'ChannelsNotEnabled) r,
-        Member (ErrorS 'NotAnMlsConversation) r
+        Member (Error ConversationSubsystemError) r
       ) =>
       TeamId ->
       Maybe TeamMember ->
       Sem r ()
     ensureCreateChannelPermissions tid (Just tm) = do
       channelsConf :: LockableFeature ChannelsConfig <- getFeatureForTeam tid
-      when (channelsConf.status == FeatureStatusDisabled) $ throwS @'ChannelsNotEnabled
-      when (Public.newConvProtocol newConv /= BaseProtocolMLSTag) $ throwS @'NotAnMlsConversation
+      when (channelsConf.status == FeatureStatusDisabled) $ throw ConversationSubsystemErrorChannelsNotEnabled
+      when (Public.newConvProtocol newConv /= BaseProtocolMLSTag) $ throw ConversationSubsystemErrorNotAnMlsConversation
       case channelsConf.config.allowedToCreateChannels of
         Conf.Everyone -> pure ()
         Conf.TeamMembers -> void $ permissionCheck AddRemoveConvMember $ Just tm
@@ -490,7 +487,7 @@ createOne2OneConversationRemotely _ _ _ _name _mtid _ =
   throw FederationNotImplemented
 
 newRegularConversation ::
-  ( Member (ErrorS 'MLSNonEmptyMemberList) r,
+  ( Member (Error ConversationSubsystemError) r,
     Member (ErrorS OperationDenied) r,
     Member (Error InvalidInput) r,
     Member (Input ConversationSubsystemConfig) r,
@@ -509,7 +506,7 @@ newRegularConversation lusr newConv = do
   users <- case Public.newConvProtocol newConv of
     BaseProtocolProteusTag -> checkedConvSize cfg uncheckedUsers
     BaseProtocolMLSTag -> do
-      unless (null uncheckedUsers) $ throwS @'MLSNonEmptyMemberList
+      unless (null uncheckedUsers) $ throw ConversationSubsystemErrorMLSNonEmptyMemberList
       pure mempty
   let usersWithoutCreator = (,newConvUsersRole newConv) <$> fromConvSize users
       newConvUsersRoles =
@@ -623,7 +620,7 @@ throwErr :: (Member (Error InvalidInput) r) => String -> Sem r a
 throwErr = throw . InvalidRange . fromString
 
 checkBindingTeamPermissions ::
-  ( Member (ErrorS 'NoBindingTeamMembers) r,
+  ( Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'NonBindingTeam) r,
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
@@ -662,7 +659,7 @@ checkBindingTeamPermissions lusr lother tid = do
         else throwS @OperationDenied
 
 verifyMembership ::
-  ( Member (ErrorS 'NoBindingTeamMembers) r,
+  ( Member (Error ConversationSubsystemError) r,
     Member TeamSubsystem r
   ) =>
   TeamId ->
@@ -671,7 +668,7 @@ verifyMembership ::
 verifyMembership tid u = do
   membership <- TeamSubsystem.internalGetTeamMember u tid
   when (isNothing membership) $
-    throwS @'NoBindingTeamMembers
+    throw ConversationSubsystemErrorNoBindingTeamMembers
 
 sendCellsNotification ::
   ( Member NotificationSubsystem r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Errors.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Errors.hs
@@ -187,15 +187,11 @@ type ConversationSubsystemErrorEffects =
      ErrorS OperationDenied,
      ErrorS 'NotConnected,
      ErrorS 'MLSNotEnabled,
-     ErrorS 'MLSNonEmptyMemberList,
      ErrorS 'MissingLegalholdConsent,
      ErrorS 'NonBindingTeam,
-     ErrorS 'NoBindingTeamMembers,
      ErrorS 'TeamNotFound,
      ErrorS 'InvalidOperation,
      ErrorS 'ConvNotFound,
-     ErrorS 'ChannelsNotEnabled,
-     ErrorS 'NotAnMlsConversation,
      ErrorS 'MLSLegalholdIncompatible,
      ErrorS 'MLSIdentityMismatch,
      ErrorS 'MLSUnsupportedMessage,
@@ -206,9 +202,6 @@ type ConversationSubsystemErrorEffects =
      ErrorS 'MLSClientSenderUserMismatch,
      ErrorS 'MLSSubConvClientNotInParent,
      ErrorS 'MLSInvalidLeafNodeSignature,
-     ErrorS 'MLSClientMismatch,
-     ErrorS 'MLSInvalidLeafNodeIndex,
-     ErrorS 'MLSUnsupportedProposal,
      ErrorS 'GroupIdVersionNotSupported,
      ErrorS 'ConvMemberNotFound,
      ErrorS 'HistoryNotSupported,
@@ -216,19 +209,13 @@ type ConversationSubsystemErrorEffects =
      ErrorS ('ActionDenied ConvRole.LeaveConversation),
      ErrorS ('ActionDenied ConvRole.RemoveConversationMember),
      ErrorS ('ActionDenied ConvRole.DeleteConversation),
-     ErrorS 'BroadcastLimitExceeded,
-     ErrorS 'MLSFederatedResetNotSupported,
      ErrorS 'MLSSubConvUnsupportedConvType,
      ErrorS 'TeamMemberNotFound,
      ErrorS 'AccessDenied,
      ErrorS 'MLSMissingGroupInfo,
      ErrorS 'CodeNotFound,
-     ErrorS 'InvalidConversationPassword,
      ErrorS 'GuestLinksDisabled,
-     ErrorS 'MLSFederatedOne2OneNotSupported,
      ErrorS 'TooManyMembers,
-     ErrorS 'CreateConversationCodeConflict,
-     ErrorS 'InvalidTarget,
      ErrorS 'MLSReadReceiptsNotAllowed,
      ErrorS 'InvalidTargetAccess,
      ErrorS 'ConvInvalidProtocolTransition,
@@ -248,7 +235,6 @@ type ConversationSubsystemErrorEffects =
      Error MLSProtocolError,
      Error GroupInfoDiagnostics,
      Error MLSOutOfSyncError,
-     Error AdminlessConversation,
      Error MLSProposalFailure,
      Error NonFederatingBackends,
      Error UnreachableBackendsLegacy,
@@ -268,7 +254,6 @@ mapErrors =
     . mapError (ConversationSubsystemErrorUnreachableBackendsLegacy)
     . mapError (ConversationSubsystemErrorNonFederatingBackends)
     . interpretServerEffect
-    . mapError (ConversationSubsystemErrorAdminlessConversation)
     . mapError (ConversationSubsystemErrorMLSOutOfSyncError)
     . mapError (ConversationSubsystemErrorGroupInfoDiagnostics)
     . mapError (ConversationSubsystemErrorMLSProtocolError)
@@ -288,19 +273,13 @@ mapErrors =
     . mapError (const ConversationSubsystemErrorConvInvalidProtocolTransition)
     . mapError (const ConversationSubsystemErrorInvalidTargetAccess)
     . mapError (const ConversationSubsystemErrorMLSReadReceiptsNotAllowed)
-    . mapError (const ConversationSubsystemErrorInvalidTarget)
-    . mapError (const ConversationSubsystemErrorCreateConversationCodeConflict)
     . mapError (const ConversationSubsystemErrorTooManyMembers)
-    . mapError (const ConversationSubsystemErrorMLSFederatedOne2OneNotSupported)
     . mapError (const ConversationSubsystemErrorGuestLinksDisabled)
-    . mapError (const ConversationSubsystemErrorInvalidConversationPassword)
     . mapError (const ConversationSubsystemErrorCodeNotFound)
     . mapError (const ConversationSubsystemErrorMLSMissingGroupInfo)
     . mapError (const ConversationSubsystemErrorAccessDenied)
     . mapError (const ConversationSubsystemErrorTeamMemberNotFound)
     . mapError (const ConversationSubsystemErrorMLSSubConvUnsupportedConvType)
-    . mapError (const ConversationSubsystemErrorMLSFederatedResetNotSupported)
-    . mapError (const ConversationSubsystemErrorBroadcastLimitExceeded)
     . mapError (const ConversationSubsystemErrorActionDeniedDeleteConversation)
     . mapError (const ConversationSubsystemErrorActionDeniedRemoveConversationMember)
     . mapError (const ConversationSubsystemErrorActionDeniedLeaveConversation)
@@ -308,9 +287,6 @@ mapErrors =
     . mapError (const ConversationSubsystemErrorHistoryNotSupported)
     . mapError (const ConversationSubsystemErrorConvMemberNotFound)
     . mapError (const ConversationSubsystemErrorGroupIdVersionNotSupported)
-    . mapError (const ConversationSubsystemErrorMLSUnsupportedProposal)
-    . mapError (const ConversationSubsystemErrorMLSInvalidLeafNodeIndex)
-    . mapError (const ConversationSubsystemErrorMLSClientMismatch)
     . mapError (const ConversationSubsystemErrorMLSInvalidLeafNodeSignature)
     . mapError (const ConversationSubsystemErrorMLSSubConvClientNotInParent)
     . mapError (const ConversationSubsystemErrorMLSClientSenderUserMismatch)
@@ -321,15 +297,11 @@ mapErrors =
     . mapError (const ConversationSubsystemErrorMLSUnsupportedMessage)
     . mapError (const ConversationSubsystemErrorMLSIdentityMismatch)
     . mapError (const ConversationSubsystemErrorMLSLegalholdIncompatible)
-    . mapError (const ConversationSubsystemErrorNotAnMlsConversation)
-    . mapError (const ConversationSubsystemErrorChannelsNotEnabled)
     . mapError (const ConversationSubsystemErrorConvNotFound)
     . mapError (const ConversationSubsystemErrorInvalidOperation)
     . mapError (const ConversationSubsystemErrorTeamNotFound)
-    . mapError (const ConversationSubsystemErrorNoBindingTeamMembers)
     . mapError (const ConversationSubsystemErrorNonBindingTeam)
     . mapError (const ConversationSubsystemErrorMissingLegalholdConsent)
-    . mapError (const ConversationSubsystemErrorMLSNonEmptyMemberList)
     . mapError (const ConversationSubsystemErrorMLSNotEnabled)
     . mapError (const ConversationSubsystemErrorNotConnected)
     . mapError (const ConversationSubsystemErrorperationDenied)

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Federation.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Federation.hs
@@ -76,6 +76,7 @@ import Wire.BrigAPIAccess (BrigAPIAccess)
 import Wire.CodeStore
 import Wire.ConversationStore qualified as E
 import Wire.ConversationSubsystem.Action
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.Enabled
 import Wire.ConversationSubsystem.MLS.GroupInfo
 import Wire.ConversationSubsystem.MLS.GroupInfoCheck (GroupInfoCheckEnabled)
@@ -581,9 +582,7 @@ sendMLSCommitBundle ::
     Member ExternalAccess r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
-    Member (ErrorS 'MLSClientMismatch) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member (FederationAPIAccess FederatorClient) r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
@@ -647,9 +646,7 @@ sendMLSMessage ::
     Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member (FederationAPIAccess FederatorClient) r,
-    Member (ErrorS 'MLSClientMismatch) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
     Member (Input (Maybe (MLSKeysByPurpose MLSPrivateKeys))) r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/CheckClients.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/CheckClients.hs
@@ -42,13 +42,14 @@ import Wire.API.MLS.LeafNode
 import Wire.API.User.Client
 import Wire.BrigAPIAccess (BrigAPIAccess)
 import Wire.ConversationStore.MLS.Types
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.Commit.Core
 import Wire.FederationAPIAccess (FederationAPIAccess)
 
 checkClients ::
   ( Member BrigAPIAccess r,
     Member (FederationAPIAccess FederatorClient) r,
-    Member (ErrorS MLSClientMismatch) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS MLSIdentityMismatch) r,
     Member (Error MLSProtocolError) r
   ) =>
@@ -98,7 +99,7 @@ checkClients lConvOrSub ciphersuite newCM = do
             )
             $
             -- FUTUREWORK: turn this error into a proper response
-            throwS @'MLSClientMismatch
+            throw ConversationSubsystemErrorMLSClientMismatch
 
           pure False
 

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/Core.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/Core.hs
@@ -63,6 +63,7 @@ import Wire.BackendNotificationQueueAccess
 import Wire.BrigAPIAccess
 import Wire.ConversationStore
 import Wire.ConversationStore.MLS.Types
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.Conversation
 import Wire.ConversationSubsystem.MLS.IncomingMessage
 import Wire.ConversationSubsystem.MLS.Proposal
@@ -82,10 +83,9 @@ type HasProposalActionEffects r =
     Member ConversationStore r,
     Member (Error InternalError) r,
     Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS 'MLSClientMismatch) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Error MLSProposalFailure) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
     Member (Error MLSProtocolError) r,
     Member (Error NonFederatingBackends) r,
     Member (Error UnreachableBackends) r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/ExternalCommit.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/ExternalCommit.hs
@@ -46,6 +46,7 @@ import Wire.API.MLS.ProposalTag
 import Wire.API.MLS.SubConversation
 import Wire.ConversationStore
 import Wire.ConversationStore.MLS.Types
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.Commit.Core
 import Wire.ConversationSubsystem.MLS.IncomingMessage
 import Wire.ConversationSubsystem.MLS.Proposal
@@ -61,8 +62,7 @@ getExternalCommitData ::
   forall r.
   ( Member (Error MLSProtocolError) r,
     Member (ErrorS 'MLSStaleMessage) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MLSInvalidLeafNodeSignature) r
   ) =>
   ClientIdentity ->

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/InternalCommit.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Commit/InternalCommit.hs
@@ -53,6 +53,7 @@ import Wire.API.Unreachable
 import Wire.ConversationStore
 import Wire.ConversationStore.MLS.Types
 import Wire.ConversationSubsystem.Action
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.CheckClients
 import Wire.ConversationSubsystem.MLS.Commit.Core
 import Wire.ConversationSubsystem.MLS.Conversation
@@ -147,7 +148,7 @@ processInternalCommit senderIdentity con lConvOrSub ciphersuite ciphersuiteUpdat
                 -- FUTUREWORK: add tests against this situation for conv v subconv
                 when (removedClients /= clientsInConv) $ do
                   -- FUTUREWORK: turn this error into a proper response
-                  throwS @'MLSClientMismatch
+                  throw ConversationSubsystemErrorMLSClientMismatch
 
                 pure qtarget
 

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Proposal.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Proposal.hs
@@ -66,6 +66,7 @@ import Wire.BackendNotificationQueueAccess
 import Wire.BrigAPIAccess
 import Wire.ConversationStore (ConversationStore)
 import Wire.ConversationStore.MLS.Types
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.IncomingMessage
 import Wire.ExternalAccess
 import Wire.FederationAPIAccess (FederationAPIAccess)
@@ -129,9 +130,7 @@ type HasProposalEffects r =
     Member (Error FederationError) r,
     Member (Error MLSProposalFailure) r,
     Member (Error MLSProtocolError) r,
-    Member (ErrorS 'MLSClientMismatch) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Error NonFederatingBackends) r,
     Member (Error UnreachableBackends) r,
     Member ExternalAccess r,
@@ -147,8 +146,7 @@ type HasProposalEffects r =
 
 derefOrCheckProposal ::
   ( Member (Error MLSProtocolError) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member ProposalStore r,
     Member (State IndexMap) r,
     Member (ErrorS 'MLSProposalNotFound) r,
@@ -169,8 +167,7 @@ derefOrCheckProposal _epoch ciphersuite _ (Inline p) = do
 
 checkProposal ::
   ( Member (Error MLSProtocolError) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MLSInvalidLeafNodeSignature) r
   ) =>
   CipherSuiteTag ->
@@ -181,7 +178,7 @@ checkProposal ciphersuite im p = void $ evalState im $ applyProposal ciphersuite
 
 addProposedClient ::
   ( Member (State IndexMap) r,
-    Member (ErrorS MLSUnsupportedProposal) r
+    Member (Error ConversationSubsystemError) r
   ) =>
   Either GroupMember KeyPackage ->
   Sem r ProposalAction
@@ -199,8 +196,7 @@ addProposedClient cidOrKp = do
 applyProposals ::
   ( Member (State IndexMap) r,
     Member (Error MLSProtocolError) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MLSInvalidLeafNodeSignature) r
   ) =>
   CipherSuiteTag ->
@@ -214,8 +210,7 @@ applyProposals ciphersuite =
 applyProposal ::
   ( Member (State IndexMap) r,
     Member (Error MLSProtocolError) r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
-    Member (ErrorS 'MLSInvalidLeafNodeIndex) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'MLSInvalidLeafNodeSignature) r
   ) =>
   CipherSuiteTag ->
@@ -236,7 +231,7 @@ applyProposal ciphersuite (AddProposal kp) = do
   addProposedClient (Right kp.value)
 applyProposal _ciphersuite (RemoveProposal idx) = do
   im <- get
-  (cid, im') <- noteS @'MLSInvalidLeafNodeIndex $ imRemoveClient im idx
+  (cid, im') <- note ConversationSubsystemErrorMLSInvalidLeafNodeIndex $ imRemoveClient im idx
   put im'
   pure (paRemoveClient cid idx)
 applyProposal _activeData _ = pure mempty
@@ -282,11 +277,11 @@ processProposal qusr lConvOrSub groupId epoch pub prop = do
           }
 
 getKeyPackageIdentity ::
-  (Member (ErrorS 'MLSUnsupportedProposal) r) =>
+  (Member (Error ConversationSubsystemError) r) =>
   KeyPackage ->
   Sem r GroupMember
 getKeyPackageIdentity =
-  either (\_ -> throwS @'MLSUnsupportedProposal) pure
+  either (\_ -> throw ConversationSubsystemErrorMLSUnsupportedProposal) pure
     . keyPackageIdentity
 
 isExternal :: Sender -> Bool
@@ -296,7 +291,7 @@ isExternal _ = True
 -- check owner/subject of the key package exists and belongs to the user
 checkExternalProposalUser ::
   ( Member BrigAPIAccess r,
-    Member (ErrorS 'MLSUnsupportedProposal) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Input (Local ())) r
   ) =>
   Qualified UserId ->
@@ -312,16 +307,16 @@ checkExternalProposalUser qusr prop = do
           case groupMember of
             RegularClient (ClientIdentity {ciUser, ciClient}) -> do
               -- requesting user must match key package owner
-              when (tUnqualified lusr /= ciUser) $ throwS @'MLSUnsupportedProposal
+              when (tUnqualified lusr /= ciUser) $ throw ConversationSubsystemErrorMLSUnsupportedProposal
               -- client referenced in key package must be one of the user's clients
               UserClients {userClients} <- lookupClients [ciUser]
               maybe
-                (throwS @'MLSUnsupportedProposal)
-                (flip when (throwS @'MLSUnsupportedProposal) . Set.null . Set.filter (== ciClient))
+                (throw ConversationSubsystemErrorMLSUnsupportedProposal)
+                (flip when (throw ConversationSubsystemErrorMLSUnsupportedProposal) . Set.null . Set.filter (== ciClient))
                 $ userClients Map.!? ciUser
             -- We currently do not support history-client adds in external proposals/commits.
-            HistoryClient _ -> throwS @'MLSUnsupportedProposal
-        _ -> throwS @'MLSUnsupportedProposal
+            HistoryClient _ -> throw ConversationSubsystemErrorMLSUnsupportedProposal
+        _ -> throw ConversationSubsystemErrorMLSUnsupportedProposal
     )
     (const $ pure ()) -- FUTUREWORK: check external proposals from remote backends
     qusr

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Reset.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/MLS/Reset.hs
@@ -39,6 +39,7 @@ import Wire.BackendNotificationQueueAccess
 import Wire.BrigAPIAccess (BrigAPIAccess)
 import Wire.ConversationStore
 import Wire.ConversationSubsystem.Action
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.MLS.Enabled (assertMLSEnabled)
 import Wire.ConversationSubsystem.MLS.Util
 import Wire.ConversationSubsystem.Update
@@ -59,7 +60,7 @@ resetMLSConversation ::
     Member (Error MLSProtocolError) r,
     Member (Error InternalError) r,
     Member (ErrorS InvalidOperation) r,
-    Member (ErrorS MLSFederatedResetNotSupported) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Input (Maybe (MLSKeysByPurpose MLSPrivateKeys))) r,
     Member (ErrorS MLSNotEnabled) r,
     Member BackendNotificationQueueAccess r,
@@ -108,7 +109,7 @@ resetRemoteMLSConversation ::
     Member (ErrorS (ActionDenied LeaveConversation)) r,
     Member (ErrorS InvalidOperation) r,
     Member (ErrorS ConvNotFound) r,
-    Member (ErrorS MLSFederatedResetNotSupported) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS MLSStaleMessage) r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -133,12 +134,12 @@ resetRemoteMLSConversation rcnv lusr reset =
       reset
   where
     handleFedError ::
-      ( Member (ErrorS MLSFederatedResetNotSupported) r,
+      ( Member (Error ConversationSubsystemError) r,
         Member (Error FederationError) r
       ) =>
       Either FederationError x ->
       Sem r ()
     handleFedError (Left (FederationCallFailure FederatorClientVersionMismatch)) =
-      throwS @MLSFederatedResetNotSupported
+      throw ConversationSubsystemErrorMLSFederatedResetNotSupported
     handleFedError (Left e) = throw e
     handleFedError (Right _) = pure ()

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Message.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Message.hs
@@ -77,6 +77,7 @@ import Wire.API.UserMap (UserMap (..))
 import Wire.BackendNotificationQueueAccess
 import Wire.BrigAPIAccess
 import Wire.ConversationStore
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.Internal qualified as ConvSubsystem
 import Wire.ConversationSubsystem.LegalholdConflicts
 import Wire.ConversationSubsystem.Util
@@ -262,7 +263,7 @@ postBroadcast ::
   ( Member BrigAPIAccess r,
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'NonBindingTeam) r,
-    Member (ErrorS 'BroadcastLimitExceeded) r,
+    Member (Error ConversationSubsystemError) r,
     Member ExternalAccess r,
     Member (Input FeatureFlags) r,
     Member Now r,
@@ -294,7 +295,7 @@ postBroadcast lusr con msg = runError $ do
   limit <- fromIntegral . fromRange <$> input @FanoutLimit
   -- If we are going to fan this out to more than limit, we want to fail early
   unless (Map.size rcps <= limit) $
-    throwS @'BroadcastLimitExceeded
+    throw ConversationSubsystemErrorBroadcastLimitExceeded
   -- In large teams, we may still use the broadcast endpoint but only if `report_missing`
   -- is used and length `report_missing` < limit since we cannot fetch larger teams than
   -- that.
@@ -343,7 +344,7 @@ postBroadcast lusr con msg = runError $ do
   pure otrResult {mssFailedToSend = failedToSend}
   where
     maybeFetchLimitedTeamMemberList ::
-      ( Member (ErrorS 'BroadcastLimitExceeded) r,
+      ( Member (Error ConversationSubsystemError) r,
         Member TeamSubsystem r
       ) =>
       Int ->
@@ -355,11 +356,11 @@ postBroadcast lusr con msg = runError $ do
       let localUserIdsInRcps = Map.keys rcps
       let localUserIdsToLookup = Set.toList $ Set.union (Set.fromList localUserIdsInFilter) (Set.fromList localUserIdsInRcps)
       unless (length localUserIdsToLookup <= limit) $
-        throwS @'BroadcastLimitExceeded
+        throw ConversationSubsystemErrorBroadcastLimitExceeded
       TeamSubsystem.internalSelectTeamMembers tid localUserIdsToLookup
 
     maybeFetchAllMembersInTeam ::
-      ( Member (ErrorS 'BroadcastLimitExceeded) r,
+      ( Member (Error ConversationSubsystemError) r,
         Member TeamSubsystem r
       ) =>
       TeamId ->
@@ -367,7 +368,7 @@ postBroadcast lusr con msg = runError $ do
     maybeFetchAllMembersInTeam tid = do
       mems <- getTeamMembersForFanout tid
       when (mems ^. teamMemberListType == ListTruncated) $
-        throwS @'BroadcastLimitExceeded
+        throw ConversationSubsystemErrorBroadcastLimitExceeded
       pure (mems ^. teamMembers)
 
 postQualifiedOtrMessage ::

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Query.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Query.hs
@@ -102,6 +102,7 @@ import Wire.CodeStore.Code (codeConvId)
 import Wire.CodeStore.Code qualified as Data
 import Wire.ConversationStore qualified as ConversationStore
 import Wire.ConversationStore.MLS.Types
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.Fetch (getConversationIdsImpl)
 import Wire.ConversationSubsystem.MLS
 import Wire.ConversationSubsystem.MLS.Enabled (assertMLSEnabled, getMLSPrivateKeys, isMLSEnabled)
@@ -640,7 +641,7 @@ getConversationByReusableCode ::
     Member CodeStore r,
     Member ConversationStore.ConversationStore r,
     Member (ErrorS 'CodeNotFound) r,
-    Member (ErrorS 'InvalidConversationPassword) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'GuestLinksDisabled) r,
@@ -777,7 +778,7 @@ getMLSOne2OneOwnConversation ::
     Member (Error InternalError) r,
     Member (ErrorS 'MLSNotEnabled) r,
     Member (ErrorS 'NotConnected) r,
-    Member (ErrorS 'MLSFederatedOne2OneNotSupported) r,
+    Member (Error ConversationSubsystemError) r,
     Member (E.FederationAPIAccess FederatorClient) r,
     Member TeamStore r,
     Member P.TinyLog r,
@@ -790,7 +791,7 @@ getMLSOne2OneOwnConversation ::
 getMLSOne2OneOwnConversation lself qother = do
   if isLocal lself qother
     then getMLSOne2OneConversationInternal lself qother
-    else throwS @MLSFederatedOne2OneNotSupported
+    else throw ConversationSubsystemErrorMLSFederatedOne2OneNotSupported
 
 getMLSOne2OneConversationInternal ::
   forall r.

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -131,6 +131,7 @@ import Wire.ConversationSubsystem (RemoveMemberResponseMode (..))
 import Wire.ConversationSubsystem.Action
 import Wire.ConversationSubsystem.Action.Kick (kickMember)
 import Wire.ConversationSubsystem.AdminlessGroups (selectAutopromotionCandidate)
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.Message
 import Wire.ConversationSubsystem.Query qualified as Query
 import Wire.ConversationSubsystem.Util
@@ -476,7 +477,7 @@ addCodeUnqualified ::
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'GuestLinksDisabled) r,
-    Member (ErrorS 'CreateConversationCodeConflict) r,
+    Member (Error ConversationSubsystemError) r,
     Member E.ExternalAccess r,
     Member NotificationSubsystem r,
     Member (Input (Local ())) r,
@@ -505,7 +506,7 @@ addCode ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'GuestLinksDisabled) r,
-    Member (ErrorS 'CreateConversationCodeConflict) r,
+    Member (Error ConversationSubsystemError) r,
     Member E.ExternalAccess r,
     Member HashPassword r,
     Member NotificationSubsystem r,
@@ -543,7 +544,7 @@ addCode lusr mbZHost mZcon lcnv mReq = do
       pure $ CodeAdded event
     -- In case conversation already has a code this case covers the allowed no-ops
     Just (code, mPw) -> do
-      when (isJust mPw || isJust (mReq >>= (.password))) $ throwS @'CreateConversationCodeConflict
+      when (isJust mPw || isJust (mReq >>= (.password))) $ throw ConversationSubsystemErrorCreateConversationCodeConflict
       pure $ CodeAlreadyExisted (mkConversationCodeInfo (isJust mPw) (codeKey code) (codeValue code) convUri)
   where
     ensureGuestsOrNonTeamMembersAllowed :: StoredConversation -> Sem r ()
@@ -633,7 +634,7 @@ checkReusableCode ::
     Member FeaturesConfigSubsystem r,
     Member (ErrorS 'CodeNotFound) r,
     Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS 'InvalidConversationPassword) r,
+    Member (Error ConversationSubsystemError) r,
     Member HashPassword r,
     Member RateLimit r
   ) =>
@@ -738,7 +739,7 @@ joinConversationByReusableCode ::
     Member CodeStore r,
     Member ConversationStore r,
     Member (ErrorS 'CodeNotFound) r,
-    Member (ErrorS 'InvalidConversationPassword) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'GuestLinksDisabled) r,
@@ -955,7 +956,7 @@ replaceMembers ::
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (ErrorS 'GroupIdVersionNotSupported) r,
     Member (ErrorS 'ConvMemberNotFound) r,
-    Member (Error AdminlessConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Error FederationError) r,
     Member (Error UnreachableBackends) r,
     Member E.ExternalAccess r,
@@ -1077,7 +1078,7 @@ updateOtherMemberLocalConv ::
   ( Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
-    Member (ErrorS 'InvalidTarget) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvMemberNotFound) r,
@@ -1095,7 +1096,7 @@ updateOtherMemberLocalConv ::
   Sem r ()
 updateOtherMemberLocalConv lcnv lusr con qvictim update = void . getUpdateResult . fmap lcuEvent $ do
   when (tUntagged lusr == qvictim) $
-    throwS @'InvalidTarget
+    throw ConversationSubsystemErrorInvalidTarget
   updateLocalConversationMemberUpdate lcnv (tUntagged lusr) (Just con) $
     ConversationMemberUpdate qvictim update
 
@@ -1103,7 +1104,7 @@ updateOtherMember ::
   ( Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
-    Member (ErrorS 'InvalidTarget) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvMemberNotFound) r,
@@ -1137,7 +1138,7 @@ removeMemberQualified ::
   ( Member BackendNotificationQueueAccess r,
     Member ConversationStore r,
     Member BrigAPIAccess r,
-    Member (Error AdminlessConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
@@ -1172,7 +1173,7 @@ removeMemberQualified responseMode lusr con qcnv victim =
 
 guardPreventAdminlessGroups ::
   ( Member ConversationStore r,
-    Member (Error AdminlessConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
     Member (ErrorS 'InvalidOperation) r,
@@ -1206,7 +1207,7 @@ guardPreventAdminlessGroups responseMode lcnv lusr victim = do
             updateLocalConversationMemberUpdate lcnv (tUntagged lusr) Nothing $
               ConversationMemberUpdate candidate (OtherMemberUpdate (Just roleNameWireAdmin))
         (RemoveMemberEligibleMembersResponse, _ : _) ->
-          throw $ AdminlessConversation (fmap fst eligibleMembers)
+          throw $ ConversationSubsystemErrorAdminlessConversation (AdminlessConversation (fmap fst eligibleMembers))
         (RemoveMemberLegacyResponse, []) ->
           -- FUTUREWORK: mark for deletion
           pure ()
@@ -1256,7 +1257,7 @@ eligibleAdminFallbackMembers lcnv leavingUser conv = do
 deleteUserFromTeamConversationsImpl ::
   ( Member BackendNotificationQueueAccess r,
     Member BrigAPIAccess r,
-    Member (Error AdminlessConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
@@ -1377,7 +1378,7 @@ removeMemberFromLocalConv ::
     Member (Input ConversationSubsystemConfig) r,
     Member (ErrorS (ActionDenied ModifyOtherConversationMember)) r,
     Member (ErrorS ConvMemberNotFound) r,
-    Member (Error AdminlessConversation) r,
+    Member (Error ConversationSubsystemError) r,
     Member FeaturesConfigSubsystem r,
     Member BrigAPIAccess r
   ) =>
@@ -1476,7 +1477,7 @@ postProteusBroadcast ::
   ( Member BrigAPIAccess r,
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'NonBindingTeam) r,
-    Member (ErrorS 'BroadcastLimitExceeded) r,
+    Member (Error ConversationSubsystemError) r,
     Member NotificationSubsystem r,
     Member E.ExternalAccess r,
     Member (Input FeatureFlags) r,
@@ -1560,7 +1561,7 @@ postOtrBroadcastUnqualified ::
   ( Member BrigAPIAccess r,
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'NonBindingTeam) r,
-    Member (ErrorS 'BroadcastLimitExceeded) r,
+    Member (Error ConversationSubsystemError) r,
     Member NotificationSubsystem r,
     Member E.ExternalAccess r,
     Member (Input FeatureFlags) r,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Util.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Util.hs
@@ -81,6 +81,7 @@ import Wire.BrigAPIAccess
 import Wire.CodeStore
 import Wire.CodeStore.Code as DataTypes
 import Wire.ConversationStore
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ExternalAccess
 import Wire.FederationAPIAccess
 import Wire.FederationSubsystem (ensureNoUnreachableBackends)
@@ -649,7 +650,7 @@ newConversationEventPush st e users =
 verifyReusableCode ::
   ( Member CodeStore r,
     Member (ErrorS 'CodeNotFound) r,
-    Member (ErrorS 'InvalidConversationPassword) r,
+    Member (Error ConversationSubsystemError) r,
     Member HashPassword r,
     Member RateLimit r
   ) =>
@@ -666,9 +667,9 @@ verifyReusableCode rateLimitKey checkPw mPtpw convCode = do
     throwS @'CodeNotFound
   case (checkPw, mPtpw, mPw) of
     (True, Just ptpw, Just pw) -> do
-      unlessM (HashPassword.verifyPassword rateLimitKey ptpw pw) $ throwS @'InvalidConversationPassword
+      unlessM (HashPassword.verifyPassword rateLimitKey ptpw pw) $ throw ConversationSubsystemErrorInvalidConversationPassword
     (True, Nothing, Just _) ->
-      throwS @'InvalidConversationPassword
+      throw ConversationSubsystemErrorInvalidConversationPassword
     (_, _, _) -> pure ()
   pure c
 

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -44,6 +44,7 @@ import Wire.BackendNotificationQueueAccess (BackendNotificationQueueAccess (..))
 import Wire.BrigAPIAccess (BrigAPIAccess (..))
 import Wire.ConversationStore (ConversationStore (..))
 import Wire.ConversationSubsystem (RemoveMemberResponseMode (..))
+import Wire.ConversationSubsystem.Errors (ConversationSubsystemError (..))
 import Wire.ConversationSubsystem.Update (removeMemberQualified)
 import Wire.ExternalAccess (ExternalAccess (..))
 import Wire.FeaturesConfigSubsystem (FeaturesConfigSubsystem (..))
@@ -97,7 +98,7 @@ spec = describe "ConversationSubsystem.Interpreter" do
                 ]
               result =
                 run
-                  . runError @AdminlessConversation
+                  . runError @ConversationSubsystemError
                   . runError @(Tagged ('ActionDenied 'RemoveConversationMember) ())
                   . runError @(Tagged ('ActionDenied 'ModifyOtherConversationMember) ())
                   . runError @(Tagged 'ConvMemberNotFound ())
@@ -127,10 +128,10 @@ spec = describe "ConversationSubsystem.Interpreter" do
                   $ removeMemberQualified RemoveMemberEligibleMembersResponse lusr connId qcnv qvictim
           pure $
             case result of
-              Left err ->
-                err === AdminlessConversation {eligibleMembers = expectedEligible}
-              Right _ ->
-                counterexample ("expected adminless-conversation, got " <> show result) False
+              Right _ -> counterexample "expected adminless-conversation, got success" False
+              Left (ConversationSubsystemErrorAdminlessConversation ac) ->
+                ac === AdminlessConversation {eligibleMembers = expectedEligible}
+              Left _ -> counterexample "expected adminless-conversation, got different error" False
 
 data MemberInputs = MemberInputs
   { localUserIds :: [UserId],


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-25033

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
