### PR TITLE
WPB-26771: Deprecate meetingsPremium endpoints at API v17

### DIFF
--- a/changelog.d/0-release-notes/wpb-26771-meetings-premium.md
+++ b/changelog.d/0-release-notes/wpb-26771-meetings-premium.md
@@ -6,4 +6,4 @@
   endpoints are retained for backward compatibility but have no behavioural
   effect; any Helm overrides for `meetingsPremium` are now ignored and can be
   removed. The public/internal HTTP endpoints now return 404 at API version v17
-  and remain available through v16; the flag type remains deprecated.
+  and remain available through v16; the flag type remains deprecated. The aggregate `GET /feature-configs` and `GET /teams/:tid/features` endpoints continue to include `meetingsPremium` at all API versions, including v17.

--- a/changelog.d/0-release-notes/wpb-26771-meetings-premium.md
+++ b/changelog.d/0-release-notes/wpb-26771-meetings-premium.md
@@ -5,4 +5,5 @@
   `charts/wire-server`. The flag's data type and its public/internal HTTP
   endpoints are retained for backward compatibility but have no behavioural
   effect; any Helm overrides for `meetingsPremium` are now ignored and can be
-  removed. The flag is scheduled for removal in a future release.
+  removed. The public/internal HTTP endpoints now return 404 at API version v17
+  and remain available through v16; the flag type remains deprecated.

--- a/changelog.d/1-api-changes/wpb-26771-meetings-premium-endpoint.md
+++ b/changelog.d/1-api-changes/wpb-26771-meetings-premium-endpoint.md
@@ -1,0 +1,5 @@
+The `meetingsPremium` team feature endpoints are deprecated and return 404 for
+clients on API version v17: the public `GET`/`PUT /teams/:tid/features/meetingsPremium`
+and the internal legacy lock `PUT /i/teams/:tid/features/meetingsPremium/(un)?locked`.
+They remain available through v16. The flag has had no behavioural effect since
+WPB-26771 (team meetings are always non-trial). (WPB-26771)

--- a/changelog.d/1-api-changes/wpb-26771-meetings-premium-endpoint.md
+++ b/changelog.d/1-api-changes/wpb-26771-meetings-premium-endpoint.md
@@ -2,4 +2,7 @@ The `meetingsPremium` team feature endpoints are deprecated and return 404 for
 clients on API version v17: the public `GET`/`PUT /teams/:tid/features/meetingsPremium`
 and the internal legacy lock `PUT /i/teams/:tid/features/meetingsPremium/(un)?locked`.
 They remain available through v16. The flag has had no behavioural effect since
-WPB-26771 (team meetings are always non-trial). (WPB-26771)
+WPB-26771 (team meetings are always non-trial). The aggregate endpoints
+`GET /feature-configs` and `GET /teams/:tid/features` are unaffected and continue
+to include `meetingsPremium` at all API versions: the aggregate feature list is
+version-agnostic, like other version-gated features such as MLS. (WPB-26771)

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -286,15 +286,15 @@ for `smtp.passwordFile`.
 
 > **Deprecated (WPB-26771).** The `meetingsPremium` feature flag no longer
 > affects meeting behaviour. Team meetings are always non-trial regardless of
-> this flag's value. The flag, its data type and its public/internal endpoints
-> are retained for backward compatibility and are scheduled for removal in a
-> future release.
+> this flag's value. The flag and its data type are retained for backward
+> compatibility.
 
 The flag now defaults to **enabled and locked** and the Helm configuration
 override has been removed (operators can no longer change it via Helm). The
-`MeetingsPremiumConfig` type carries a `DEPRECATED` pragma. Existing
-`GET/PUT /teams/:tid/features/meetingsPremium` and internal lock-status
-endpoints remain available but have no behavioural effect.
+`MeetingsPremiumConfig` type carries a `DEPRECATED` pragma. The public
+`GET/PUT /teams/:tid/features/meetingsPremium` endpoints and the internal
+lock-status endpoints have no behavioural effect and now return 404 at API
+version v17; they remain available through v16.
 
 ### Background Effects
 

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -296,6 +296,10 @@ override has been removed (operators can no longer change it via Helm). The
 lock-status endpoints have no behavioural effect and now return 404 at API
 version v17; they remain available through v16.
 
+The aggregate list endpoints (`GET /feature-configs`,
+`GET /teams/:tid/features`) continue to include `meetingsPremium` at all API
+versions, including v17.
+
 ### Background Effects
 
 The `backgroundEffects` feature flag controls whether background effects are available in meetings. It is disabled and locked by default. If you want a different configuration, use the following syntax: 

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -91,5 +91,12 @@ testNonMemberAccess :: (HasCallStack) => Feature -> App ()
 testNonMemberAccess (Feature featureName) = do
   (_, tid, _) <- createTeam OwnDomain 0
   nonMember <- randomUser OwnDomain def
-  Public.getTeamFeature nonMember tid featureName
-    >>= assertForbidden
+  -- meetingsPremium's public per-feature GET is version-gated at v17
+  -- (WPB-26771): it 404s there. Hit it at v16 so the non-member-access
+  -- authz check (403 no-team-member) is still exercised.
+  let getFeature = Public.getTeamFeature nonMember tid featureName
+  resp <-
+    if featureName == "meetingsPremium"
+      then withAPIVersion 16 getFeature
+      else getFeature
+  assertForbidden resp

--- a/integration/test/Test/FeatureFlags/MeetingPremium.hs
+++ b/integration/test/Test/FeatureFlags/MeetingPremium.hs
@@ -49,3 +49,21 @@ testMeetingPremiumRemovedAtV17 = do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "enabled"
     resp.json %. "lockStatus" `shouldMatch` "locked"
+
+-- | WPB-26771: the aggregate list endpoints 'GET /feature-configs' and
+-- 'GET /teams/:tid/features' are version-agnostic — like 'From'-gated features
+-- (e.g. MLS), they include every feature at every API version. Even though the
+-- dedicated meetingsPremium endpoints 404 at v17, both list endpoints keep
+-- returning the (default enabled+locked) meetingsPremium entry. This test
+-- locks that behaviour in.
+testMeetingPremiumListedAtV17 :: (HasCallStack) => App ()
+testMeetingPremiumListedAtV17 = do
+  (owner, tid, _) <- createTeam OwnDomain 0
+  let assertMeetingPremium resp = do
+        resp.status `shouldMatchInt` 200
+        mp <- resp.json %. "meetingsPremium"
+        mp %. "status" `shouldMatch` "enabled"
+        mp %. "lockStatus" `shouldMatch` "locked"
+      teamFeatures = joinHttpPath ["teams", tid, "features"]
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) "/feature-configs" >>= submit "GET") assertMeetingPremium
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) teamFeatures >>= submit "GET") assertMeetingPremium

--- a/integration/test/Test/FeatureFlags/MeetingPremium.hs
+++ b/integration/test/Test/FeatureFlags/MeetingPremium.hs
@@ -17,14 +17,35 @@
 
 module Test.FeatureFlags.MeetingPremium where
 
+import SetupHelpers (createTeam)
 import Test.FeatureFlags.Util
 import Testlib.Prelude
 
 testPatchMeetingPremium :: (HasCallStack) => App ()
-testPatchMeetingPremium = checkPatch OwnDomain "meetingsPremium" disabledLocked
+testPatchMeetingPremium = withAPIVersion 16 $ checkPatch OwnDomain "meetingsPremium" disabledLocked
 
 testMeetingPremium :: (HasCallStack) => APIAccess -> App ()
 testMeetingPremium access =
-  mkFeatureTests "meetingsPremium"
+  withAPIVersion 16
+    $ mkFeatureTests "meetingsPremium"
     & addUpdate enabled
     & runFeatureTests OwnDomain access
+
+-- | WPB-26771: the public meetingsPremium endpoints are gated at v17 (404)
+-- while remaining available through v16. Only the v16 GET is asserted here:
+-- v16 PUT success is covered by 'testMeetingPremium' (whose runFeatureTests
+-- unlocks the feature first), and a public PUT in this test would 409
+-- feature-locked against the default enabled+locked state.
+testMeetingPremiumRemovedAtV17 :: (HasCallStack) => App ()
+testMeetingPremiumRemovedAtV17 = do
+  (owner, tid, _) <- createTeam OwnDomain 0
+  let p = joinHttpPath ["teams", tid, "features", "meetingsPremium"]
+      body = object ["status" .= "enabled", "lockStatus" .= "locked"]
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p >>= submit "GET") $ \resp -> do
+    resp.status `shouldMatchInt` 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p <&> addJSON body >>= submit "PUT") $ \resp -> do
+    resp.status `shouldMatchInt` 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 16) p >>= submit "GET") $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "status" `shouldMatch` "enabled"
+    resp.json %. "lockStatus" `shouldMatch` "locked"

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -99,7 +99,7 @@ type IFeatureAPI =
     :<|> IFeatureStatusLockStatusPut SimplifiedUserConnectionRequestQRCodeConfig
     :<|> IFeatureStatusLockStatusPut StealthUsersConfig
     :<|> IFeatureStatusLockStatusPut MeetingsConfig
-    :<|> IFeatureStatusLockStatusPut MeetingsPremiumConfig
+    :<|> Until 'V17 ::> IFeatureStatusLockStatusPut MeetingsPremiumConfig
     :<|> IFeatureStatusLockStatusPut BackgroundEffectsConfig
     -- all feature configs
     :<|> Named

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -22,6 +22,7 @@ import Data.Id
 import GHC.TypeLits
 import Servant
 import Servant.OpenApi.Internal.Orphans ()
+import Wire.API.Deprecated
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.OAuth
@@ -83,7 +84,8 @@ type FeatureAPI =
     :<|> FeatureAPIGet StealthUsersConfig
     :<|> FeatureAPIGet CellsInternalConfig
     :<|> FeatureAPIGetPut MeetingsConfig
-    :<|> FeatureAPIGetPut MeetingsPremiumConfig
+    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGet MeetingsPremiumConfig
+    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIPut MeetingsPremiumConfig
     :<|> FeatureAPIGetPut BackgroundEffectsConfig
 
 type VersionedFeatureAPIPut named reqBodyVersion cfg =

--- a/libs/wire-api/src/Wire/API/VersionInfo.hs
+++ b/libs/wire-api/src/Wire/API/VersionInfo.hs
@@ -130,6 +130,13 @@ instance
 instance (RoutesToPaths api) => RoutesToPaths (Until v :> api) where
   getRoutes = getRoutes @api
 
+-- | 'Until' is transparent for OpenAPI generation: version gating is a runtime
+-- concern, and a non-version-specific doc (e.g. the internal API) renders the
+-- inner endpoint. Per-version docs go through 'SpecialiseToVersion', which
+-- strips 'Until'\/'From' and never reaches this instance.
+instance (HasOpenApi api) => HasOpenApi (Until v :> api) where
+  toOpenApi _ = toOpenApi (Proxy @api)
+
 instance
   ( SingI n,
     Ord (Demote v),
@@ -171,6 +178,11 @@ instance
 
 instance (RoutesToPaths api) => RoutesToPaths (From v :> api) where
   getRoutes = getRoutes @api
+
+-- | Same as the 'Until' instance above: a doc no-op for non-version-specific
+-- docs (e.g. the internal API). Per-version docs specialise it away.
+instance (HasOpenApi api) => HasOpenApi (From v :> api) where
+  toOpenApi _ = toOpenApi (Proxy @api)
 
 instance (Enum v, HasServer api ctx) => HasServer (APIVersion (v :: Type) :> api) ctx where
   type ServerT (APIVersion v :> api) m = v -> ServerT api m

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -84,7 +84,8 @@ featureAPI =
     <@> mkNamedAPI @'("get", StealthUsersConfig) getFeature
     <@> mkNamedAPI @'("get", CellsInternalConfig) getFeature
     <@> featureAPIGetPut @MeetingsConfig
-    <@> featureAPIGetPut @MeetingsPremiumConfig
+    <@> mkNamedAPI @'("get", MeetingsPremiumConfig) getFeature
+    <@> mkNamedAPI @'("put", MeetingsPremiumConfig) setFeature
     <@> featureAPIGetPut @BackgroundEffectsConfig
 
 deprecatedFeatureConfigAPI :: API DeprecatedFeatureAPI GalleyEffects


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-26771

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
