### PR TITLE
Deflake modservice

### DIFF
--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -34,7 +34,7 @@ import Control.Applicative
 import Control.Concurrent
 import Control.Concurrent.Async
 import qualified Control.Exception as E
-import Control.Monad.Catch (catch, catchAll, throwM)
+import Control.Monad.Catch (catch, throwM)
 import Control.Monad.Codensity
 import Control.Monad.Extra
 import Control.Monad.Reader
@@ -473,7 +473,7 @@ checkFederationIngress origin target = do
               (do
                   label <- inner %. "label" & asString
                   pure $ res.status == 533 && label == "federation-denied"
-              ) `catchAll` const (pure False)
+              ) `catch` \(_ :: AssertionFailure) -> pure False
           pure (is200 || isFedDenied)
         _ -> pure False
   eith <- liftIO (E.try checkStatus)

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -63,6 +63,7 @@ import qualified Data.Yaml as Yaml
 import GHC.Stack
 import qualified Network.HTTP.Client as HTTP
 import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory, removeDirectoryRecursive, removeFile)
+import System.Environment (lookupEnv)
 import System.Exit
 import System.FilePath
 import System.IO
@@ -669,23 +670,37 @@ logToConsoleDebug mOutput colorize prefix hdl = do
 federatorIngressDelay :: Int
 federatorIngressDelay = 30 * 1000 * 1000
 
--- | Pre-warm the static 'domain1' <-> 'domain2' federation path once, before
--- the test suite bursts. 'ensureBackendReachable' only warms /dynamic/ backends
--- (it skips the two static domains), so the very first cross-domain call
--- between them can fail with a transient federator-transport error
--- (521 connection refused, 525 SSL, 533 unreachable backend). Polling the
--- federator ingress in both directions here removes that cold-start race
--- globally, rather than retrying individual requests whose execution order is
--- not guaranteed.
+-- | Pre-warm the static federation paths once, before the test suite bursts.
+-- 'ensureBackendReachable' only warms dynamic backends, so static federation
+-- paths must be warmed here before tests run concurrently.
 warmupFederation :: (HasCallStack) => App ()
 warmupFederation = do
   env <- ask
-  let checkBoth =
+  enabledFedDomains <- liftIO $ fmap catMaybes $ for
+    [ (env.federationV0Domain, "ENABLE_FEDERATION_V0"),
+      (env.federationV1Domain, "ENABLE_FEDERATION_V1"),
+      (env.federationV2Domain, "ENABLE_FEDERATION_V2")
+    ]
+    $ \(domain, flag) -> do
+      enabled <- lookupEnv flag
+      pure $ if enabled == Just "1" then Just domain else Nothing
+  let primaryDomains = [env.domain1, env.domain2]
+      federationPairs =
+        [(env.domain1, env.domain2), (env.domain2, env.domain1)]
+          <> [ (origin, fedDomain)
+             | fedDomain <- enabledFedDomains,
+               origin <- primaryDomains
+             ]
+          <> [ (fedDomain, origin)
+             | fedDomain <- enabledFedDomains,
+               origin <- primaryDomains
+             ]
+      checkAll =
         and
           <$> traverse
             (uncurry checkFederationIngress)
-            [(env.domain1, env.domain2), (env.domain2, env.domain1)]
-  retryRequestUntil checkBoth "Static federator ingress (domain1 <-> domain2)"
+            federationPairs
+  retryRequestUntil checkAll "Static federator ingress"
 
 retryRequestUntil :: (HasCallStack) => ((HasCallStack) => App Bool) -> String -> App ()
 retryRequestUntil = retryRequestUntilDebug federatorIngressDelay Nothing

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -470,10 +470,11 @@ checkFederationIngress origin target = do
           isFedDenied <- case mInner of
             Nothing -> pure False
             Just inner ->
-              (do
+              ( do
                   label <- inner %. "label" & asString
                   pure $ res.status == 533 && label == "federation-denied"
-              ) `catch` \(_ :: AssertionFailure) -> pure False
+              )
+                `catch` \(_ :: AssertionFailure) -> pure False
           pure (is200 || isFedDenied)
         _ -> pure False
   eith <- liftIO (E.try checkStatus)
@@ -676,11 +677,13 @@ federatorIngressDelay = 30 * 1000 * 1000
 warmupFederation :: (HasCallStack) => App ()
 warmupFederation = do
   env <- ask
-  enabledFedDomains <- liftIO $ fmap catMaybes $ for
-    [ (env.federationV0Domain, "ENABLE_FEDERATION_V0"),
-      (env.federationV1Domain, "ENABLE_FEDERATION_V1"),
-      (env.federationV2Domain, "ENABLE_FEDERATION_V2")
-    ]
+  enabledFedDomains <- liftIO
+    $ fmap catMaybes
+    $ for
+      [ (env.federationV0Domain, "ENABLE_FEDERATION_V0"),
+        (env.federationV1Domain, "ENABLE_FEDERATION_V1"),
+        (env.federationV2Domain, "ENABLE_FEDERATION_V2")
+      ]
     $ \(domain, flag) -> do
       enabled <- lookupEnv flag
       pure $ if enabled == Just "1" then Just domain else Nothing

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -34,7 +34,7 @@ import Control.Applicative
 import Control.Concurrent
 import Control.Concurrent.Async
 import qualified Control.Exception as E
-import Control.Monad.Catch (catch, throwM)
+import Control.Monad.Catch (catch, catchAll, throwM)
 import Control.Monad.Codensity
 import Control.Monad.Extra
 import Control.Monad.Reader
@@ -459,14 +459,22 @@ checkFederationIngress origin target = do
         . (addJSONObject [])
   checkStatus <- appToIO $ do
     submit "POST" req `bindResponse` \res -> do
-      let is200 = res.status == 200
-      mInner <- lookupField res.json "inner"
-      isFedDenied <- case mInner of
-        Nothing -> pure False
-        Just inner -> do
-          label <- inner %. "label" & asString
-          pure $ res.status == 533 && label == "federation-denied"
-      pure (is200 || isFedDenied)
+      case res.json of
+        -- A federator can briefly return an empty or JSON-null body while the
+        -- backend is warming up. Keep the retry alive instead of letting
+        -- lookupField turn that transient response into a test failure.
+        Just (Object _) -> do
+          let is200 = res.status == 200
+          mInner <- lookupField res.json "inner"
+          isFedDenied <- case mInner of
+            Nothing -> pure False
+            Just inner ->
+              (do
+                  label <- inner %. "label" & asString
+                  pure $ res.status == 533 && label == "federation-denied"
+              ) `catchAll` const (pure False)
+          pure (is200 || isFedDenied)
+        _ -> pure False
   eith <- liftIO (E.try checkStatus)
   pure $ either (\(_e :: HTTP.HttpException) -> False) id eith
 


### PR DESCRIPTION
I looked at [Flake News](https://grafana.zinfra.io/d/6zSJfHVSk/flake-news-overview?orgId=1&from=now-30d&to=now&timezone=browser&var-db=P1B034DC710B014BB&var-run_id=20260302180221897638894) 

And at some test failures that keep coming up.

Then I asked some AI to help me figure out what might be wrong. This PR is the result of multiple rounds of AI prompting. To my naive eye it looks like it could be an improvement to 50% flake probability status quo. But maybe I'm wrong. I'm sorry to ask you to review a small piece of AI-generated code, but the 50% flakiness *is super annoying*, alternatively feel free to close/reject this PR and then please find alternative ways to improve the flakiness.

## Checklist

 - ~~[ ] Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
