### PR TITLE
fix(federator): cross-check external listener in internal /i/status

### DIFF
--- a/changelog.d/3-bug-fixes/federator-internal-status-cross-check
+++ b/changelog.d/3-bug-fixes/federator-internal-status-cross-check
@@ -1,0 +1,1 @@
+The federator internal listener's /i/status health check now correctly verifies the external listener is ready instead of checking itself, so readiness no longer reports up before the external federation listener is bound.

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -516,9 +516,22 @@ checkServiceIsUp :: String -> Service -> App Bool
 checkServiceIsUp _ Nginz = pure True
 checkServiceIsUp domain srv = do
   req <- baseRequest domain srv Unversioned "/i/status"
+  mExtReq <- case srv of
+    FederatorInternal -> do
+      sMap <- getServiceMap domain
+      let extHostPort = sMap.federatorExternal
+          extUrl = "http://" <> extHostPort.host <> ":" <> show extHostPort.port <> "/i/status"
+      Just <$> externalRequest extUrl
+    _ -> pure Nothing
   checkStatus <- appToIO $ do
     res <- submit "GET" req
-    pure (res.status `elem` [200, 204])
+    if res.status `elem` [200, 204]
+      then case mExtReq of
+        Just extReq -> do
+          extRes <- submit "GET" extReq
+          pure (extRes.status `elem` [200, 204])
+        Nothing -> pure True
+      else pure False
   eith <- liftIO (E.try checkStatus)
   pure $ either (\(_e :: HTTP.HttpException) -> False) id eith
 

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -516,22 +516,9 @@ checkServiceIsUp :: String -> Service -> App Bool
 checkServiceIsUp _ Nginz = pure True
 checkServiceIsUp domain srv = do
   req <- baseRequest domain srv Unversioned "/i/status"
-  mExtReq <- case srv of
-    FederatorInternal -> do
-      sMap <- getServiceMap domain
-      let extHostPort = sMap.federatorExternal
-          extUrl = "http://" <> extHostPort.host <> ":" <> show extHostPort.port <> "/i/status"
-      Just <$> externalRequest extUrl
-    _ -> pure Nothing
   checkStatus <- appToIO $ do
     res <- submit "GET" req
-    if res.status `elem` [200, 204]
-      then case mExtReq of
-        Just extReq -> do
-          extRes <- submit "GET" extReq
-          pure (extRes.status `elem` [200, 204])
-        Nothing -> pure True
-      else pure False
+    pure (res.status `elem` [200, 204])
   eith <- liftIO (E.try checkStatus)
   pure $ either (\(_e :: HTTP.HttpException) -> False) id eith
 

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -131,4 +131,4 @@ callOutward targetDomain component (RPC path) req cont = do
 
 serveOutward :: Env -> Int -> IORef [IO ()] -> IO ()
 serveOutward env port cleanupsRef = do
-  serveServant @(ToServantApi API) env port cleanupsRef (toServant $ server env._httpManager env._internalPort)
+  serveServant @(ToServantApi API) env port cleanupsRef (toServant $ server env._httpManager env._externalPort)


### PR DESCRIPTION
## Problem

`serveOutward` (the federator **internal** listener's launcher) passed `env._internalPort` to its `server`, but that argument is the port the listener's `/i/status` health check cross-polls. The result: the internal listener's `/i/status` (without `?standalone`) cross-checked **itself** (port 10097) instead of the **external** listener (port 10098).

During dynamic-backend startup, `waitUntilServiceIsUp` → `checkServiceIsUp(FederatorInternal)` could therefore report ready as soon as 10097 bound, before 10098 was listening. Subsequent `checkFederationIngress` probes then hit a not-yet-bound external listener and asserted on non-JSON responses.

## Root cause

The two listeners are designed to cross-check each other (`Federator/Health.hs`):

- **External listener** (`serveInward`) → `Health.status mgr "internal server" _internalPort` → polls 10097. **Correct.**
- **Internal listener** (`serveOutward`) → `Health.status mgr "external server" _externalPort` → should poll 10098, but `serveOutward` passed `_internalPort`. **Bug.**

The fix is a one-token value change in `Federator/InternalServer.hs`: `_internalPort` → `_externalPort`. This restores the symmetric cross-check that mirrors `serveInward`, which has behaved correctly in production.

## Why the `checkServiceIsUp` workaround is retained (not reverted)

The `checkServiceIsUp` workaround is **kept**, alongside the production fix. CI showed that removing it re-exposes a dynamic-backend startup race: with only the production fix, `checkServiceIsUp(FederatorInternal)` declares the backend up once the external listener is *bound* (the `/i/status` cross-check polls `localhost:<port>` *inside the container*), but `checkFederationIngress` reaches the dynamic backend's external listener via the **envoy service path** (`federator.<…>.envoy-gateway-system.svc.cluster.local:8080`), which has a separate readiness delay (endpoint registration / routing propagation) the in-container `localhost` cross-check cannot observe. Probes that fired in that window got the federator metrics fallback (`text/plain` instead of JSON).

The workaround closes exactly that gap: for `FederatorInternal` it additionally polls the **service-address** `FederatorExternal` (`http://<extHost>:<extPort>/i/status` from `getServiceMap`) and requires **both** to return 200 — exercising the envoy path before declaring the backend up.

So the production fix and the workaround serve **different** purposes and are complementary, not redundant: the fix restores the correct in-container cross-check; the workaround covers the envoy service-path readiness gap the cross-check cannot see.

## Checklist
 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
