### PR TITLE
Replace gone bitnami image cache

### DIFF
--- a/changelog.d/5-internal/wire-image-mirror-for-integration-tests
+++ b/changelog.d/5-internal/wire-image-mirror-for-integration-tests
@@ -1,0 +1,5 @@
+Use wire image mirror for integration tests as `public.ecr.aws/bitnami/` is no
+longer available
+(https://aws.amazon.com/blogs/containers/bitnami-image-removal-from-ecr-public/).
+Docker Hub has strict rate-limiting. So, in lieu of better options, we now use
+our own image cache at `quay.io/wire/mirror-images`.

--- a/hack/helm_vars/wire-image-mirror.yaml
+++ b/hack/helm_vars/wire-image-mirror.yaml
@@ -1,6 +1,6 @@
 global:
   # The default is to use docker hub, which has very strict rate limiting. This
   # comes in the way of testing, specially when running flake-news.
-  imageRegistry: public.ecr.aws
+  imageRegistry: quay.io/wire/mirror-images
   security:
     allowInsecureImages: true

--- a/hack/helmfile.yaml.gotmpl
+++ b/hack/helmfile.yaml.gotmpl
@@ -118,7 +118,7 @@ releases:
     namespace: '{{ .Values.namespace1 }}'
     chart: '../.local/charts/redis-ephemeral'
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/redis-ephemeral/values.yaml'
     needs:
       - certs
@@ -151,7 +151,7 @@ releases:
     namespace: '{{ .Values.namespace2 }}'
     chart: '../.local/charts/redis-ephemeral'
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/redis-ephemeral/values.yaml'
     needs:
       - certs
@@ -164,8 +164,10 @@ releases:
     namespace: "{{ .Values.namespace1 }}"
     chart: "bitnami/postgresql"
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/postgresql/values.yaml.gotmpl'
+      - image:
+          repository: postgresql
       - primary:
           initdb:
             scripts:
@@ -184,8 +186,10 @@ releases:
     namespace: "{{ .Values.namespace2 }}"
     chart: "bitnami/postgresql"
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/postgresql/values.yaml.gotmpl'
+      - image:
+          repository: postgresql
       - primary:
           initdb:
             scripts:
@@ -253,16 +257,20 @@ releases:
     chart: 'bitnami/rabbitmq'
     version: '16.0.14'
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/rabbitmq/values.yaml.gotmpl'
+      - image:
+          repository: rabbitmq
 
   - name: 'rabbitmq'
     namespace: '{{ .Values.namespace2 }}'
     chart: 'bitnami/rabbitmq'
     version: '16.0.14'
     values:
-      - './helm_vars/bitnami.yaml'
+      - './helm_vars/wire-image-mirror.yaml'
       - './helm_vars/rabbitmq/values.yaml.gotmpl'
+      - image:
+          repository: rabbitmq
 
   - name: 'ingress'
     namespace: '{{ .Values.namespace1 }}'


### PR DESCRIPTION
Restating the changelog entry:

> Use wire image mirror for integration tests as `public.ecr.aws/bitnami/` is no
longer available
(https://aws.amazon.com/blogs/containers/bitnami-image-removal-from-ecr-public/).
Docker Hub has strict rate-limiting. So, in lieu of better options, we now use
our own image cache at `quay.io/wire/mirror-images`.

Ticket: https://wearezeta.atlassian.net/browse/WPB-26364

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
