### PR TITLE
WPB-23631: Move `Spar.Sem.VerdictFormatStore` in `Wire.VerdictFormatStore`

### DIFF
--- a/changelog.d/5-internal/WPB-23631-5
+++ b/changelog.d/5-internal/WPB-23631-5
@@ -1,0 +1,1 @@
+Move `Spar.Sem.VerdictFormatStore` in `Wire.VerdictFormatStore`.

--- a/libs/wire-subsystems/src/Wire/VerdictFormatStore.hs
+++ b/libs/wire-subsystems/src/Wire/VerdictFormatStore.hs
@@ -17,7 +17,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore
+module Wire.VerdictFormatStore
   ( VerdictFormatStore (..),
     store,
     get,

--- a/libs/wire-subsystems/src/Wire/VerdictFormatStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/VerdictFormatStore/Cassandra.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- Disabling to stop warnings on HasCallStack
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
@@ -18,7 +19,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Cassandra
+module Wire.VerdictFormatStore.Cassandra
   ( verdictFormatStoreToCassandra,
   )
 where
@@ -28,13 +29,42 @@ import Control.Lens
 import Data.Time
 import Imports
 import Polysemy
-import Spar.Data
-import Spar.Data.Instances (VerdictFormatCon, VerdictFormatRow, fromVerdictFormat, toVerdictFormat)
-import Spar.Sem.VerdictFormatStore
 import URI.ByteString
 import Wire.API.User.Auth
 import Wire.API.User.Saml
 import Wire.IdPConfigStore.Orphans ()
+import Wire.VerdictFormatStore
+
+-- Duplicated from Spar.Data (Wire cannot depend on Spar); Spar.Data keeps its
+-- own copy for mkTTLNDT.
+nominalDiffToSeconds :: NominalDiffTime -> Int32
+nominalDiffToSeconds = round @Double . realToFrac
+
+-- Moved from Spar.Data.Instances: row codec for the @verdict@ table.
+type VerdictFormatRow = (VerdictFormatCon, Maybe URI, Maybe URI, Maybe CookieLabel)
+
+data VerdictFormatCon = VerdictFormatConWeb | VerdictFormatConMobile
+
+instance Cql VerdictFormatCon where
+  ctype = Tagged IntColumn
+
+  toCql VerdictFormatConWeb = CqlInt 0
+  toCql VerdictFormatConMobile = CqlInt 1
+
+  fromCql (CqlInt i) = case i of
+    0 -> pure VerdictFormatConWeb
+    1 -> pure VerdictFormatConMobile
+    n -> Left $ "unexpected VerdictFormatCon: " ++ show n
+  fromCql _ = Left "member-status: int expected"
+
+fromVerdictFormat :: VerdictFormat -> VerdictFormatRow
+fromVerdictFormat (VerdictFormatWeb mlabel) = (VerdictFormatConWeb, Nothing, Nothing, mlabel)
+fromVerdictFormat (VerdictFormatMobile succredir errredir mlabel) = (VerdictFormatConMobile, Just succredir, Just errredir, mlabel)
+
+toVerdictFormat :: VerdictFormatRow -> Maybe VerdictFormat
+toVerdictFormat (VerdictFormatConWeb, Nothing, Nothing, mlabel) = Just $ VerdictFormatWeb mlabel
+toVerdictFormat (VerdictFormatConMobile, Just succredir, Just errredir, mlabel) = Just $ VerdictFormatMobile succredir errredir mlabel
+toVerdictFormat _ = Nothing
 
 verdictFormatStoreToCassandra ::
   forall m r a.

--- a/libs/wire-subsystems/src/Wire/VerdictFormatStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/VerdictFormatStore/Cassandra.hs
@@ -40,7 +40,6 @@ import Wire.VerdictFormatStore
 nominalDiffToSeconds :: NominalDiffTime -> Int32
 nominalDiffToSeconds = round @Double . realToFrac
 
--- Moved from Spar.Data.Instances: row codec for the @verdict@ table.
 type VerdictFormatRow = (VerdictFormatCon, Maybe URI, Maybe URI, Maybe CookieLabel)
 
 data VerdictFormatCon = VerdictFormatConWeb | VerdictFormatConMobile

--- a/libs/wire-subsystems/src/Wire/VerdictFormatStore/Mem.hs
+++ b/libs/wire-subsystems/src/Wire/VerdictFormatStore/Mem.hs
@@ -17,21 +17,21 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Mem
+module Wire.VerdictFormatStore.Mem
   ( verdictFormatStoreToMem,
   )
 where
 
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Imports
 import Polysemy
 import Polysemy.State hiding (Get)
 import SAML2.WebSSO (addTime)
-import qualified SAML2.WebSSO.Types as SAML
-import Spar.Sem.VerdictFormatStore
+import SAML2.WebSSO.Types qualified as SAML
 import Wire.API.User.Saml (AReqId, VerdictFormat)
 import Wire.Sem.Now (Now, boolTTL)
-import qualified Wire.Sem.Now as Now
+import Wire.Sem.Now qualified as Now
+import Wire.VerdictFormatStore
 
 verdictFormatStoreToMem ::
   (Member Now r) =>

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -509,6 +509,9 @@ library
     Wire.UserSubsystem.Interpreter
     Wire.UserSubsystem.UserSubsystemConfig
     Wire.Util
+    Wire.VerdictFormatStore
+    Wire.VerdictFormatStore.Cassandra
+    Wire.VerdictFormatStore.Mem
     Wire.VerificationCode
     Wire.VerificationCodeGen
     Wire.VerificationCodeStore

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -80,9 +80,6 @@ library
     Spar.Sem.ScimTokenStore.Cassandra
     Spar.Sem.ScimTokenStore.Mem
     Spar.Sem.Utils
-    Spar.Sem.VerdictFormatStore
-    Spar.Sem.VerdictFormatStore.Cassandra
-    Spar.Sem.VerdictFormatStore.Mem
 
   other-modules:      Paths_spar
   hs-source-dirs:     src

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -102,8 +102,6 @@ import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
-import Spar.Sem.VerdictFormatStore (VerdictFormatStore)
-import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
 import System.Logger (Msg)
 import qualified System.Logger as Log
 import qualified URI.ByteString as URI
@@ -140,6 +138,8 @@ import qualified Wire.Sem.Logger as Logger
 import Wire.Sem.Now (Now)
 import Wire.Sem.Random (Random)
 import qualified Wire.Sem.Random as Random
+import Wire.VerdictFormatStore (VerdictFormatStore)
+import qualified Wire.VerdictFormatStore as VerdictFormatStore
 
 app :: Env -> Application
 app ctx0 req cont = do

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -87,8 +87,6 @@ import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
-import Spar.Sem.VerdictFormatStore (VerdictFormatStore)
-import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
 import System.Logger (Msg)
 import qualified System.Logger as Log
 import qualified System.Logger as TinyLog
@@ -115,6 +113,8 @@ import Wire.Sem.Logger (Logger)
 import qualified Wire.Sem.Logger as Logger
 import Wire.Sem.Random (Random)
 import qualified Wire.Sem.Random as Random
+import Wire.VerdictFormatStore (VerdictFormatStore)
+import qualified Wire.VerdictFormatStore as VerdictFormatStore
 
 throwSparSem :: (Member (Error SparError) r) => SparCustomError -> Sem r a
 throwSparSem = throw . SAML.CustomError

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -48,8 +48,6 @@ import Spar.Sem.SAMLUserStore.Cassandra (samlUserStoreToCassandra)
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import Spar.Sem.ScimTokenStore.Cassandra (scimTokenStoreToCassandra)
 import Spar.Sem.Utils
-import Spar.Sem.VerdictFormatStore (VerdictFormatStore)
-import Spar.Sem.VerdictFormatStore.Cassandra (verdictFormatStoreToCassandra)
 import qualified System.Logger as TinyLog
 import Wire.API.Routes.Version (expandVersionExp)
 import Wire.API.User.Saml (TTLError)
@@ -84,6 +82,8 @@ import Wire.Sem.Now (Now)
 import Wire.Sem.Now.IO (nowToIO)
 import Wire.Sem.Random (Random)
 import Wire.Sem.Random.IO (randomToIO)
+import Wire.VerdictFormatStore (VerdictFormatStore)
+import Wire.VerdictFormatStore.Cassandra (verdictFormatStoreToCassandra)
 
 type CanonicalEffs =
   '[IdPSubsystem, ScimSubsystem]

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -21,7 +21,6 @@ module Spar.Data
     Env (..),
     mkEnv,
     mkTTLAssertions,
-    nominalDiffToSeconds,
     mkTTLAuthnRequests,
 
     -- * SAML Users

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -29,10 +29,6 @@ import Data.Functor.Alt (Alt ((<!>)))
 import qualified Data.Text.Encoding as T
 import Data.Text.Encoding.Error
 import Imports
-import Spar.Scim.Types (ScimUserCreationStatus (..))
-import URI.ByteString
-import Wire.API.User.Auth
-import Wire.API.User.Saml
 import Wire.API.User.Scim
 
 deriving instance Cql ScimToken

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -20,16 +20,7 @@
 
 -- | 'Cql' instances for Spar types, as well as conversion functions used in "Spar.Data"
 -- (which does the actual database work).
-module Spar.Data.Instances
-  ( -- * Raw database types
-    VerdictFormatRow,
-    VerdictFormatCon (..),
-
-    -- ** Conversions
-    fromVerdictFormat,
-    toVerdictFormat,
-  )
-where
+module Spar.Data.Instances () where
 
 import Cassandra as Cas
 import Data.ByteString (toStrict)
@@ -38,35 +29,11 @@ import Data.Functor.Alt (Alt ((<!>)))
 import qualified Data.Text.Encoding as T
 import Data.Text.Encoding.Error
 import Imports
+import Spar.Scim.Types (ScimUserCreationStatus (..))
 import URI.ByteString
 import Wire.API.User.Auth
 import Wire.API.User.Saml
 import Wire.API.User.Scim
-
-type VerdictFormatRow = (VerdictFormatCon, Maybe URI, Maybe URI, Maybe CookieLabel)
-
-data VerdictFormatCon = VerdictFormatConWeb | VerdictFormatConMobile
-
-instance Cql VerdictFormatCon where
-  ctype = Tagged IntColumn
-
-  toCql VerdictFormatConWeb = CqlInt 0
-  toCql VerdictFormatConMobile = CqlInt 1
-
-  fromCql (CqlInt i) = case i of
-    0 -> pure VerdictFormatConWeb
-    1 -> pure VerdictFormatConMobile
-    n -> Left $ "unexpected VerdictFormatCon: " ++ show n
-  fromCql _ = Left "member-status: int expected"
-
-fromVerdictFormat :: VerdictFormat -> VerdictFormatRow
-fromVerdictFormat (VerdictFormatWeb mlabel) = (VerdictFormatConWeb, Nothing, Nothing, mlabel)
-fromVerdictFormat (VerdictFormatMobile succredir errredir mlabel) = (VerdictFormatConMobile, Just succredir, Just errredir, mlabel)
-
-toVerdictFormat :: VerdictFormatRow -> Maybe VerdictFormat
-toVerdictFormat (VerdictFormatConWeb, Nothing, Nothing, mlabel) = Just $ VerdictFormatWeb mlabel
-toVerdictFormat (VerdictFormatConMobile, Just succredir, Just errredir, mlabel) = Just $ VerdictFormatMobile succredir errredir mlabel
-toVerdictFormat _ = Nothing
 
 deriving instance Cql ScimToken
 

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -35,7 +35,6 @@ import qualified Spar.Sem.AReqIDStore as AReqIDStore
 import qualified Spar.Sem.AssIDStore as AssIDStore
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
-import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
 import Type.Reflection (typeRep)
 import URI.ByteString.QQ (uri)
 import Util.Core
@@ -46,6 +45,7 @@ import Web.Scim.Schema.Meta as Scim.Meta
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
 import qualified Wire.IdPConfigStore as IdPEffect
+import qualified Wire.VerdictFormatStore as VerdictFormatStore
 
 spec :: SpecWith TestEnv
 spec = do

--- a/services/spar/test/Test/Spar/Saml/IdPSpec.hs
+++ b/services/spar/test/Test/Spar/Saml/IdPSpec.hs
@@ -40,7 +40,6 @@ import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.SAMLUserStore.Mem
 import Spar.Sem.ScimTokenStore
 import Spar.Sem.ScimTokenStore.Mem
-import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
 import System.FilePath ((</>))
 import System.Logger (Msg)
 import System.Logger.Class (Level (..))
@@ -75,6 +74,7 @@ import Wire.Sem.Logger (discardLogs)
 import Wire.Sem.Logger.TinyLog (LogRecorder (..), newLogRecorder, recordLogs)
 import Wire.Sem.Random
 import Wire.Sem.Random.Null
+import qualified Wire.VerdictFormatStore as VerdictFormatStore
 
 spec :: Spec
 spec =

--- a/weeder.toml
+++ b/weeder.toml
@@ -137,7 +137,7 @@ roots = [ # may of the entries here are about general-purpose module
          "^Spar.Sem.AReqIDStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
          "^Spar.Sem.AssIDStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
          "^Spar.Sem.ScimTokenStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
-         "^Spar.Sem.VerdictFormatStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
+         "^Wire.VerdictFormatStore.Mem.*$", # FUTUREWORK: @fisx can we delete this?
          "^Spec.main$",
          "^Stern.App.runHandler$",
          "^System.Logger.Extended.runWithLogger$",


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-23631

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
