### PR TITLE
fix 2025-q2 CI

### DIFF
--- a/changelog.d/3-bug-fixes/bitnamilegacy-repo
+++ b/changelog.d/3-bug-fixes/bitnamilegacy-repo
@@ -1,0 +1,5 @@
+Use *bitnamilegacy* *docker.io* repository for bitnami images. The
+`docker.io/bitnami` repository is deprecated and offline;
+`docker.io/bitnamilegacy` provides the old images for continued compatibility.
+Updated RabbitMQ, Redis, PostgreSQL, and kubectl images to use the legacy
+repository.

--- a/changelog.d/3-bug-fixes/rabbitmq-repo
+++ b/changelog.d/3-bug-fixes/rabbitmq-repo
@@ -1,0 +1,1 @@
+Use *bitnamilegacy* *docker.io* repository for RabbitMQ images. The `docker.io/bitnami` repository is deprecated and offline; `docker.io/bitnamilegacy` provides the old images for continued compatibility.

--- a/changelog.d/3-bug-fixes/rabbitmq-repo
+++ b/changelog.d/3-bug-fixes/rabbitmq-repo
@@ -1,1 +1,0 @@
-Use *bitnamilegacy* *docker.io* repository for RabbitMQ images. The `docker.io/bitnami` repository is deprecated and offline; `docker.io/bitnamilegacy` provides the old images for continued compatibility.

--- a/charts/legalhold/values.yaml
+++ b/charts/legalhold/values.yaml
@@ -22,3 +22,8 @@ podSecurityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+
+postgresql:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -1,0 +1,5 @@
+rabbitmq:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/rabbitmq
+    tag: 3.13.7-debian-12-r2

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               app: reaper
       containers:
         - name: reaper
-          image: bitnami/kubectl:1.32.2
+          image: bitnamilegacy/kubectl:1.32.2
           command: ["/app/reaper.sh", "{{ .Release.Namespace }}"]
           volumeMounts:
             - name: reaper-script

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1,3 +1,7 @@
 redis-cluster:
   usePassword: false
   fullnameOverride: "redis-cluster"
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis-cluster
+    tag: 6.2.7-debian-11-r9

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -4,4 +4,3 @@ redis-cluster:
   image:
     registry: docker.io
     repository: bitnamilegacy/redis-cluster
-    tag: 6.2.7-debian-11-r9

--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -3,6 +3,10 @@ redis-ephemeral:
   architecture: standalone
   auth:
     enabled: false
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+    tag: 6.2.7-debian-11-r0
   master:
     persistence:
       enabled: false

--- a/charts/redis-ephemeral/values.yaml
+++ b/charts/redis-ephemeral/values.yaml
@@ -6,7 +6,6 @@ redis-ephemeral:
   image:
     registry: docker.io
     repository: bitnamilegacy/redis
-    tag: 6.2.7-debian-11-r0
   master:
     persistence:
       enabled: false

--- a/charts/restund/templates/statefulset.yaml
+++ b/charts/restund/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
 {{- end }}
       initContainers:
         - name: get-external-ip
-          image: bitnami/kubectl:1.24.12
+          image: bitnamilegacy/kubectl:1.24.12
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip


### PR DESCRIPTION
Use `bitnamilegacy` instead of the deleted `bitnami` `docker.io` image repository. 

Ticket: https://wearezeta.atlassian.net/browse/WPB-27321
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
