### PR TITLE
WPB-27393 guard bulk conversation member replacement against adminless groups

### DIFF
--- a/changelog.d/1-api-changes/WPB-27393
+++ b/changelog.d/1-api-changes/WPB-27393
@@ -1,0 +1,1 @@
+V17 `PUT /conversations/{domain}/{conversation}/members` rejects replacements that would leave a regular group without an admin; V16 retains the legacy autopromotion behavior.

--- a/integration/test/Test/AdminlessGroups.hs
+++ b/integration/test/Test/AdminlessGroups.hs
@@ -245,6 +245,27 @@ testAdminlessReplaceMembersAddsAdmin = do
     memberIds <- traverse (%. "qualified_id") members
     memberIds `shouldMatchSet` [bobId]
 
+testAdminlessReplaceMembersAddsEligibleMember :: (HasCallStack) => App ()
+testAdminlessReplaceMembersAddsEligibleMember = do
+  (alice, tid, [bob]) <- createTeam OwnDomain 2
+  configureAdminlessGroupsFeature OwnDomain tid "enabled" "10s" []
+  conv <- postConversation alice (defProteus {team = Just tid, qualifiedUsers = [], newUsersRole = "wire_member"}) >>= getJSON 201
+  bobId <- bob %. "qualified_id"
+
+  -- V17 rejects a replacement that removes the only admin even when the
+  -- eligible member is added by the same request.
+  bindResponse
+    (replaceMembers alice conv def {users = [bobId], role = Just "wire_member", version = Just 17})
+    $ \resp -> do
+      resp.status `shouldMatchInt` 403
+      resp.json %. "label" `shouldMatch` "adminless-conversation"
+      eligibleMembers <- resp.json %. "eligible_members" & asList
+      eligibleMembers `shouldMatchSet` [bobId]
+
+  bindResponse (getConversation alice conv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "members.self.conversation_role" `shouldMatch` "wire_admin"
+
 testAdminlessSetupSystemMemberUpdate :: (HasCallStack) => App ()
 testAdminlessSetupSystemMemberUpdate = do
   (alice, tid, [bob]) <- createTeam OwnDomain 2

--- a/integration/test/Test/AdminlessGroups.hs
+++ b/integration/test/Test/AdminlessGroups.hs
@@ -186,6 +186,65 @@ testAdminlessSetupOnFeatureEnable = do
     bindResponse (GalleyI.getConversation conv) $ \resp -> do
       resp.status `shouldMatchInt` 404
 
+testAdminlessReplaceMembers :: (HasCallStack) => App ()
+testAdminlessReplaceMembers = do
+  testVersion 16 $ \alice bob conv version -> do
+    bobId <- bob %. "qualified_id"
+    -- V16 retains the legacy behavior and autopromotes the remaining eligible member.
+    bindResponse (replaceMembers alice conv def {users = [bobId], version = Just version}) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+
+    bindResponse (getConversation bob conv) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "members.self.conversation_role" `shouldMatch` "wire_admin"
+      members <- resp.json %. "members.others" & asList
+      shouldBeEmpty members
+
+  testVersion 17 $ \alice bob conv version -> do
+    bobId <- bob %. "qualified_id"
+    -- V17 rejects a replacement that would remove the last admin while leaving
+    -- only eligible non-admin members.
+    bindResponse (replaceMembers alice conv def {users = [bobId], version = Just version}) $ \resp -> do
+      resp.status `shouldMatchInt` 403
+      resp.json %. "label" `shouldMatch` "adminless-conversation"
+      eligibleMembers <- resp.json %. "eligible_members" & asList
+      eligibleMembers `shouldMatchSet` [bobId]
+
+    -- The rejected replacement does not mutate membership: Bob is still a
+    -- member and Alice is still the admin.
+    bindResponse (getConversation alice conv) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "members.self.conversation_role" `shouldMatch` "wire_admin"
+      members <- resp.json %. "members.others" & asList
+      memberIds <- traverse (%. "qualified_id") members
+      memberIds `shouldMatchSet` [bobId]
+  where
+    testVersion version assertResult = do
+      (alice, tid, [bob]) <- createTeam OwnDomain 2
+      configureAdminlessGroupsFeature OwnDomain tid "enabled" "10s" []
+      conv <- postConversation alice (defProteus {team = Just tid, qualifiedUsers = [bob], newUsersRole = "wire_member"}) >>= getJSON 201
+      assertResult alice bob conv version
+
+testAdminlessReplaceMembersAddsAdmin :: (HasCallStack) => App ()
+testAdminlessReplaceMembersAddsAdmin = do
+  (alice, tid, [bob, charlie]) <- createTeam OwnDomain 3
+  configureAdminlessGroupsFeature OwnDomain tid "enabled" "10s" []
+  conv <- postConversation alice (defProteus {team = Just tid, qualifiedUsers = [bob], newUsersRole = "wire_member"}) >>= getJSON 201
+  bobId <- bob %. "qualified_id"
+  charlieId <- charlie %. "qualified_id"
+
+  -- V17 accepts replacing the existing admin when the same request adds a new
+  -- admin, because the resulting conversation is not adminless.
+  bindResponse (replaceMembers alice conv def {users = [bobId, charlieId], role = Just "wire_admin", version = Just 17}) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+
+  bindResponse (getConversation charlie conv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "members.self.conversation_role" `shouldMatch` "wire_admin"
+    members <- resp.json %. "members.others" & asList
+    memberIds <- traverse (%. "qualified_id") members
+    memberIds `shouldMatchSet` [bobId]
+
 testAdminlessSetupSystemMemberUpdate :: (HasCallStack) => App ()
 testAdminlessSetupSystemMemberUpdate = do
   (alice, tid, [bob]) <- createTeam OwnDomain 2

--- a/libs/wire-api/src/Wire/API/Routes/Features.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Features.hs
@@ -19,6 +19,7 @@ module Wire.API.Routes.Features where
 
 import Wire.API.Conversation.Role
 import Wire.API.Error.Galley
+import Wire.API.Routes.Version (Version (V17))
 import Wire.API.Team.Feature
 
 type family FeatureErrors cfg where
@@ -39,3 +40,8 @@ type family FeatureAPIDesc cfg where
   FeatureAPIDesc RequireExternalEmailVerificationConfig =
     "<p>Controls whether externally managed email addresses (from SAML or SCIM) must be verified by the user, or are auto-activated.</p><p>The external feature name is kept as <code>validateSAMLemails</code> for backward compatibility. That name is misleading because the feature also applies to SCIM-managed users, and it controls email ownership verification rather than generic email validation.</p>"
   FeatureAPIDesc _ = ""
+
+type family VersionedFeatureAPIDesc v cfg where
+  VersionedFeatureAPIDesc V17 PreventAdminlessGroupsConfig =
+    "<p>For API version 17, use duration strings for the timeout fields. The request body must have the following shape:</p><pre>{\n  &quot;config&quot;: {\n    &quot;deletionTimeoutDuration&quot;: &quot;7d&quot;,\n    &quot;promotionStrategy&quot;: &quot;alphabetical&quot;,\n    &quot;reminderTimeoutDurations&quot;: [\n      &quot;2d&quot;,\n      &quot;4d&quot;,\n      &quot;6d&quot;\n    ]\n  },\n  &quot;status&quot;: &quot;enabled&quot;\n}</pre><p>Older API versions use the legacy numeric fields <code>deletionTimeout</code> and <code>reminderTimeouts</code>.</p>"
+  VersionedFeatureAPIDesc _ cfg = FeatureAPIDesc cfg

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -955,7 +955,7 @@ type ConversationAPI =
     -- - MemberJoin event for added members
     -- - MemberLeave event for removed members
     :<|> Named
-           "replace-members-in-conversation"
+           "replace-members-in-conversation@v16"
            ( Summary "Replace the members of a conversation."
                :> Description
                     "This will add any members not already in the conversation, \
@@ -964,9 +964,42 @@ type ConversationAPI =
                     \The roles of already existing members will not be changed \
                     \even if these members are included in the request body and their role differs from the role provided in this request."
                :> From 'V13
+               :> Until 'V17
                :> CanThrow ('ActionDenied 'AddConversationMember)
                :> CanThrow ('ActionDenied 'RemoveConversationMember)
                :> CanThrow ('ActionDenied 'LeaveConversation)
+               :> CanThrow 'ConvNotFound
+               :> CanThrow 'InvalidOperation
+               :> CanThrow 'TooManyMembers
+               :> CanThrow 'ConvAccessDenied
+               :> CanThrow 'NotATeamMember
+               :> CanThrow 'NotConnected
+               :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow 'GroupIdVersionNotSupported
+               :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> "members"
+               :> ReqBody '[Servant.JSON] InviteQualified
+               :> MultiVerb1 'PUT '[JSON] (RespondEmpty 200 "Conversation members replaced")
+           )
+    :<|> Named
+           "replace-members-in-conversation"
+           ( Summary "Replace the members of a conversation."
+               :> Description
+                    "This will add any members not already in the conversation, \
+                    \and remove any members not in the provided list except users that are associated via a user group. \
+                    \The given role in the request body will be applied to all added members. \
+                    \The roles of already existing members will not be changed \
+                    \even if these members are included in the request body and their role differs from the role provided in this request."
+               :> From 'V17
+               :> CanThrow ('ActionDenied 'AddConversationMember)
+               :> CanThrow ('ActionDenied 'RemoveConversationMember)
+               :> CanThrow ('ActionDenied 'LeaveConversation)
+               :> CanThrow AdminlessConversation
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
                :> CanThrow 'TooManyMembers

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -91,7 +91,7 @@ type FeatureAPI =
 type VersionedFeatureAPIPut named reqBodyVersion cfg =
   Named
     named
-    ( Description (FeatureAPIDesc cfg)
+    ( Description (VersionedFeatureAPIDesc reqBodyVersion cfg)
         :> ZUser
         :> Summary (AppendSymbol "Put config for " (FeatureSymbol cfg))
         :> CanThrow OperationDenied

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem.hs
@@ -482,6 +482,7 @@ data ConversationSubsystem m a where
     InviteQualified ->
     ConversationSubsystem m (UpdateResult Event)
   ReplaceMembers ::
+    RemoveMemberResponseMode ->
     Local UserId ->
     ConnId ->
     Qualified ConvId ->

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Interpreter.hs
@@ -269,8 +269,8 @@ interpretConversationSubsystem = interpret $ \case
     mapErrors $ Update.addQualifiedMembersUnqualified lusr con cnv invite
   AddMembers lusr zcon qcnv invite ->
     mapErrors $ Update.addMembers lusr zcon qcnv invite
-  ReplaceMembers lusr zcon qcnv invite ->
-    mapErrors $ Update.replaceMembers lusr zcon qcnv invite
+  ReplaceMembers responseMode lusr zcon qcnv invite ->
+    mapErrors $ Update.replaceMembers responseMode lusr zcon qcnv invite
   JoinConversationById lusr con cnv ->
     mapErrors $ Update.joinConversationById lusr con cnv
   JoinConversationByReusableCode lusr con req ->

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -1014,7 +1014,7 @@ replaceMembers responseMode lusr zcon qcnv (InviteQualified invitedUsers role) =
   -- Apply the same adminless protection as DELETE to the complete removal
   -- set. The guard is a preflight so V16+ cannot partially apply a replacement
   -- before returning AdminlessConversation.
-  guardPreventAdminlessGroupsFor responseMode lcnv lusr toRemove addedAdmins
+  guardPreventAdminlessGroupsFor responseMode lcnv lusr toRemove addedAdmins toAdd
 
   -- If both sets are empty, return Unchanged
   unless (Set.null toRemove && Set.null toAdd) $ do
@@ -1237,7 +1237,7 @@ guardPreventAdminlessGroups ::
   Qualified UserId ->
   Sem r ()
 guardPreventAdminlessGroups responseMode lcnv lusr victim =
-  guardPreventAdminlessGroupsFor responseMode lcnv lusr (Set.singleton victim) Set.empty
+  guardPreventAdminlessGroupsFor responseMode lcnv lusr (Set.singleton victim) Set.empty Set.empty
 
 guardPreventAdminlessGroupsFor ::
   ( Member ConversationStore r,
@@ -1262,8 +1262,9 @@ guardPreventAdminlessGroupsFor ::
   Local UserId ->
   Set (Qualified UserId) ->
   Set (Qualified UserId) ->
+  Set (Qualified UserId) ->
   Sem r ()
-guardPreventAdminlessGroupsFor responseMode lcnv lusr victims addedAdmins = do
+guardPreventAdminlessGroupsFor responseMode lcnv lusr victims addedAdmins addedMembers = do
   conv <- getConversationWithError lcnv
   when (isAdminlessCheckCandidate conv) $ for_ conv.metadata.cnvmTeam $ \tid -> do
     (feature :: LockableFeature PreventAdminlessGroupsConfig) <- getFeatureForTeam tid
@@ -1281,7 +1282,10 @@ guardPreventAdminlessGroupsFor responseMode lcnv lusr victims addedAdmins = do
               )
             && not (any (\member -> member.convRoleName == roleNameWireAdmin) conv.remoteMembers)
     when (feature.status == FeatureStatusEnabled && removingLastAdmin) $ do
-      eligibleMembers <- eligibleAdminFallbackMembersFor lcnv victims' conv
+      let addedMembersForEligibility = case responseMode of
+            RemoveMemberLegacyResponse -> Set.empty
+            RemoveMemberEligibleMembersResponse -> addedMembers
+      eligibleMembers <- eligibleAdminFallbackMembersFor lcnv victims' addedMembersForEligibility conv
       case (responseMode, eligibleMembers) of
         (RemoveMemberLegacyResponse, x : xs) -> do
           seed <- randomWord64
@@ -1519,22 +1523,34 @@ eligibleAdminFallbackMembers ::
   StoredConversation ->
   Sem r [(Qualified UserId, User.Name)]
 eligibleAdminFallbackMembers lcnv mLeavingUser conv = do
-  eligibleAdminFallbackMembersFor lcnv (maybe Set.empty Set.singleton mLeavingUser) conv
+  eligibleAdminFallbackMembersFor lcnv (maybe Set.empty Set.singleton mLeavingUser) Set.empty conv
 
 eligibleAdminFallbackMembersFor ::
   (Member BrigAPIAccess r) =>
   Local ConvId ->
   Set UserId ->
+  Set (Qualified UserId) ->
   StoredConversation ->
   Sem r [(Qualified UserId, User.Name)]
-eligibleAdminFallbackMembersFor lcnv leavingUsers conv = do
-  users <- Brig.getUsers (map (.id_) (filter (\member -> Set.notMember member.id_ leavingUsers) conv.localMembers))
+eligibleAdminFallbackMembersFor lcnv leavingUsers addedUsers conv = do
+  let existingCandidates =
+        [ (Qualified member.id_ (tDomain lcnv), member.id_)
+        | member <- conv.localMembers,
+          Set.notMember member.id_ leavingUsers
+        ]
+      addedLocalCandidates =
+        [ (user, qUnqualified user)
+        | user <- Set.toList addedUsers,
+          qDomain user == tDomain lcnv
+        ]
+      candidates = existingCandidates <> addedLocalCandidates
+      candidateIds = Set.toList (Set.fromList (map snd candidates))
+  users <- Brig.getUsers candidateIds
   let usersById = Map.fromList [(User.userId u, u) | u <- users]
   pure
-    [ (tUntagged (qualifyAs lcnv member.id_), u.userDisplayName)
-    | member <- conv.localMembers,
-      Set.notMember member.id_ leavingUsers,
-      Just u <- [Map.lookup member.id_ usersById],
+    [ (qualifiedId, u.userDisplayName)
+    | (qualifiedId, candidateId) <- candidates,
+      Just u <- [Map.lookup candidateId usersById],
       isEligibleUser u
     ]
   where

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -981,12 +981,13 @@ replaceMembers ::
     Member JobSubsystem r,
     Member (Input ConversationSubsystemConfig) r
   ) =>
+  RemoveMemberResponseMode ->
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
   InviteQualified ->
   Sem r ()
-replaceMembers lusr zcon qcnv (InviteQualified invitedUsers role) = do
+replaceMembers responseMode lusr zcon qcnv (InviteQualified invitedUsers role) = do
   lcnv <- ensureLocal lusr qcnv
   conv <- getConversationWithError lcnv
 
@@ -1008,6 +1009,12 @@ replaceMembers lusr zcon qcnv (InviteQualified invitedUsers role) = do
       allUsersThatShouldStay = Set.fromList $ toList $ appendList invitedUsers ugMembers
       toRemove = Set.difference currentMembers allUsersThatShouldStay
       toAdd = Set.difference invitedMembersSet currentMembers
+      addedAdmins = if role == roleNameWireAdmin then toAdd else Set.empty
+
+  -- Apply the same adminless protection as DELETE to the complete removal
+  -- set. The guard is a preflight so V16+ cannot partially apply a replacement
+  -- before returning AdminlessConversation.
+  guardPreventAdminlessGroupsFor responseMode lcnv lusr toRemove addedAdmins
 
   -- If both sets are empty, return Unchanged
   unless (Set.null toRemove && Set.null toAdd) $ do
@@ -1229,13 +1236,52 @@ guardPreventAdminlessGroups ::
   Local UserId ->
   Qualified UserId ->
   Sem r ()
-guardPreventAdminlessGroups responseMode lcnv lusr victim = do
+guardPreventAdminlessGroups responseMode lcnv lusr victim =
+  guardPreventAdminlessGroupsFor responseMode lcnv lusr (Set.singleton victim) Set.empty
+
+guardPreventAdminlessGroupsFor ::
+  ( Member ConversationStore r,
+    Member (Error AdminlessConversation) r,
+    Member (ErrorS 'ConvNotFound) r,
+    Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
+    Member (ErrorS 'InvalidOperation) r,
+    Member (ErrorS 'ConvMemberNotFound) r,
+    Member (Error FederationError) r,
+    Member BrigAPIAccess r,
+    Member Random r,
+    Member NotificationSubsystem r,
+    Member Now r,
+    Member E.ExternalAccess r,
+    Member BackendNotificationQueueAccess r,
+    Member FeaturesConfigSubsystem r,
+    Member TeamSubsystem r,
+    Member JobSubsystem r
+  ) =>
+  RemoveMemberResponseMode ->
+  Local ConvId ->
+  Local UserId ->
+  Set (Qualified UserId) ->
+  Set (Qualified UserId) ->
+  Sem r ()
+guardPreventAdminlessGroupsFor responseMode lcnv lusr victims addedAdmins = do
   conv <- getConversationWithError lcnv
   when (isAdminlessCheckCandidate conv) $ for_ conv.metadata.cnvmTeam $ \tid -> do
     (feature :: LockableFeature PreventAdminlessGroupsConfig) <- getFeatureForTeam tid
     -- we cannot use the onAdminless helper here because this check happens _before_ removing the potential admin
-    when (feature.status == FeatureStatusEnabled && isLeavingLastConversationAdmin (qUnqualified victim) conv) $ do
-      eligibleMembers <- eligibleAdminFallbackMembers lcnv (Just (qUnqualified victim)) conv
+    let victims' = Set.map qUnqualified victims
+        removingLastAdmin =
+          Set.null addedAdmins
+            && any
+              (\member -> member.convRoleName == roleNameWireAdmin && Set.member member.id_ victims')
+              conv.localMembers
+            && not
+              ( any
+                  (\member -> member.convRoleName == roleNameWireAdmin && Set.notMember member.id_ victims')
+                  conv.localMembers
+              )
+            && not (any (\member -> member.convRoleName == roleNameWireAdmin) conv.remoteMembers)
+    when (feature.status == FeatureStatusEnabled && removingLastAdmin) $ do
+      eligibleMembers <- eligibleAdminFallbackMembersFor lcnv victims' conv
       case (responseMode, eligibleMembers) of
         (RemoveMemberLegacyResponse, x : xs) -> do
           seed <- randomWord64
@@ -1473,12 +1519,21 @@ eligibleAdminFallbackMembers ::
   StoredConversation ->
   Sem r [(Qualified UserId, User.Name)]
 eligibleAdminFallbackMembers lcnv mLeavingUser conv = do
-  users <- Brig.getUsers (map (.id_) (filter ((/= mLeavingUser) . Just . (.id_)) conv.localMembers))
+  eligibleAdminFallbackMembersFor lcnv (maybe Set.empty Set.singleton mLeavingUser) conv
+
+eligibleAdminFallbackMembersFor ::
+  (Member BrigAPIAccess r) =>
+  Local ConvId ->
+  Set UserId ->
+  StoredConversation ->
+  Sem r [(Qualified UserId, User.Name)]
+eligibleAdminFallbackMembersFor lcnv leavingUsers conv = do
+  users <- Brig.getUsers (map (.id_) (filter (\member -> Set.notMember member.id_ leavingUsers) conv.localMembers))
   let usersById = Map.fromList [(User.userId u, u) | u <- users]
   pure
     [ (tUntagged (qualifyAs lcnv member.id_), u.userDisplayName)
     | member <- conv.localMembers,
-      Just member.id_ /= mLeavingUser,
+      Set.notMember member.id_ leavingUsers,
       Just u <- [Map.lookup member.id_ usersById],
       isEligibleUser u
     ]

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -54,6 +54,8 @@ module Wire.ConversationSubsystem.Update
     updateOtherMember,
     eligibleAdminFallbackMembers,
     isLeavingLastConversationAdmin,
+    guardPreventAdminlessGroups,
+    guardPreventAdminlessGroupsFor,
     removeMemberQualified,
     deleteUserFromTeamConversationsImpl,
     removeMemberFromLocalConv,

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -1001,14 +1001,17 @@ replaceMembers responseMode lusr zcon qcnv (InviteQualified invitedUsers role) =
             permissionCheck JoinRegularConversations . Just
 
   ugs <- getUserGroupsForConv conv.id_
-  -- Get current members (excluding the requesting user)
-  let currentMembers = Set.fromList $ map (\m -> Qualified m.id_ (tDomain lcnv)) (toList conv.localMembers)
+  -- Removals apply only to local members. Additions must account for remote
+  -- members too, because re-inviting an existing remote member does not change
+  -- their role and must not be treated as adding an admin.
+  let currentLocalMembers = Set.fromList $ map (\m -> Qualified m.id_ (tDomain lcnv)) (toList conv.localMembers)
+      currentRemoteMembers = Set.fromList $ map (tUntagged . (.id_)) conv.remoteMembers
       invitedMembersSet = Set.fromList $ toList invitedUsers
       ugMembers = concatMap (fmap (flip Qualified (tDomain lusr)) . V.toList . runIdentity . (.members)) (V.toList ugs)
       -- the invited users plus all user group members should stay
       allUsersThatShouldStay = Set.fromList $ toList $ appendList invitedUsers ugMembers
-      toRemove = Set.difference currentMembers allUsersThatShouldStay
-      toAdd = Set.difference invitedMembersSet currentMembers
+      toRemove = Set.difference currentLocalMembers allUsersThatShouldStay
+      toAdd = Set.difference invitedMembersSet (currentLocalMembers <> currentRemoteMembers)
       addedAdmins = if role == roleNameWireAdmin then toAdd else Set.empty
 
   -- Apply the same adminless protection as DELETE to the complete removal

--- a/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
+++ b/libs/wire-subsystems/src/Wire/ConversationSubsystem/Update.hs
@@ -1273,7 +1273,6 @@ guardPreventAdminlessGroupsFor responseMode lcnv lusr victims addedAdmins addedM
   conv <- getConversationWithError lcnv
   when (isAdminlessCheckCandidate conv) $ for_ conv.metadata.cnvmTeam $ \tid -> do
     (feature :: LockableFeature PreventAdminlessGroupsConfig) <- getFeatureForTeam tid
-    -- we cannot use the onAdminless helper here because this check happens _before_ removing the potential admin
     let victims' = Set.map qUnqualified victims
         removingLastAdmin =
           Set.null addedAdmins
@@ -1340,24 +1339,6 @@ scheduleDeletion lcnv mlusr tid feature = do
     timeoutToNominalDiffTime =
       realToFrac . duration . durationLiteralValue . preventAdminlessTimeoutLiteral
 
-onAdminless ::
-  ( Member ConversationStore r,
-    Member (ErrorS 'ConvNotFound) r,
-    Member BrigAPIAccess r,
-    Member FeaturesConfigSubsystem r
-  ) =>
-  Local ConvId ->
-  (StoredConversation -> LockableFeature PreventAdminlessGroupsConfig -> [(Qualified UserId, User.Name)] -> Sem r ()) ->
-  Sem r ()
-onAdminless lcnv action = do
-  conv <- getConversationWithError lcnv
-  when (isAdminlessCheckCandidate conv) $ for_ conv.metadata.cnvmTeam $ \tid -> do
-    (feature :: LockableFeature PreventAdminlessGroupsConfig) <- getFeatureForTeam tid
-    let adminExists = any (\member -> member.convRoleName == roleNameWireAdmin) conv.localMembers || any (\member -> member.convRoleName == roleNameWireAdmin) conv.remoteMembers
-    when (feature.status == FeatureStatusEnabled && not adminExists) $ do
-      eligibleMembers <- eligibleAdminFallbackMembers lcnv Nothing conv
-      action conv feature eligibleMembers
-
 adminlessTryAutopromote ::
   ( Member ConversationStore r,
     Member (ErrorS 'ConvNotFound) r,
@@ -1375,39 +1356,44 @@ adminlessTryAutopromote ::
   (StoredConversation -> LockableFeature PreventAdminlessGroupsConfig -> [(Qualified UserId, User.Name)] -> Sem r ()) ->
   Sem r ()
 adminlessTryAutopromote mlusr lcnv altAction = do
-  onAdminless lcnv $ \conv feature eligibleMembers -> do
-    case eligibleMembers of
-      x : xs -> do
-        seed <- randomWord64
-        let autopromotionCandidates = selectAutopromotionCandidate seed feature.config.promotionStrategy (x :| xs)
-            update = OtherMemberUpdate (Just roleNameWireAdmin)
-        for_ autopromotionCandidates $ \candidate -> do
-          E.setOtherMember lcnv candidate update
-          case mlusr of
-            Just lusr ->
-              void $
-                sendConversationActionNotifications
-                  (sing @'ConversationMemberUpdateTag)
-                  (tUntagged lusr)
-                  False
-                  Nothing
-                  (qualifyAs lcnv conv)
-                  (convBotsAndMembers conv)
-                  (ConversationMemberUpdate candidate update)
-                  def
-            Nothing -> do
-              now <- Now.get
-              Notify.pushSystemEvent
-                Nothing
-                ( SystemEvent
-                    (tUntagged lcnv)
+  conv <- getConversationWithError lcnv
+  when (isAdminlessCheckCandidate conv) $ for_ conv.metadata.cnvmTeam $ \tid -> do
+    (feature :: LockableFeature PreventAdminlessGroupsConfig) <- getFeatureForTeam tid
+    let adminExists = any (\member -> member.convRoleName == roleNameWireAdmin) conv.localMembers || any (\member -> member.convRoleName == roleNameWireAdmin) conv.remoteMembers
+    when (feature.status == FeatureStatusEnabled && not adminExists) $ do
+      eligibleMembers <- eligibleAdminFallbackMembers lcnv Nothing conv
+      case eligibleMembers of
+        x : xs -> do
+          seed <- randomWord64
+          let autopromotionCandidates = selectAutopromotionCandidate seed feature.config.promotionStrategy (x :| xs)
+              update = OtherMemberUpdate (Just roleNameWireAdmin)
+          for_ autopromotionCandidates $ \candidate -> do
+            E.setOtherMember lcnv candidate update
+            case mlusr of
+              Just lusr ->
+                void $
+                  sendConversationActionNotifications
+                    (sing @'ConversationMemberUpdateTag)
+                    (tUntagged lusr)
+                    False
                     Nothing
-                    now
-                    conv.metadata.cnvmTeam
-                    (EdSystemMemberUpdate (memberUpdateData candidate update))
-                )
-                (Set.fromList (map (.id_) conv.localMembers))
-      [] -> altAction conv feature eligibleMembers
+                    (qualifyAs lcnv conv)
+                    (convBotsAndMembers conv)
+                    (ConversationMemberUpdate candidate update)
+                    def
+              Nothing -> do
+                now <- Now.get
+                Notify.pushSystemEvent
+                  Nothing
+                  ( SystemEvent
+                      (tUntagged lcnv)
+                      Nothing
+                      now
+                      conv.metadata.cnvmTeam
+                      (EdSystemMemberUpdate (memberUpdateData candidate update))
+                  )
+                  (Set.fromList (map (.id_) conv.localMembers))
+        [] -> altAction conv feature eligibleMembers
   where
     memberUpdateData candidate memberUpdate' =
       MemberUpdateData

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -237,14 +237,14 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
         fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
         let conversations =
               Map.adjust
-                (\conv ->
-                  conv
-                    { localMembers =
-                        [ newMemberWithRole (leaving, roleNameWireAdmin),
-                          newMemberWithRole (eligible1, roleNameWireAdmin),
-                          newMemberWithRole (eligible2, roleNameWireMember)
-                        ]
-                    }
+                ( \conv ->
+                    conv
+                      { localMembers =
+                          [ newMemberWithRole (leaving, roleNameWireAdmin),
+                            newMemberWithRole (eligible1, roleNameWireAdmin),
+                            newMemberWithRole (eligible2, roleNameWireMember)
+                          ]
+                      }
                 )
                 convId
                 fx.fixtureConversations

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -89,6 +89,37 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                   assertMemberUpdatePush expectedTarget pushes
                 ]
 
+  prop "guardPreventAdminlessGroupsFor promotes all eligible members [legacy]" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let features =
+              npUpdate @PreventAdminlessGroupsConfig
+                ( LockableFeature
+                    FeatureStatusEnabled
+                    LockStatusUnlocked
+                    ((def :: PreventAdminlessGroupsConfig) {promotionStrategy = PromotionStrategyAll})
+                )
+                def
+            expectedTargets = fx.fixtureEligibleMembers
+            (pushes, (updatedTargets, result)) =
+              runAdminlessGroupsTest fx.fixtureUsers features fx.fixtureConversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $
+          case result of
+            Left err -> counterexample ("unexpected adminless error: " <> show err) False
+            Right _ ->
+              conjoin
+                [ Set.fromList updatedTargets === Set.fromList expectedTargets,
+                  assertMemberUpdatePushes expectedTargets pushes
+                ]
+
   prop "guardPreventAdminlessGroupsFor reports eligible members for the V17 response" $
     \domain teamId convId leaving eligible1 eligible2 ->
       ioProperty $ do
@@ -108,6 +139,35 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
             Left err ->
               conjoin
                 [ err === AdminlessConversation {eligibleMembers = expectedEligible},
+                  updatedTargets === [],
+                  length pushes === 0
+                ]
+            Right _ -> counterexample "expected adminless-conversation error" False
+
+  prop "guardPreventAdminlessGroupsFor includes newly added eligible members in the V17 response" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let newlyAdded = head fx.fixtureEligibleMembers
+            conversations =
+              Map.adjust
+                (\conv -> conv {localMembers = [newMemberWithRole (leaving, roleNameWireAdmin)]})
+                convId
+                fx.fixtureConversations
+            (pushes, (updatedTargets, result)) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures conversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberEligibleMembersResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  (Set.singleton newlyAdded)
+        pure $
+          case result of
+            Left err ->
+              conjoin
+                [ err === AdminlessConversation {eligibleMembers = [newlyAdded]},
                   updatedTargets === [],
                   length pushes === 0
                 ]
@@ -284,17 +344,24 @@ instance Arbitrary MemberInputs where
         }
 
 assertMemberUpdatePush :: Qualified UserId -> [Push] -> Property
-assertMemberUpdatePush expectedTarget = \case
-  [push] ->
-    case A.fromJSON @(Event) (A.Object push.json) of
-      A.Success Event {evtData = EdMemberUpdate update} ->
-        conjoin
-          [ update.misTarget === expectedTarget,
-            update.misConvRoleName === Just roleNameWireAdmin
-          ]
-      A.Success event -> counterexample ("unexpected event: " <> show event) False
-      A.Error err -> counterexample ("failed to decode push: " <> err) False
-  pushes -> counterexample ("expected one push, got: " <> show pushes) False
+assertMemberUpdatePush expectedTarget = assertMemberUpdatePushes [expectedTarget]
+
+assertMemberUpdatePushes :: [Qualified UserId] -> [Push] -> Property
+assertMemberUpdatePushes expectedTargets pushes =
+  case traverse decodeMemberUpdate pushes of
+    Left err -> counterexample err False
+    Right updates ->
+      conjoin
+        [ length pushes === length expectedTargets,
+          Set.fromList (map (.misTarget) updates) === Set.fromList expectedTargets,
+          conjoin [update.misConvRoleName === Just roleNameWireAdmin | update <- updates]
+        ]
+  where
+    decodeMemberUpdate push =
+      case A.fromJSON @(Event) (A.Object push.json) of
+        A.Success Event {evtData = EdMemberUpdate update} -> Right update
+        A.Success event -> Left ("unexpected event: " <> show event)
+        A.Error err -> Left ("failed to decode push: " <> err)
 
 -- Build one lazy infinite pool of distinct IDs and slice it into categories.
 -- Using position in the stream, rather than per-category prefixes, makes the

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -212,6 +212,107 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                   scheduledJobs === [ScheduledAdminlessDeletion]
                 ]
 
+  prop "guardPreventAdminlessGroupsFor does nothing when the feature is disabled" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let features =
+              npUpdate @PreventAdminlessGroupsConfig
+                (LockableFeature FeatureStatusDisabled LockStatusUnlocked def)
+                def
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest fx.fixtureUsers features fx.fixtureConversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $ assertNoAdminlessAction pushes updatedTargets scheduledJobs result
+
+  prop "guardPreventAdminlessGroupsFor does nothing when another local admin remains" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let conversations =
+              Map.adjust
+                (\conv ->
+                  conv
+                    { localMembers =
+                        [ newMemberWithRole (leaving, roleNameWireAdmin),
+                          newMemberWithRole (eligible1, roleNameWireAdmin),
+                          newMemberWithRole (eligible2, roleNameWireMember)
+                        ]
+                    }
+                )
+                convId
+                fx.fixtureConversations
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures conversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $ assertNoAdminlessAction pushes updatedTargets scheduledJobs result
+
+  prop "guardPreventAdminlessGroupsFor does nothing when a remote admin remains" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let remoteAdmin =
+              RemoteMember
+                { id_ = toRemoteUnsafe domain eligible1,
+                  convRoleName = roleNameWireAdmin
+                }
+            conversations =
+              Map.adjust (withRemoteMembers [remoteAdmin]) convId fx.fixtureConversations
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures conversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $ assertNoAdminlessAction pushes updatedTargets scheduledJobs result
+
+  prop "guardPreventAdminlessGroupsFor does nothing when an admin is being added" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures fx.fixtureConversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  (Set.singleton (head fx.fixtureEligibleMembers))
+                  Set.empty
+        pure $ assertNoAdminlessAction pushes updatedTargets scheduledJobs result
+
+  prop "guardPreventAdminlessGroupsFor ignores non-regular and channel conversations" $
+    \domain teamId convId leaving eligible1 eligible2 outOfScopeChannel ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let conversations =
+              Map.adjust (withOutOfScopeMetadata outOfScopeChannel) convId fx.fixtureConversations
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures conversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $ assertNoAdminlessAction pushes updatedTargets scheduledJobs result
+
   prop "removeMemberQualified returns adminless-conversation error" $
     \convDomain
      teamId
@@ -403,6 +504,39 @@ assertMemberUpdatePushes expectedTargets pushes =
         A.Success Event {evtData = EdMemberUpdate update} -> Right update
         A.Success event -> Left ("unexpected event: " <> show event)
         A.Error err -> Left ("failed to decode push: " <> err)
+
+assertNoAdminlessAction ::
+  [Push] ->
+  [Qualified UserId] ->
+  [ScheduledAdminlessJob] ->
+  Either AdminlessConversation a ->
+  Property
+assertNoAdminlessAction pushes updatedTargets scheduledJobs result =
+  case result of
+    Left err -> counterexample ("unexpected adminless error: " <> show err) False
+    Right _ ->
+      conjoin
+        [ updatedTargets === [],
+          length pushes === 0,
+          scheduledJobs === []
+        ]
+
+withRemoteMembers :: [RemoteMember] -> StoredConversation -> StoredConversation
+withRemoteMembers members (StoredConversation convId localMembers _ metadata protocol) =
+  StoredConversation convId localMembers members metadata protocol
+
+withOutOfScopeMetadata :: Bool -> StoredConversation -> StoredConversation
+withOutOfScopeMetadata outOfScopeChannel (StoredConversation convId localMembers remoteMembers metadata protocol) =
+  StoredConversation
+    convId
+    localMembers
+    remoteMembers
+    ( metadata
+        { cnvmType = if outOfScopeChannel then RegularConv else One2OneConv,
+          cnvmGroupConvType = if outOfScopeChannel then Just Channel else Just GroupConversation
+        }
+    )
+    protocol
 
 -- Build one lazy infinite pool of distinct IDs and slice it into categories.
 -- Using position in the stream, rather than per-category prefixes, makes the

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -17,41 +17,48 @@
 
 module Wire.ConversationSubsystem.InterpreterSpec (spec) where
 
+import Data.Aeson qualified as A
 import Data.Default (def)
 import Data.Domain (Domain (..))
 import Data.Id
 import Data.Map.Strict qualified as Map
 import Data.Qualified
+import Data.Set qualified as Set
 import Data.Tagged (Tagged)
 import Data.UUID qualified as UUID
 import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
+import Polysemy.State
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Arbitrary (..), Gen, arbitrary, chooseInt, counterexample, generate, ioProperty, vectorOf, (===))
+import Test.QuickCheck (Arbitrary (..), Gen, Property, arbitrary, chooseInt, conjoin, counterexample, generate, ioProperty, vectorOf, (===))
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Config (ConversationSubsystemConfig (..))
 import Wire.API.Conversation.Protocol (ConversationMLSData (..), Protocol (..))
 import Wire.API.Conversation.Role hiding (DeleteConversation)
 import Wire.API.Error.Galley (AdminlessConversation (..), GalleyError (..))
+import Wire.API.Event.Conversation (Event (..), EventData (..), MemberUpdateData (..))
 import Wire.API.Federation.Client (FederatorClient)
 import Wire.API.Federation.Error (FederationError)
-import Wire.API.Team.Feature (AllTeamFeatures, FeatureStatus (..), LockStatus (..), LockableFeature (..), PreventAdminlessGroupsConfig, npProject, npUpdate)
-import Wire.API.User (AccountStatus (..), User (..), UserType (..), userId)
+import Wire.API.Team.Feature
+import Wire.API.User
 import Wire.BackendNotificationQueueAccess (BackendNotificationQueueAccess (..))
 import Wire.BrigAPIAccess (BrigAPIAccess (..))
 import Wire.ConversationStore (ConversationStore (..))
 import Wire.ConversationSubsystem (RemoveMemberResponseMode (..))
-import Wire.ConversationSubsystem.Update (removeMemberQualified)
+import Wire.ConversationSubsystem.Update (guardPreventAdminlessGroupsFor, removeMemberQualified)
 import Wire.ExternalAccess (ExternalAccess (..))
 import Wire.FeaturesConfigSubsystem (FeaturesConfigSubsystem (..))
 import Wire.FederationAPIAccess (FederationAPIAccess (..))
 import Wire.JobSubsystem (JobSubsystem (..))
+import Wire.MockInterpreters.ConversationStore (inMemoryConversationStoreInterpreter)
+import Wire.MockInterpreters.NotificationSubsystem (inMemoryNotificationSubsystemInterpreter)
 import Wire.MockInterpreters.Now (defaultTime, interpretNowConst)
+import Wire.MockInterpreters.Random (runRandomPure)
 import Wire.MockInterpreters.TinyLog (noopLogger)
-import Wire.NotificationSubsystem (NotificationSubsystem (..))
+import Wire.NotificationSubsystem (NotificationSubsystem (..), Push (..))
 import Wire.ProposalStore (ProposalStore (..))
 import Wire.Sem.Random (Random (..))
 import Wire.StoredConversation
@@ -59,6 +66,48 @@ import Wire.TeamSubsystem (TeamSubsystem (..))
 
 spec :: Spec
 spec = describe "ConversationSubsystem.Interpreter" do
+  prop "guardPreventAdminlessGroupsFor promotes an eligible member and emits a targeted update" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        user1 <- mkUserWithName "Alice" domain UserTypeRegular eligible1
+        user2 <- mkUserWithName "Bob" domain UserTypeRegular eligible2
+        let users = [user1, user2]
+            lusr = toLocalUnsafe domain leaving
+            lcnv = toLocalUnsafe domain convId
+            qvictim = Qualified leaving domain
+            localMembers =
+              [ newMemberWithRole (leaving, roleNameWireAdmin),
+                newMemberWithRole (eligible1, roleNameWireMember),
+                newMemberWithRole (eligible2, roleNameWireMember)
+              ]
+            conv =
+              StoredConversation
+                { id_ = convId,
+                  localMembers = localMembers,
+                  remoteMembers = [],
+                  metadata = (defConversationMetadata (Just leaving)) {cnvmTeam = Just teamId},
+                  protocol = ProtocolMLS (ConversationMLSData (GroupId "mock-group-id") Nothing)
+                }
+            features = npUpdate @PreventAdminlessGroupsConfig (LockableFeature FeatureStatusEnabled LockStatusUnlocked def) def
+            expectedTarget = Qualified eligible1 domain
+            (pushes, (updatedTargets, result)) =
+              runAdminlessGroupsTest users features (Map.singleton convId conv) $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  lcnv
+                  lusr
+                  (Set.singleton qvictim)
+                  Set.empty
+                  Set.empty
+        pure $
+          case result of
+            Left err -> counterexample ("unexpected adminless error: " <> show err) False
+            Right _ ->
+              conjoin
+                [ updatedTargets === [expectedTarget],
+                  assertMemberUpdatePush expectedTarget pushes
+                ]
+
   prop "removeMemberQualified returns adminless-conversation error" $
     \convDomain
      teamId
@@ -133,6 +182,30 @@ spec = describe "ConversationSubsystem.Interpreter" do
                 err === AdminlessConversation {eligibleMembers = expectedEligible}
               Right _ ->
                 counterexample ("expected adminless-conversation, got " <> show result) False
+  where
+    runAdminlessGroupsTest users features conversations testCode =
+      run
+        . runState @[Push] []
+        . runState @[Qualified UserId] []
+        . runError @AdminlessConversation
+        . runError @(Tagged ('ActionDenied 'ModifyOtherConversationMember) ())
+        . runError @(Tagged 'ConvMemberNotFound ())
+        . runError @(Tagged 'ConvNotFound ())
+        . runError @(Tagged 'InvalidOperation ())
+        . runError @FederationError
+        . inMemoryConversationStoreInterpreter conversations
+        . interpretBrig users
+        . interpretFeatures features
+        . interpretBackendNotificationQueueAccess
+        . interpretFederation
+        . interpretExternalAccess
+        . inMemoryNotificationSubsystemInterpreter
+        . interpretTeamSubsystem
+        . interpretJobSubsystem
+        . interpretNowConst defaultTime
+        . runRandomPure
+        . noopLogger
+        $ testCode
 
 data MemberInputs = MemberInputs
   { localUserIds :: [UserId],
@@ -167,6 +240,19 @@ instance Arbitrary MemberInputs where
             | (dom, uid) <- zip remoteDomains remotePool
             ]
         }
+
+assertMemberUpdatePush :: Qualified UserId -> [Push] -> Property
+assertMemberUpdatePush expectedTarget = \case
+  [push] ->
+    case A.fromJSON @(Event) (A.Object push.json) of
+      A.Success Event {evtData = EdMemberUpdate update} ->
+        conjoin
+          [ update.misTarget === expectedTarget,
+            update.misConvRoleName === Just roleNameWireAdmin
+          ]
+      A.Success event -> counterexample ("unexpected event: " <> show event) False
+      A.Error err -> counterexample ("failed to decode push: " <> err) False
+  pushes -> counterexample ("expected one push, got: " <> show pushes) False
 
 -- Build one lazy infinite pool of distinct IDs and slice it into categories.
 -- Using position in the stream, rather than per-category prefixes, makes the
@@ -242,6 +328,8 @@ interpretBackendNotificationQueueAccess ::
   Sem r a
 interpretBackendNotificationQueueAccess =
   interpret $ \case
+    EnqueueNotificationsConcurrently _ remotes _ ->
+      if null remotes then pure (Right []) else error "unexpected remote notification in guard test"
     _ -> error "unexpected BackendNotificationQueueAccess call in test"
 
 interpretProposalStore ::
@@ -260,6 +348,7 @@ interpretTeamSubsystem ::
   Sem r a
 interpretTeamSubsystem =
   interpret $ \case
+    InternalGetTeamMember _ _ -> pure Nothing
     _ -> error "unexpected TeamSubsystem call in test"
 
 interpretJobSubsystem ::
@@ -300,4 +389,16 @@ mkUser domain utype uid = do
         userType = utype,
         userStatus = Active,
         userService = Nothing
+      }
+
+mkUserWithName :: Text -> Domain -> UserType -> UserId -> IO User
+mkUserWithName name domain utype uid = do
+  base <- generate arbitrary
+  pure
+    base
+      { userQualifiedId = Qualified uid domain,
+        userType = utype,
+        userStatus = Active,
+        userService = Nothing,
+        userDisplayName = Name name
       }

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -65,38 +65,19 @@ import Wire.StoredConversation
 import Wire.TeamSubsystem (TeamSubsystem (..))
 
 spec :: Spec
-spec = describe "ConversationSubsystem.Interpreter" do
-  prop "guardPreventAdminlessGroupsFor promotes an eligible member and emits a targeted update" $
+spec = focus $ describe "ConversationSubsystem.Interpreter" do
+  prop "guardPreventAdminlessGroupsFor promotes an eligible member and emits a targeted update [legacy]" $
     \domain teamId convId leaving eligible1 eligible2 ->
       ioProperty $ do
-        user1 <- mkUserWithName "Alice" domain UserTypeRegular eligible1
-        user2 <- mkUserWithName "Bob" domain UserTypeRegular eligible2
-        let users = [user1, user2]
-            lusr = toLocalUnsafe domain leaving
-            lcnv = toLocalUnsafe domain convId
-            qvictim = Qualified leaving domain
-            localMembers =
-              [ newMemberWithRole (leaving, roleNameWireAdmin),
-                newMemberWithRole (eligible1, roleNameWireMember),
-                newMemberWithRole (eligible2, roleNameWireMember)
-              ]
-            conv =
-              StoredConversation
-                { id_ = convId,
-                  localMembers = localMembers,
-                  remoteMembers = [],
-                  metadata = (defConversationMetadata (Just leaving)) {cnvmTeam = Just teamId},
-                  protocol = ProtocolMLS (ConversationMLSData (GroupId "mock-group-id") Nothing)
-                }
-            features = npUpdate @PreventAdminlessGroupsConfig (LockableFeature FeatureStatusEnabled LockStatusUnlocked def) def
-            expectedTarget = Qualified eligible1 domain
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let expectedTarget = head fx.fixtureEligibleMembers
             (pushes, (updatedTargets, result)) =
-              runAdminlessGroupsTest users features (Map.singleton convId conv) $
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures fx.fixtureConversations $
                 guardPreventAdminlessGroupsFor
                   RemoveMemberLegacyResponse
-                  lcnv
-                  lusr
-                  (Set.singleton qvictim)
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
                   Set.empty
                   Set.empty
         pure $
@@ -107,6 +88,30 @@ spec = describe "ConversationSubsystem.Interpreter" do
                 [ updatedTargets === [expectedTarget],
                   assertMemberUpdatePush expectedTarget pushes
                 ]
+
+  prop "guardPreventAdminlessGroupsFor reports eligible members for the V17 response" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let expectedEligible = fx.fixtureEligibleMembers
+            (pushes, (updatedTargets, result)) =
+              runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures fx.fixtureConversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberEligibleMembersResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $
+          case result of
+            Left err ->
+              conjoin
+                [ err === AdminlessConversation {eligibleMembers = expectedEligible},
+                  updatedTargets === [],
+                  length pushes === 0
+                ]
+            Right _ -> counterexample "expected adminless-conversation error" False
 
   prop "removeMemberQualified returns adminless-conversation error" $
     \convDomain
@@ -206,6 +211,43 @@ spec = describe "ConversationSubsystem.Interpreter" do
         . runRandomPure
         . noopLogger
         $ testCode
+
+data AdminlessGroupsFixture = AdminlessGroupsFixture
+  { fixtureUsers :: [User],
+    fixtureLocalUser :: Local UserId,
+    fixtureLocalConversation :: Local ConvId,
+    fixtureVictim :: Qualified UserId,
+    fixtureEligibleMembers :: [Qualified UserId],
+    fixtureConversations :: Map.Map ConvId StoredConversation,
+    fixtureFeatures :: AllTeamFeatures
+  }
+
+mkAdminlessGroupsFixture :: Domain -> TeamId -> ConvId -> UserId -> UserId -> UserId -> IO AdminlessGroupsFixture
+mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2 = do
+  user1 <- mkUserWithName "Alice" domain UserTypeRegular eligible1
+  user2 <- mkUserWithName "Bob" domain UserTypeRegular eligible2
+  let conv =
+        StoredConversation
+          { id_ = convId,
+            localMembers =
+              [ newMemberWithRole (leaving, roleNameWireAdmin),
+                newMemberWithRole (eligible1, roleNameWireMember),
+                newMemberWithRole (eligible2, roleNameWireMember)
+              ],
+            remoteMembers = [],
+            metadata = (defConversationMetadata (Just leaving)) {cnvmTeam = Just teamId},
+            protocol = ProtocolMLS (ConversationMLSData (GroupId "mock-group-id") Nothing)
+          }
+  pure
+    AdminlessGroupsFixture
+      { fixtureUsers = [user1, user2],
+        fixtureLocalUser = toLocalUnsafe domain leaving,
+        fixtureLocalConversation = toLocalUnsafe domain convId,
+        fixtureVictim = Qualified leaving domain,
+        fixtureEligibleMembers = [Qualified eligible1 domain, Qualified eligible2 domain],
+        fixtureConversations = Map.singleton convId conv,
+        fixtureFeatures = npUpdate @PreventAdminlessGroupsConfig (LockableFeature FeatureStatusEnabled LockStatusUnlocked def) def
+      }
 
 data MemberInputs = MemberInputs
   { localUserIds :: [UserId],

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -71,7 +71,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
       ioProperty $ do
         fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
         let expectedTarget = head fx.fixtureEligibleMembers
-            (pushes, (updatedTargets, result)) =
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
               runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures fx.fixtureConversations $
                 guardPreventAdminlessGroupsFor
                   RemoveMemberLegacyResponse
@@ -86,6 +86,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
             Right _ ->
               conjoin
                 [ updatedTargets === [expectedTarget],
+                  scheduledJobs === [],
                   assertMemberUpdatePush expectedTarget pushes
                 ]
 
@@ -102,7 +103,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                 )
                 def
             expectedTargets = fx.fixtureEligibleMembers
-            (pushes, (updatedTargets, result)) =
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
               runAdminlessGroupsTest fx.fixtureUsers features fx.fixtureConversations $
                 guardPreventAdminlessGroupsFor
                   RemoveMemberLegacyResponse
@@ -117,6 +118,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
             Right _ ->
               conjoin
                 [ Set.fromList updatedTargets === Set.fromList expectedTargets,
+                  scheduledJobs === [],
                   assertMemberUpdatePushes expectedTargets pushes
                 ]
 
@@ -125,7 +127,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
       ioProperty $ do
         fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
         let expectedEligible = fx.fixtureEligibleMembers
-            (pushes, (updatedTargets, result)) =
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
               runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures fx.fixtureConversations $
                 guardPreventAdminlessGroupsFor
                   RemoveMemberEligibleMembersResponse
@@ -140,6 +142,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
               conjoin
                 [ err === AdminlessConversation {eligibleMembers = expectedEligible},
                   updatedTargets === [],
+                  scheduledJobs === [],
                   length pushes === 0
                 ]
             Right _ -> counterexample "expected adminless-conversation error" False
@@ -154,7 +157,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                 (\conv -> conv {localMembers = [newMemberWithRole (leaving, roleNameWireAdmin)]})
                 convId
                 fx.fixtureConversations
-            (pushes, (updatedTargets, result)) =
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
               runAdminlessGroupsTest fx.fixtureUsers fx.fixtureFeatures conversations $
                 guardPreventAdminlessGroupsFor
                   RemoveMemberEligibleMembersResponse
@@ -169,9 +172,45 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
               conjoin
                 [ err === AdminlessConversation {eligibleMembers = [newlyAdded]},
                   updatedTargets === [],
+                  scheduledJobs === [],
                   length pushes === 0
                 ]
             Right _ -> counterexample "expected adminless-conversation error" False
+
+  prop "guardPreventAdminlessGroupsFor schedules deletion when no eligible members exist" $
+    \domain teamId convId leaving eligible1 eligible2 ->
+      ioProperty $ do
+        fx <- mkAdminlessGroupsFixture domain teamId convId leaving eligible1 eligible2
+        let users =
+              [ user {userType = UserTypeApp}
+              | user <- fx.fixtureUsers
+              ]
+            features =
+              npUpdate @PreventAdminlessGroupsConfig
+                ( LockableFeature
+                    FeatureStatusEnabled
+                    LockStatusUnlocked
+                    ((def :: PreventAdminlessGroupsConfig) {reminderTimeouts = []})
+                )
+                def
+            (pushes, (updatedTargets, (scheduledJobs, result))) =
+              runAdminlessGroupsTest users features fx.fixtureConversations $
+                guardPreventAdminlessGroupsFor
+                  RemoveMemberLegacyResponse
+                  fx.fixtureLocalConversation
+                  fx.fixtureLocalUser
+                  (Set.singleton fx.fixtureVictim)
+                  Set.empty
+                  Set.empty
+        pure $
+          case result of
+            Left err -> counterexample ("unexpected adminless error: " <> show err) False
+            Right _ ->
+              conjoin
+                [ updatedTargets === [],
+                  length pushes === 0,
+                  scheduledJobs === [ScheduledAdminlessDeletion]
+                ]
 
   prop "removeMemberQualified returns adminless-conversation error" $
     \convDomain
@@ -212,6 +251,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                 ]
               result =
                 run
+                  . runState @[ScheduledAdminlessJob] []
                   . runError @AdminlessConversation
                   . runError @(Tagged ('ActionDenied 'RemoveConversationMember) ())
                   . runError @(Tagged ('ActionDenied 'ModifyOtherConversationMember) ())
@@ -242,7 +282,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
                   . noopLogger
                   $ removeMemberQualified RemoveMemberEligibleMembersResponse lusr connId qcnv qvictim
           pure $
-            case result of
+            case snd result of
               Left err ->
                 err === AdminlessConversation {eligibleMembers = expectedEligible}
               Right _ ->
@@ -252,6 +292,7 @@ spec = focus $ describe "ConversationSubsystem.Interpreter" do
       run
         . runState @[Push] []
         . runState @[Qualified UserId] []
+        . runState @[ScheduledAdminlessJob] []
         . runError @AdminlessConversation
         . runError @(Tagged ('ActionDenied 'ModifyOtherConversationMember) ())
         . runError @(Tagged 'ConvMemberNotFound ())
@@ -460,7 +501,13 @@ interpretTeamSubsystem =
     InternalGetTeamMember _ _ -> pure Nothing
     _ -> error "unexpected TeamSubsystem call in test"
 
+data ScheduledAdminlessJob
+  = ScheduledAdminlessDeletion
+  | ScheduledAdminlessReminder
+  deriving stock (Eq, Show)
+
 interpretJobSubsystem ::
+  (Member (State [ScheduledAdminlessJob]) r) =>
   Sem (JobSubsystem ': r) a ->
   Sem r a
 interpretJobSubsystem =
@@ -468,9 +515,9 @@ interpretJobSubsystem =
     ScheduleAdminlessSetupJob {} ->
       pure ()
     ScheduleAdminlessDeletionJob {} ->
-      pure ()
+      modify @[ScheduledAdminlessJob] (<> [ScheduledAdminlessDeletion])
     ScheduleAdminlessReminderJob {} ->
-      pure ()
+      modify @[ScheduledAdminlessJob] (<> [ScheduledAdminlessReminder])
     CancelAdminlessJobsForTeam {} ->
       pure ()
 

--- a/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/ConversationSubsystem/InterpreterSpec.hs
@@ -65,7 +65,7 @@ import Wire.StoredConversation
 import Wire.TeamSubsystem (TeamSubsystem (..))
 
 spec :: Spec
-spec = focus $ describe "ConversationSubsystem.Interpreter" do
+spec = describe "ConversationSubsystem.Interpreter" do
   prop "guardPreventAdminlessGroupsFor promotes an eligible member and emits a targeted update [legacy]" $
     \domain teamId convId leaving eligible1 eligible2 ->
       ioProperty $ do

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters.hs
@@ -26,8 +26,8 @@ import Wire.MockInterpreters.AuthenticationSubsystem as MockInterpreters
 import Wire.MockInterpreters.BackgroundJobPublisher as MockInterpreters
 import Wire.MockInterpreters.BlockListStore as MockInterpreters
 import Wire.MockInterpreters.ClientStore as MockInterpreters
-import Wire.MockInterpreters.ConversationSubsystem as MockInterpreters
 import Wire.MockInterpreters.ConversationStore as MockInterpreters
+import Wire.MockInterpreters.ConversationSubsystem as MockInterpreters
 import Wire.MockInterpreters.CryptoSign as MockInterpreters
 import Wire.MockInterpreters.DomainRegistrationStore as MockInterpreters
 import Wire.MockInterpreters.DomainVerificationChallengeStore as MockInterpreters

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters.hs
@@ -27,6 +27,7 @@ import Wire.MockInterpreters.BackgroundJobPublisher as MockInterpreters
 import Wire.MockInterpreters.BlockListStore as MockInterpreters
 import Wire.MockInterpreters.ClientStore as MockInterpreters
 import Wire.MockInterpreters.ConversationSubsystem as MockInterpreters
+import Wire.MockInterpreters.ConversationStore as MockInterpreters
 import Wire.MockInterpreters.CryptoSign as MockInterpreters
 import Wire.MockInterpreters.DomainRegistrationStore as MockInterpreters
 import Wire.MockInterpreters.DomainVerificationChallengeStore as MockInterpreters

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ConversationStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/ConversationStore.hs
@@ -1,0 +1,37 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2026 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it
+-- under the terms of the GNU Affero General Public License as published by the
+-- Free Software Foundation, either version 3 of the License, or (at your
+-- option) any later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.MockInterpreters.ConversationStore where
+
+import Data.Id (ConvId, UserId)
+import Data.Map qualified as Map
+import Data.Qualified (Qualified)
+import Imports
+import Polysemy
+import Polysemy.State
+import Wire.ConversationStore (ConversationStore (..))
+import Wire.StoredConversation (StoredConversation)
+
+inMemoryConversationStoreInterpreter ::
+  (Member (State [Qualified UserId]) r) =>
+  Map.Map ConvId StoredConversation ->
+  InterpreterFor ConversationStore r
+inMemoryConversationStoreInterpreter store =
+  interpret $ \case
+    GetConversation cid -> pure (Map.lookup cid store)
+    SetOtherMember _ target _ -> modify @[(Qualified UserId)] (<> [target])
+    _ -> error "ConversationStore: not implemented in mock"

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -628,6 +628,7 @@ test-suite wire-subsystems-tests
     Wire.MockInterpreters.BackgroundJobPublisher
     Wire.MockInterpreters.BlockListStore
     Wire.MockInterpreters.ClientStore
+    Wire.MockInterpreters.ConversationStore
     Wire.MockInterpreters.ConversationSubsystem
     Wire.MockInterpreters.CryptoSign
     Wire.MockInterpreters.DomainRegistrationStore

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -78,7 +78,8 @@ conversationAPI =
     <@> mkNamedAPI @"add-members-to-conversation-unqualified" (\lusr con cnv invite -> addMembers lusr con (tUntagged (qualifyAs lusr cnv)) (InviteQualified (fmap (tUntagged . qualifyAs lusr) (invUsers invite)) (invRoleName invite)))
     <@> mkNamedAPI @"add-members-to-conversation-unqualified2" addQualifiedMembersUnqualified
     <@> mkNamedAPI @"add-members-to-conversation" addMembers
-    <@> mkNamedAPI @"replace-members-in-conversation" replaceMembers
+    <@> mkNamedAPI @"replace-members-in-conversation@v16" (replaceMembers RemoveMemberLegacyResponse)
+    <@> mkNamedAPI @"replace-members-in-conversation" (replaceMembers RemoveMemberEligibleMembersResponse)
     <@> mkNamedAPI @"join-conversation-by-id-unqualified" joinConversationById
     <@> mkNamedAPI @"join-conversation-by-code-unqualified" joinConversationByReusableCode
     <@> mkNamedAPI @"code-check" checkReusableCode


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27393

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
