### PR TITLE
WPB-26705: move meeting qualified id to event envelope

### DIFF
--- a/changelog.d/2-features/wpb-26705-meeting-events.md
+++ b/changelog.d/2-features/wpb-26705-meeting-events.md
@@ -1,7 +1,8 @@
 * Added meeting lifecycle events: `meeting.create`, `meeting.update`, and
   `meeting.delete` (WPB-26705). These websocket notifications are pushed to all
   local members of the meeting's conversation on every successful create, update,
-  and delete operation. The events use the standard conversation event envelope:
-  each payload contains the event `type`, the meeting's qualified ID in the
-  `data.qualified_id` field, the `qualified_conversation`, `qualified_from`,
-  `via`, `time`, and optional `team`.
+  and delete operation. Each payload carries the event `type`, the meeting's
+  qualified ID in the top-level `qualified_id` field, the
+  `qualified_conversation`, `qualified_from`, `via`, `time`, and optional `team`.
+  Meeting events use a dedicated event envelope (not the conversation event
+  envelope).

--- a/changelog.d/2-features/wpb-26705-meeting-events.md
+++ b/changelog.d/2-features/wpb-26705-meeting-events.md
@@ -2,6 +2,6 @@
   `meeting.delete` (WPB-26705). These websocket notifications are pushed to all
   local members of the meeting's conversation on every successful create, update,
   and delete operation. The events use the standard conversation event envelope:
-  each payload contains the event `type`, the meeting's qualified ID in the `data`
-  field, the `qualified_conversation`, `qualified_from`, `via`, `time`, and
-  optional `team`.
+  each payload contains the event `type`, the meeting's qualified ID in the
+  `data.qualified_id` field, the `qualified_conversation`, `qualified_from`,
+  `via`, `time`, and optional `team`.

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -31,8 +31,10 @@ testMeetingCreate = do
       resp <- postMeetings owner newMeeting
       assertSuccess resp
       void $ awaitMatch isConvCreateMeetingNotif ws
-      void $ awaitMatch isMeetingCreateNotif ws
-      getJSON 201 resp
+      m <- getJSON 201 resp
+      createNotif <- awaitMatch isMeetingCreateNotif ws
+      assertMeetingNotif createNotif (m %. "qualified_id")
+      pure m
 
   meeting %. "title" `shouldMatch` ("Team Standup" :: String)
   meeting %. "qualified_creator" %. "id" `shouldMatch` ownerId
@@ -95,6 +97,18 @@ assertConversationMatchesLegacy meeting = do
   convId <- meeting %. "conversation" %. "qualified_id"
   legacyConvId <- meeting %. "qualified_conversation"
   convId `shouldMatch` legacyConvId
+
+-- | Assert a meeting lifecycle notification carries the meeting's qualified id flat
+-- at payload.0.qualified_id and has NO "data" wrapper (proves the no-nesting
+-- contract).
+assertMeetingNotif ::
+  (HasCallStack, MakesValue notif, MakesValue qid) =>
+  notif ->
+  qid ->
+  App ()
+assertMeetingNotif notif qid = do
+  notif %. "payload.0.qualified_id" `shouldMatch` qid
+  assertFieldMissing notif "payload.0.data"
 
 -- | Helper to create a default new meeting JSON object
 defaultMeetingJson :: String -> UTCTime -> UTCTime -> [String] -> Value
@@ -217,7 +231,8 @@ testMeetingRecurrence = do
   r2 <- withWebSocket owner $ \ws -> do
     resp <- putMeeting owner domain meetingId updatedMeeting
     assertSuccess resp
-    void $ awaitMatch isMeetingUpdateNotif ws
+    updateNotif <- awaitMatch isMeetingUpdateNotif ws
+    assertMeetingNotif updateNotif (object ["id" .= meetingId, "domain" .= domain])
     pure resp
 
   updated <- getJSON 200 r2
@@ -460,7 +475,8 @@ testMeetingDelete = do
   (meetingId, domain) <- getMeetingIdAndDomain meeting
   withWebSocket owner $ \ws -> do
     deleteMeeting owner domain meetingId >>= assertStatus 200
-    void $ awaitMatch isMeetingDeleteNotif ws
+    deleteNotif <- awaitMatch isMeetingDeleteNotif ws
+    assertMeetingNotif deleteNotif (object ["id" .= meetingId, "domain" .= domain])
   getMeeting owner domain meetingId >>= assertStatus 404
 
 testMeetingDeleteNotFound :: (HasCallStack) => App ()

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -570,10 +570,17 @@ taggedEventDataSchema =
       ProtocolUpdate -> tag _EdProtocolUpdate (unnamed (unProtocolUpdate <$> P.ProtocolUpdate .= schema))
       AddPermissionUpdate -> tag _EdAddPermissionUpdate (unnamed schema)
       ConvHistoryUpdate -> tag _EdConvHistoryUpdate (unnamed schema)
-      MeetingCreate -> tag _EdMeetingCreate (unnamed schema)
-      MeetingUpdate -> tag _EdMeetingUpdate (unnamed schema)
-      MeetingDelete -> tag _EdMeetingDelete (unnamed schema)
+      MeetingCreate -> tag _EdMeetingCreate meetingEventDataSchema
+      MeetingUpdate -> tag _EdMeetingUpdate meetingEventDataSchema
+      MeetingDelete -> tag _EdMeetingDelete meetingEventDataSchema
       ConvAdminlessReminder -> tag _EdAdminlessReminder (unnamed schema)
+
+-- | All meeting lifecycle events ('EdMeetingCreate', 'EdMeetingUpdate',
+-- 'EdMeetingDelete') carry only the meeting's qualified ID. It is rendered
+-- under a @qualified_id@ field, consistent with the rest of the API (see
+-- the @Meeting@, @Conversation@, and @Member@ types).
+meetingEventDataSchema :: ValueSchema SwaggerDoc (Qualified MeetingId)
+meetingEventDataSchema = unnamed (object (field "qualified_id" schema))
 
 memberLeaveSchema :: ValueSchema NamedSwaggerDoc (EdMemberLeftReason, QualifiedUserIdList)
 memberLeaveSchema =

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -28,6 +28,8 @@ module Wire.API.Event.Conversation
     EventVia (..),
     EventFrom (..),
     eventFromUserId,
+    mkEventFrom,
+    eventVia,
     AddCodeResult (..),
     createConversationEventData,
     isCellsConversationEvent,
@@ -58,9 +60,6 @@ module Wire.API.Event.Conversation
     _EdMLSMessage,
     _EdMLSWelcome,
     _EdAddPermissionUpdate,
-    _EdMeetingCreate,
-    _EdMeetingUpdate,
-    _EdMeetingDelete,
 
     -- * Event data helpers
     SimpleMember (..),
@@ -198,9 +197,6 @@ data EventType
   | ProtocolUpdate
   | AddPermissionUpdate
   | ConvHistoryUpdate
-  | MeetingCreate
-  | MeetingUpdate
-  | MeetingDelete
   | ConvAdminlessReminder
   deriving stock (Eq, Show, Generic, Enum, Bounded, Ord)
   deriving (Arbitrary) via (GenericUniform EventType)
@@ -231,9 +227,6 @@ instance ToSchema EventType where
           element "conversation.protocol-update" ProtocolUpdate,
           element "conversation.add-permission-update" AddPermissionUpdate,
           element "conversation.history-update" ConvHistoryUpdate,
-          element "meeting.create" MeetingCreate,
-          element "meeting.update" MeetingUpdate,
-          element "meeting.delete" MeetingDelete,
           element "conversation.adminless-reminder" ConvAdminlessReminder
         ]
 
@@ -259,9 +252,6 @@ data EventData
   | EdProtocolUpdate P.ProtocolTag
   | EdAddPermissionUpdate Conv.AddPermissionUpdate
   | EdConvHistoryUpdate History
-  | EdMeetingCreate (Qualified MeetingId)
-  | EdMeetingUpdate (Qualified MeetingId)
-  | EdMeetingDelete (Qualified MeetingId)
   | EdAdminlessReminder AdminlessReminder
   deriving stock (Eq, Show, Generic)
 
@@ -288,9 +278,6 @@ genEventData = \case
   ProtocolUpdate -> EdProtocolUpdate <$> arbitrary
   AddPermissionUpdate -> EdAddPermissionUpdate <$> arbitrary
   ConvHistoryUpdate -> EdConvHistoryUpdate <$> arbitrary
-  MeetingCreate -> EdMeetingCreate <$> arbitrary
-  MeetingUpdate -> EdMeetingUpdate <$> arbitrary
-  MeetingDelete -> EdMeetingDelete <$> arbitrary
   ConvAdminlessReminder -> EdAdminlessReminder <$> arbitrary
 
 eventDataType :: EventData -> EventType
@@ -315,9 +302,6 @@ eventDataType (EdConvReset _) = ConvReset
 eventDataType (EdProtocolUpdate _) = ProtocolUpdate
 eventDataType (EdAddPermissionUpdate _) = AddPermissionUpdate
 eventDataType (EdConvHistoryUpdate _) = ConvHistoryUpdate
-eventDataType (EdMeetingCreate _) = MeetingCreate
-eventDataType (EdMeetingUpdate _) = MeetingUpdate
-eventDataType (EdMeetingDelete _) = MeetingDelete
 eventDataType (EdAdminlessReminder _) = ConvAdminlessReminder
 
 createConversationEventData ::
@@ -350,9 +334,6 @@ isCellsConversationEvent eventType =
     ProtocolUpdate -> False
     AddPermissionUpdate -> False
     ConvHistoryUpdate -> False
-    MeetingCreate -> False
-    MeetingUpdate -> False
-    MeetingDelete -> False
     ConvAdminlessReminder -> False
 
 --------------------------------------------------------------------------------
@@ -570,17 +551,7 @@ taggedEventDataSchema =
       ProtocolUpdate -> tag _EdProtocolUpdate (unnamed (unProtocolUpdate <$> P.ProtocolUpdate .= schema))
       AddPermissionUpdate -> tag _EdAddPermissionUpdate (unnamed schema)
       ConvHistoryUpdate -> tag _EdConvHistoryUpdate (unnamed schema)
-      MeetingCreate -> tag _EdMeetingCreate meetingEventDataSchema
-      MeetingUpdate -> tag _EdMeetingUpdate meetingEventDataSchema
-      MeetingDelete -> tag _EdMeetingDelete meetingEventDataSchema
       ConvAdminlessReminder -> tag _EdAdminlessReminder (unnamed schema)
-
--- | All meeting lifecycle events ('EdMeetingCreate', 'EdMeetingUpdate',
--- 'EdMeetingDelete') carry only the meeting's qualified ID. It is rendered
--- under a @qualified_id@ field, consistent with the rest of the API (see
--- the @Meeting@, @Conversation@, and @Member@ types).
-meetingEventDataSchema :: ValueSchema SwaggerDoc (Qualified MeetingId)
-meetingEventDataSchema = unnamed (object (field "qualified_id" schema))
 
 memberLeaveSchema :: ValueSchema NamedSwaggerDoc (EdMemberLeftReason, QualifiedUserIdList)
 memberLeaveSchema =

--- a/libs/wire-api/src/Wire/API/Event/Meeting.hs
+++ b/libs/wire-api/src/Wire/API/Event/Meeting.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-
 {-# LANGUAGE StrictData #-}
 
 module Wire.API.Event.Meeting
@@ -23,7 +22,7 @@ module Wire.API.Event.Meeting
     EventType (..),
 
     -- * Envelope
-    EventFrom (..)
+    EventFrom (..),
   )
 where
 
@@ -119,4 +118,3 @@ instance ToJSON Event where
 
 instance S.ToSchema Event where
   declareNamedSchema = schemaToSwagger
-

--- a/libs/wire-api/src/Wire/API/Event/Meeting.hs
+++ b/libs/wire-api/src/Wire/API/Event/Meeting.hs
@@ -1,0 +1,122 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2026 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+{-# LANGUAGE StrictData #-}
+
+module Wire.API.Event.Meeting
+  ( -- * Event
+    Event (..),
+    EventType (..),
+
+    -- * Envelope
+    EventFrom (..)
+  )
+where
+
+import Control.Applicative (optional)
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Id
+import Data.Json.Util
+import Data.OpenApi qualified as S
+import Data.Qualified
+import Data.Schema
+import Data.Time (UTCTime)
+import Imports
+import Wire.API.Event.Conversation (EventFrom (..), eventFromUserId, eventVia, mkEventFrom)
+import Wire.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
+
+--------------------------------------------------------------------------------
+-- EventType
+
+data EventType = Create | Update | Delete
+  deriving stock (Eq, Show, Generic, Enum, Bounded, Ord)
+  deriving (Arbitrary) via (GenericUniform EventType)
+  deriving (FromJSON, ToJSON, S.ToSchema) via Schema EventType
+
+instance ToSchema EventType where
+  schema =
+    enum @Text $
+      mconcat
+        [ element "meeting.create" Create,
+          element "meeting.update" Update,
+          element "meeting.delete" Delete
+        ]
+
+--------------------------------------------------------------------------------
+-- Event
+
+-- | A self-contained meeting lifecycle event. Unlike conversation events, the
+-- meeting's qualified id is carried flat at the envelope top level
+-- (@qualified_id@), with no @data@ wrapper. The 'EventFrom' envelope helper is
+-- shared with "Wire.API.Event.Conversation".
+data Event = Event
+  { evtType :: EventType,
+    evtMeeting :: Qualified MeetingId,
+    evtConv :: Qualified ConvId,
+    evtFrom :: EventFrom,
+    evtTime :: UTCTime,
+    evtTeam :: Maybe TeamId
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance Arbitrary Event where
+  arbitrary =
+    Event
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> (milli <$> arbitrary)
+      <*> arbitrary
+    where
+      milli = fromUTCTimeMillis . toUTCTimeMillis
+
+instance ToSchema Event where
+  schema = object eventObjectSchema
+
+eventObjectSchema :: ObjectSchema SwaggerDoc Event
+eventObjectSchema =
+  mk
+    <$> evtType .= field "type" schema
+    <*> evtMeeting .= field "qualified_id" schema
+    <* (qUnqualified . evtConv) .= optional (field "conversation" schema)
+    <*> evtConv .= field "qualified_conversation" schema
+    <* (qUnqualified . eventFromUserId . evtFrom) .= optional (field "from" schema)
+    <*> (eventFromUserId . evtFrom) .= field "qualified_from" schema
+    <*> (eventVia . evtFrom) .= field "via" schema
+    <*> (toUTCTimeMillis . evtTime) .= field "time" (fromUTCTimeMillis <$> schema)
+    <*> evtTeam .= maybe_ (optField "team" schema)
+  where
+    mk typ meeting cid uid evVia tm tid =
+      Event typ meeting cid (mkEventFrom evVia uid) tm tid
+
+instance ToJSONObject Event where
+  toJSONObject =
+    KeyMap.fromList
+      . fromMaybe []
+      . schemaOut eventObjectSchema
+
+instance FromJSON Event where
+  parseJSON = schemaParseJSON
+
+instance ToJSON Event where
+  toJSON = schemaToJSON
+
+instance S.ToSchema Event where
+  declareNamedSchema = schemaToSwagger
+

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -49,6 +49,7 @@ import Test.Wire.API.Golden.Manual.ListConversations
 import Test.Wire.API.Golden.Manual.ListUsersById
 import Test.Wire.API.Golden.Manual.LoginId_user
 import Test.Wire.API.Golden.Manual.Login_user
+import Test.Wire.API.Golden.Manual.MeetingEvent
 import Test.Wire.API.Golden.Manual.MLSKeys
 import Test.Wire.API.Golden.Manual.Pagination
 import Test.Wire.API.Golden.Manual.Presence
@@ -153,8 +154,11 @@ tests =
         testObjects
           [ (testObject_Event_conversation_manual_1, "testObject_Event_conversation_manual_1.json"),
             (testObject_Event_conversation_manual_2, "testObject_Event_conversation_manual_2.json"),
-            (testObject_Event_conversation_manual_3, "testObject_Event_conversation_manual_3.json"),
-            (testObject_Event_meeting_create_manual_1, "testObject_Event_meeting_create_manual_1.json"),
+            (testObject_Event_conversation_manual_3, "testObject_Event_conversation_manual_3.json")
+          ],
+      testGroup "MeetingEvent" $
+        testObjects
+          [ (testObject_Event_meeting_create_manual_1, "testObject_Event_meeting_create_manual_1.json"),
             (testObject_Event_meeting_update_manual_1, "testObject_Event_meeting_update_manual_1.json"),
             (testObject_Event_meeting_delete_manual_1, "testObject_Event_meeting_delete_manual_1.json")
           ],

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -49,8 +49,8 @@ import Test.Wire.API.Golden.Manual.ListConversations
 import Test.Wire.API.Golden.Manual.ListUsersById
 import Test.Wire.API.Golden.Manual.LoginId_user
 import Test.Wire.API.Golden.Manual.Login_user
-import Test.Wire.API.Golden.Manual.MeetingEvent
 import Test.Wire.API.Golden.Manual.MLSKeys
+import Test.Wire.API.Golden.Manual.MeetingEvent
 import Test.Wire.API.Golden.Manual.Pagination
 import Test.Wire.API.Golden.Manual.Presence
 import Test.Wire.API.Golden.Manual.Push

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -153,7 +153,10 @@ tests =
         testObjects
           [ (testObject_Event_conversation_manual_1, "testObject_Event_conversation_manual_1.json"),
             (testObject_Event_conversation_manual_2, "testObject_Event_conversation_manual_2.json"),
-            (testObject_Event_conversation_manual_3, "testObject_Event_conversation_manual_3.json")
+            (testObject_Event_conversation_manual_3, "testObject_Event_conversation_manual_3.json"),
+            (testObject_Event_meeting_create_manual_1, "testObject_Event_meeting_create_manual_1.json"),
+            (testObject_Event_meeting_update_manual_1, "testObject_Event_meeting_update_manual_1.json"),
+            (testObject_Event_meeting_delete_manual_1, "testObject_Event_meeting_delete_manual_1.json")
           ],
       testGroup "GetPaginatedConversationIds" $
         testObjects

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
@@ -59,3 +59,36 @@ testObject_Event_conversation_manual_3 =
       evtData = EdProtocolUpdate P.ProtocolMixedTag,
       evtTeam = Nothing
     }
+
+testObject_Event_meeting_create_manual_1 :: Event
+testObject_Event_meeting_create_manual_1 =
+  Event
+    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtSubConv = Nothing,
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtData = EdMeetingCreate (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
+      evtTeam = Nothing
+    }
+
+testObject_Event_meeting_update_manual_1 :: Event
+testObject_Event_meeting_update_manual_1 =
+  Event
+    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtSubConv = Nothing,
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtData = EdMeetingUpdate (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
+      evtTeam = Nothing
+    }
+
+testObject_Event_meeting_delete_manual_1 :: Event
+testObject_Event_meeting_delete_manual_1 =
+  Event
+    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtSubConv = Nothing,
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtData = EdMeetingDelete (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
+      evtTeam = Nothing
+    }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
@@ -59,36 +59,3 @@ testObject_Event_conversation_manual_3 =
       evtData = EdProtocolUpdate P.ProtocolMixedTag,
       evtTeam = Nothing
     }
-
-testObject_Event_meeting_create_manual_1 :: Event
-testObject_Event_meeting_create_manual_1 =
-  Event
-    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
-      evtSubConv = Nothing,
-      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
-      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
-      evtData = EdMeetingCreate (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
-      evtTeam = Nothing
-    }
-
-testObject_Event_meeting_update_manual_1 :: Event
-testObject_Event_meeting_update_manual_1 =
-  Event
-    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
-      evtSubConv = Nothing,
-      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
-      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
-      evtData = EdMeetingUpdate (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
-      evtTeam = Nothing
-    }
-
-testObject_Event_meeting_delete_manual_1 :: Event
-testObject_Event_meeting_delete_manual_1 =
-  Event
-    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
-      evtSubConv = Nothing,
-      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
-      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
-      evtData = EdMeetingDelete (Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}}),
-      evtTeam = Nothing
-    }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/MeetingEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/MeetingEvent.hs
@@ -1,0 +1,59 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2026 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Golden.Manual.MeetingEvent where
+
+import Data.Domain (Domain (..))
+import Data.Id
+import Data.Qualified (Qualified (..))
+import Data.Time
+import Data.UUID qualified as UUID
+import Imports
+import Wire.API.Event.Meeting
+
+testObject_Event_meeting_create_manual_1 :: Event
+testObject_Event_meeting_create_manual_1 =
+  Event
+    { evtType = Create,
+      evtMeeting = Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}},
+      evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtTeam = Nothing
+    }
+
+testObject_Event_meeting_update_manual_1 :: Event
+testObject_Event_meeting_update_manual_1 =
+  Event
+    { evtType = Update,
+      evtMeeting = Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}},
+      evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtTeam = Nothing
+    }
+
+testObject_Event_meeting_delete_manual_1 :: Event
+testObject_Event_meeting_delete_manual_1 =
+  Event
+    { evtType = Delete,
+      evtMeeting = Qualified {qUnqualified = Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")), qDomain = Domain {_domainText = "example.com"}},
+      evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtFrom = EventFromUser $ Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtTeam = Nothing
+    }

--- a/libs/wire-api/test/golden/testObject_Event_meeting_create_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_create_manual_1.json
@@ -1,0 +1,21 @@
+{
+    "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "data": {
+        "qualified_id": {
+            "domain": "example.com",
+            "id": "00000001-0000-0000-0000-000000000001"
+        }
+    },
+    "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
+    "qualified_conversation": {
+        "domain": "example.com",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "qualified_from": {
+        "domain": "example.com",
+        "id": "a471447c-aa30-4592-81b0-dec6c1c02bca"
+    },
+    "time": "2018-01-01T00:00:00.000Z",
+    "type": "meeting.create",
+    "via": "user"
+}

--- a/libs/wire-api/test/golden/testObject_Event_meeting_create_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_create_manual_1.json
@@ -1,10 +1,8 @@
 {
     "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
-    "data": {
-        "qualified_id": {
-            "domain": "example.com",
-            "id": "00000001-0000-0000-0000-000000000001"
-        }
+    "qualified_id": {
+        "domain": "example.com",
+        "id": "00000001-0000-0000-0000-000000000001"
     },
     "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
     "qualified_conversation": {

--- a/libs/wire-api/test/golden/testObject_Event_meeting_delete_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_delete_manual_1.json
@@ -1,10 +1,8 @@
 {
     "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
-    "data": {
-        "qualified_id": {
-            "domain": "example.com",
-            "id": "00000001-0000-0000-0000-000000000001"
-        }
+    "qualified_id": {
+        "domain": "example.com",
+        "id": "00000001-0000-0000-0000-000000000001"
     },
     "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
     "qualified_conversation": {

--- a/libs/wire-api/test/golden/testObject_Event_meeting_delete_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_delete_manual_1.json
@@ -1,0 +1,21 @@
+{
+    "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "data": {
+        "qualified_id": {
+            "domain": "example.com",
+            "id": "00000001-0000-0000-0000-000000000001"
+        }
+    },
+    "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
+    "qualified_conversation": {
+        "domain": "example.com",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "qualified_from": {
+        "domain": "example.com",
+        "id": "a471447c-aa30-4592-81b0-dec6c1c02bca"
+    },
+    "time": "2018-01-01T00:00:00.000Z",
+    "type": "meeting.delete",
+    "via": "user"
+}

--- a/libs/wire-api/test/golden/testObject_Event_meeting_update_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_update_manual_1.json
@@ -1,0 +1,21 @@
+{
+    "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "data": {
+        "qualified_id": {
+            "domain": "example.com",
+            "id": "00000001-0000-0000-0000-000000000001"
+        }
+    },
+    "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
+    "qualified_conversation": {
+        "domain": "example.com",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "qualified_from": {
+        "domain": "example.com",
+        "id": "a471447c-aa30-4592-81b0-dec6c1c02bca"
+    },
+    "time": "2018-01-01T00:00:00.000Z",
+    "type": "meeting.update",
+    "via": "user"
+}

--- a/libs/wire-api/test/golden/testObject_Event_meeting_update_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_meeting_update_manual_1.json
@@ -1,10 +1,8 @@
 {
     "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
-    "data": {
-        "qualified_id": {
-            "domain": "example.com",
-            "id": "00000001-0000-0000-0000-000000000001"
-        }
+    "qualified_id": {
+        "domain": "example.com",
+        "id": "00000001-0000-0000-0000-000000000001"
     },
     "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
     "qualified_conversation": {

--- a/libs/wire-api/test/unit/Test/Wire/API/Conversation.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Conversation.hs
@@ -86,9 +86,6 @@ testIsCellsConversationEvent =
         OtrMessageAdd -> isCellsConversationEvent e === False
         ProtocolUpdate -> isCellsConversationEvent e === False
         Typing -> isCellsConversationEvent e === False
-        MeetingCreate -> isCellsConversationEvent e === False
-        MeetingUpdate -> isCellsConversationEvent e === False
-        MeetingDelete -> isCellsConversationEvent e === False
 
 --------------------------------------------------------------------------------
 -- Legacy conversion tests

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -105,6 +105,7 @@ library
     Wire.API.Event.Federation
     Wire.API.Event.Gundeck
     Wire.API.Event.LeaveReason
+    Wire.API.Event.Meeting
     Wire.API.Event.Team
     Wire.API.Event.WebSocketProtocol
     Wire.API.FederationStatus
@@ -645,6 +646,7 @@ test-suite wire-api-golden-tests
     Test.Wire.API.Golden.Manual.ListUsersById
     Test.Wire.API.Golden.Manual.Login_user
     Test.Wire.API.Golden.Manual.LoginId_user
+    Test.Wire.API.Golden.Manual.MeetingEvent
     Test.Wire.API.Golden.Manual.MLSKeys
     Test.Wire.API.Golden.Manual.Pagination
     Test.Wire.API.Golden.Manual.Presence

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -42,7 +42,7 @@ import Polysemy.TinyLog qualified as TinyLog
 import System.Logger qualified as Log
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Role (roleNameWireAdmin)
-import Wire.API.Event.Conversation qualified as ConvEvent
+import Wire.API.Event.Meeting qualified as MeetingEvent
 import Wire.API.Meeting qualified as API
 import Wire.API.Push.V2 qualified as PushV2
 import Wire.API.Routes.MultiTablePaging qualified as MultiTablePaging
@@ -193,7 +193,7 @@ createMeetingImpl zUser newMeeting = do
       trial
 
   let qMeetingId = Qualified storedMeeting.id (tDomain zUser)
-  pushMeetingEvent zUser Nothing storedConv.localMembers (Qualified storedConv.id_ (tDomain zUser)) conversationTeamId (ConvEvent.EdMeetingCreate qMeetingId)
+  pushMeetingEvent zUser Nothing storedConv.localMembers (Qualified storedConv.id_ (tDomain zUser)) conversationTeamId MeetingEvent.Create qMeetingId
 
   pure $ storedMeetingToMeetingWithConversation zUser storedConv storedMeeting
 
@@ -243,7 +243,7 @@ updateMeetingImpl zUser meetingId update validityPeriod = do
           update.endTime
           update.recurrence
     conv <- MaybeT $ getMeetingConversationOrFail meetingId updatedMeeting.conversationId
-    lift $ pushMeetingEvent zUser Nothing conv.localMembers (Qualified conv.id_ (tDomain zUser)) maybeTeamId (ConvEvent.EdMeetingUpdate meetingId)
+    lift $ pushMeetingEvent zUser Nothing conv.localMembers (Qualified conv.id_ (tDomain zUser)) maybeTeamId MeetingEvent.Update meetingId
     pure $ storedMeetingToMeetingWithConversation zUser conv updatedMeeting
 
 deleteMeetingImpl ::
@@ -280,7 +280,7 @@ deleteMeetingImpl zUser connId meetingId validityPeriod = do
           void $
             ConversationSubsystem.deleteLocalConversation zUser connId lConvId
       lift $ Store.deleteMeeting (qUnqualified meetingId)
-      lift $ pushMeetingEvent zUser (Just connId) conv.localMembers (Qualified conv.id_ (tDomain zUser)) maybeTeamId (ConvEvent.EdMeetingDelete meetingId)
+      lift $ pushMeetingEvent zUser (Just connId) conv.localMembers (Qualified conv.id_ (tDomain zUser)) maybeTeamId MeetingEvent.Delete meetingId
   pure $ isJust result
 
 getMeetingImpl ::
@@ -349,20 +349,21 @@ pushMeetingEvent ::
   [LocalMember] ->
   Qualified ConvId ->
   Maybe TeamId ->
-  ConvEvent.EventData ->
+  MeetingEvent.EventType ->
+  Qualified MeetingId ->
   Sem r ()
-pushMeetingEvent lUser conn members qConvId mTeamId edata = do
+pushMeetingEvent lUser conn members qConvId mTeamId meetingType qMeetingId = do
   now <- Now.get
   let evt =
-        ConvEvent.Event
-          { evtConv = qConvId,
-            evtSubConv = Nothing,
+        MeetingEvent.Event
+          { evtType = meetingType,
+            evtMeeting = qMeetingId,
+            evtConv = qConvId,
             evtFrom =
-              ConvEvent.EventFromUser
+              MeetingEvent.EventFromUser
                 (Qualified (tUnqualified lUser) (tDomain lUser)),
             evtTime = now,
-            evtTeam = mTeamId,
-            evtData = edata
+            evtTeam = mTeamId
           }
   pushNotifications
     [ def

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -44,7 +44,7 @@ import Text.Email.Parser (unsafeEmailAddress)
 import Wire.API.Conversation (Access (InviteAccess, PrivateAccess), Conversation (metadata, qualifiedId), ConversationMetadata (cnvmAccess))
 import Wire.API.Error (ErrorS)
 import Wire.API.Error.Galley (GalleyError (TeamMemberNotFound, TeamNotFound))
-import Wire.API.Event.Conversation qualified as ConvEvent
+import Wire.API.Event.Meeting qualified as MeetingEvent
 import Wire.API.Meeting qualified as API
 import Wire.API.Team.Feature
 import Wire.API.Team.Member (TeamMember, mkTeamMember)
@@ -135,21 +135,12 @@ runTestStack now gen teams configs =
     . inMemoryMeetingsStoreInterpreter
     . interpretMeetingsSubsystem 3600
 
--- | Decode all 'Push' payloads that are conversation events carrying meeting
--- lifecycle data.
-extractMeetingEvents :: [Push] -> [ConvEvent.Event]
+-- | Decode all 'Push' payloads that are meeting lifecycle events. Any push that
+-- decodes as a 'MeetingEvent.Event' is one: conversation events use distinct
+-- @type@ tags that the meeting 'EventType' enum rejects.
+extractMeetingEvents :: [Push] -> [MeetingEvent.Event]
 extractMeetingEvents pushes =
-  [ e
-  | push <- pushes,
-    Success e <- [fromJSON (Object push.json)],
-    isMeetingEvent e
-  ]
-  where
-    isMeetingEvent e = case e.evtData of
-      ConvEvent.EdMeetingCreate _ -> True
-      ConvEvent.EdMeetingUpdate _ -> True
-      ConvEvent.EdMeetingDelete _ -> True
-      _ -> False
+  [ e | push <- pushes, Success e <- [fromJSON (Object push.json)] ]
 
 spec :: Spec
 spec = describe "MeetingsSubsystem.Interpreter" $ do
@@ -1389,9 +1380,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         Right (meeting, pushes) -> do
           let events = extractMeetingEvents pushes
           length events `shouldBe` 1
-          case (head events).evtData of
-            ConvEvent.EdMeetingCreate mid -> mid `shouldBe` meeting.meeting.id
-            other -> fail $ "expected EdMeetingCreate, got " <> show other
+          (head events).evtType `shouldBe` MeetingEvent.Create
+          (head events).evtMeeting `shouldBe` meeting.meeting.id
 
     it "emits a meeting.update event on successful update" $ do
       result <-
@@ -1406,9 +1396,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         Right pushes -> do
           let events = extractMeetingEvents pushes
           length events `shouldBe` 1
-          case (head events).evtData of
-            ConvEvent.EdMeetingUpdate _ -> pure ()
-            other -> fail $ "expected EdMeetingUpdate, got " <> show other
+          (head events).evtType `shouldBe` MeetingEvent.Update
 
     it "emits a meeting.delete event on successful delete" $ do
       result <-
@@ -1423,9 +1411,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         Right pushes -> do
           let events = extractMeetingEvents pushes
           length events `shouldBe` 1
-          case (head events).evtData of
-            ConvEvent.EdMeetingDelete _ -> pure ()
-            other -> fail $ "expected EdMeetingDelete, got " <> show other
+          (head events).evtType `shouldBe` MeetingEvent.Delete
 
     it "does not emit an event when updateMeeting fails (non-creator)" $ do
       result <-

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -140,7 +140,7 @@ runTestStack now gen teams configs =
 -- @type@ tags that the meeting 'EventType' enum rejects.
 extractMeetingEvents :: [Push] -> [MeetingEvent.Event]
 extractMeetingEvents pushes =
-  [ e | push <- pushes, Success e <- [fromJSON (Object push.json)] ]
+  [e | push <- pushes, Success e <- [fromJSON (Object push.json)]]
 
 spec :: Spec
 spec = describe "MeetingsSubsystem.Interpreter" $ do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-26705

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
