### PR TITLE
[WPB-27705] Roll back: do *not* include collaborator apps in get-apps end-point.

### DIFF
--- a/changelog.d/1-api-changes/WPB-27705-roll-back_-do-_not_-include-collaborator-apps-in-get-apps-end-point
+++ b/changelog.d/1-api-changes/WPB-27705-roll-back_-do-_not_-include-collaborator-apps-in-get-apps-end-point
@@ -1,0 +1,1 @@
+Roll back: do *not* include collaborator apps in get-apps end-point.

--- a/changelog.d/3-bug-fixes/WPB-27227-include-collaborating-apps-_aka-external-apps_-in-_get-_teams__tid_apps_
+++ b/changelog.d/3-bug-fixes/WPB-27227-include-collaborating-apps-_aka-external-apps_-in-_get-_teams__tid_apps_
@@ -1,1 +1,0 @@
-Include collaborating apps (aka external apps) in "GET /teams/:tid/apps".  (Drive-by improvement: move access control for UserSubsystem.GetLocalAppProfiles from brig into wire-subsystems.)

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -60,7 +60,6 @@ import Wire.API.Federation.Error
 import Wire.API.MLS.CipherSuite (CipherSuiteTag, csSignatureScheme)
 import Wire.API.Routes.FederationDomainConfig
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti (TeamStatus (..))
-import Wire.API.Team.Collaborator
 import Wire.API.Team.Export
 import Wire.API.Team.Feature
 import Wire.API.Team.Member
@@ -103,7 +102,6 @@ import Wire.Sem.Metrics qualified as Metrics
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now qualified as Now
 import Wire.StoredUser
-import Wire.TeamCollaboratorsSubsystem
 import Wire.TeamSubsystem
 import Wire.UserGroupStore (UserGroupStore, getUserGroupIdsForUsers)
 import Wire.UserKeyStore
@@ -118,8 +116,7 @@ import Wire.UserSubsystem.UserSubsystemConfig
 import Witherable (wither)
 
 runUserSubsystem ::
-  ( Member TeamCollaboratorsSubsystem r,
-    Member AppStore r,
+  ( Member AppStore r,
     Member UserStore r,
     Member ClientStore r,
     Member MlsKeyPackageSubsystem r,
@@ -438,7 +435,6 @@ getLocalAppProfilesImpl ::
     Member (Concurrency Unsafe) r,
     Member (Input (Local any)) r,
     Member AppSubsystem r,
-    Member TeamCollaboratorsSubsystem r,
     Member TeamSubsystem r
   ) =>
   Local UserId ->

--- a/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/UserSubsystem/Interpreter.hs
@@ -462,12 +462,7 @@ getLocalAppProfilesImpl self tid = do
               Just app -> profile {profileApp = Just (storedAppToAppInfo app)}
               Nothing -> profile
 
-  collaboratingApps :: [UserProfile] <- do
-    allIds <- (.gUser) <$$> getAllTeamCollaborators self tid
-    allProfiles <- getUserProfilesLocalPart (Just self) (qualifyAs self allIds)
-    pure (filter (isJust . (.profileApp)) allProfiles)
-
-  pure ((injectPreloadedApp <$> profiles) <> collaboratingApps)
+  pure (injectPreloadedApp <$> profiles)
 
 getUserProfilesFromDomain ::
   ( Member (Error FederationError) r,

--- a/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/UserSubsystem/InterpreterSpec.hs
@@ -1145,7 +1145,7 @@ spec = describe "UserSubsystem.Interpreter" do
               pure $ result.searchResults === [expectedContact | fromMaybe True searchee.searchable]
 
   describe "getLocalAppProfiles" $ do
-    prop "includes apps that are collaborators from other teams" $
+    prop "does *not* include apps that are collaborators from other teams" $
       \(NotPendingStoredUser appUser_)
        (NotPendingStoredUser ownerA_)
        (NotPendingStoredUser ownerB_)
@@ -1198,7 +1198,7 @@ spec = describe "UserSubsystem.Interpreter" do
                      in (,)
                           <$> getAppId teamAId teamAOwnerId
                           <*> getAppId teamBId teamBOwnerId
-             in result === ([appUser.id], [appUser.id])
+             in result === ([], [appUser.id])
 
     prop "denies access when the caller's own team is not the requested team" . withMaxSuccess 1 $
       \(NotPendingStoredUser caller_)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27705

There is `GET /teams/:tid/apps` and `GET /teams/:tid/collaborators`, and mixing the two concerns in these two end-points seems incoherent to me.

There is an ongoing discussion whether collaborators are team members (they interact with the team, but do you have to pay for their seats, even though the home team has already paid?), but for these two end-points there shouldn't be any disagreements.  (...  right?)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)