### PR TITLE
fix(federator): reject leaked prometheus metrics dumps in discoverAndCall

### DIFF
--- a/changelog.d/5-internal/federator-reject-leaked-metrics-dump
+++ b/changelog.d/5-internal/federator-reject-leaked-metrics-dump
@@ -1,0 +1,6 @@
+The federator now rejects a leaked Prometheus metrics dump returned by a remote
+federator in response to a federation RPC (Content-Type
+`text/plain; version=0.0.4`) and surfaces it as a retryable
+`federation-remote-error` (533) instead of forwarding it as a success body.
+This fixes an intermittent failure where a `/i/metrics` response desynchronized
+onto a federation connection and was proxied back to the caller.

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -23,6 +23,7 @@ module Federator.Remote
     RemoteError (..),
     interpretRemote,
     discoverAndCall,
+    isPrometheusMetricsDump,
   )
 where
 
@@ -87,6 +88,15 @@ data Remote m a where
 
 makeSem ''Remote
 
+-- | True when the response carries the Prometheus exposition content-type
+-- (@text/plain; version=0.0.4@), emitted solely by
+-- @wai-middleware-prometheus@'s @respondWithMetrics@ for @GET \/i\/metrics@.
+-- A federation response is never such a dump, so the 'interpretRemote' guard
+-- surfaces it as a retryable remote error rather than a fake-success body.
+isPrometheusMetricsDump :: Foldable f => f HTTP.Header -> Bool
+isPrometheusMetricsDump =
+  any (\(n, v) -> n == HTTP.hContentType && v == "text/plain; version=0.0.4")
+
 interpretRemote ::
   ( Member (Embed (Codensity IO)) r,
     Member DiscoverFederator r,
@@ -131,6 +141,16 @@ interpretRemote = interpret $ \case
             E.Handler $ k . Left . FederatorClientHTTP2Exception,
             E.Handler $ k . Left . FederatorClientConnectionError
           ]
+
+    -- Safe to throw without draining: the body came over a single-use HTTP/2
+    -- connection (withHTTP2RequestOnSingleUseConnWithHook), torn down after.
+    when (isPrometheusMetricsDump (responseHeaders resp)) $
+      throw $
+        RemoteErrorResponse
+          target
+          pathT
+          (responseStatusCode resp)
+          "received prometheus metrics dump instead of a federation response"
 
     unless (HTTP.statusIsSuccessful (responseStatusCode resp)) $ do
       bdy <- embed @(Codensity IO) . liftIO $ streamingResponseStrictBody resp

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -27,7 +27,7 @@ import Federator.Options
 import Federator.Remote
 import Federator.Run (mkTLSSettingsOrThrow)
 import Imports
-import Network.HTTP.Types (status200)
+import Network.HTTP.Types (hContentType, status200)
 import Network.Wai
 import Network.Wai.Handler.Warp qualified as Warp
 import Network.Wai.Handler.WarpTLS qualified as Warp
@@ -52,7 +52,8 @@ tests =
     "Federator.Remote"
     [ testValidatesCertificateSuccess,
       testValidatesCertificateWrongHostname,
-      testConnectionError
+      testConnectionError,
+      testIsPrometheusMetricsDump
     ]
 
 settings :: RunSettings
@@ -165,6 +166,18 @@ testConnectionError = testCase "connection failures are reported correctly" $ do
     Left (RemoteError _ _ (FederatorClientConnectionError _)) -> pure ()
     Left x -> assertFailure $ "Expected connection error, got: " <> show x
     Right _ -> assertFailure "Expected connection with the server to fail"
+
+testIsPrometheusMetricsDump :: TestTree
+testIsPrometheusMetricsDump =
+  testGroup
+    "isPrometheusMetricsDump"
+    [ testCase "matches the prometheus exposition content-type" $
+        isPrometheusMetricsDump [(hContentType, "text/plain; version=0.0.4")] @?= True,
+      testCase "does not match a normal federation content-type" $
+        isPrometheusMetricsDump [(hContentType, "application/json")] @?= False,
+      testCase "does not match when content-type is absent" $
+        isPrometheusMetricsDump [] @?= False
+    ]
 
 certForLocalhost :: Warp.TLSSettings
 certForLocalhost = Warp.tlsSettings "test/resources/unit/localhost.pem" "test/resources/unit/localhost-key.pem"


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
