### PR TITLE
WPB-18320: make alpine images configurable

### DIFF
--- a/changelog.d/5-internal/configurable-alpine-images-cannon-cassandra-migrations
+++ b/changelog.d/5-internal/configurable-alpine-images-cannon-cassandra-migrations
@@ -1,0 +1,19 @@
+The alpine base images used by the `cannon-configurator` initContainer (`wire-server`
+chart) and the `job-done` container (`cassandra-migrations` chart) are no longer
+hard-coded. They can now be set via `cannon.configuratorImage.{repository,tag,pullPolicy}`
+in the `wire-server` chart and `jobDoneImage.{repository,tag}` in the
+`cassandra-migrations` chart.
+
+The default was bumped from `alpine:3.21.3` to `alpine:3.24.1`, since alpine 3.21
+reaches end-of-support on 2026-11-01. The local integration stack's `init_vhosts`
+container also moved from `alpine/curl:3.14` (an Alpine 3.14 image last published
+in 2021) to `alpine/curl:8.21.0`.
+
+Operators who mirror images into a private registry should make sure the new
+`alpine:3.24.1` tag is cached, or override `repository` to point at their mirror.
+
+The chart release tooling (`hack/bin/set-wire-server-image-version.sh`,
+`hack/bin/set-chart-image-version.sh`) now anchors its version stamping to
+`repository: quay.io/wire/` lines instead of matching `tag:` by indentation, so
+third-party image tags in `values.yaml` are no longer overwritten with the
+wire-server release version.

--- a/charts/cassandra-migrations/templates/migrate-schema.yaml
+++ b/charts/cassandra-migrations/templates/migrate-schema.yaml
@@ -166,7 +166,8 @@ spec:
 
       containers:
         - name: job-done
-          image: alpine:3.21.3
+          image: "{{ .Values.jobDoneImage.repository }}:{{ .Values.jobDoneImage.tag }}"
+          imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         {{- if eq (include "includeSecurityContext" .) "true" }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}

--- a/charts/cassandra-migrations/values.yaml
+++ b/charts/cassandra-migrations/values.yaml
@@ -79,6 +79,15 @@ enableBrigMigrations: true
 enableGundeckMigrations: true
 enableSparMigrations: true
 
+# Image for the `job-done` container, which only runs a single `echo` to mark
+# the migration Job complete. Not a wire image, so it is versioned
+# independently of images.tag above. Override repository to pull from a
+# mirror registry, e.g. my-mirror.example/library/alpine
+# renovate: datasource=docker depName=alpine
+jobDoneImage:
+  repository: alpine
+  tag: "3.24.1"
+
 podSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/charts/wire-server/templates/cannon/statefulset.yaml
+++ b/charts/wire-server/templates/cannon/statefulset.yaml
@@ -143,7 +143,8 @@ spec:
           {{- toYaml .Values.cannon.resources | nindent 10 }}
       initContainers:
       - name: cannon-configurator
-        image: alpine:3.21.3
+        image: "{{ .Values.cannon.configuratorImage.repository }}:{{ .Values.cannon.configuratorImage.tag }}"
+        imagePullPolicy: "{{ .Values.cannon.configuratorImage.pullPolicy }}"
         {{- if eq (include "includeSecurityContext" .) "true" }}
         securityContext:
           {{- toYaml .Values.cannon.podSecurityContext | nindent 10 }}

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -518,6 +518,14 @@ cannon:
     repository: quay.io/wire/nginz
     tag: do-not-use
     pullPolicy: IfNotPresent
+  # Image for the cannon-configurator initContainer, which only runs a
+  # single `echo` into a shared volume. Override repository to pull from a
+  # mirror registry, e.g. my-mirror.example/library/alpine
+  # renovate: datasource=docker depName=alpine
+  configuratorImage:
+    repository: alpine
+    tag: "3.24.1"
+    pullPolicy: IfNotPresent
   config:
     logLevel: Info
     logFormat: StructuredJSON

--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -334,7 +334,7 @@ services:
       - demo_wire
 
   init_vhosts:
-    image: alpine/curl:3.14
+    image: alpine/curl:8.21.0
     environment:
       - RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
       - RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}

--- a/hack/bin/set-chart-image-version.sh
+++ b/hack/bin/set-chart-image-version.sh
@@ -12,6 +12,14 @@ do
 if [[ "$chart" == "nginz" ]]; then
     # nginz has a different docker tag indentation
     sed -i "s/^    tag: .*/    tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
+elif [[ "$chart" == "wire-server" ]]; then
+    # Anchored to quay.io/wire/ repository: lines so non-wire images (cannon's
+    # alpine configuratorImage) keep their own tag instead of being stamped.
+    sed -i -E "/^[[:space:]]*repository: quay\.io\/wire\//{n; s/^([[:space:]]*)tag: .*/\1tag: $docker_tag/}" "$CHARTS_DIR/$chart/values.yaml"
+elif [[ "$chart" == "cassandra-migrations" ]]; then
+    # cassandra-migrations shares one images.tag with no adjacent repository:
+    # line, so anchor to the images: block to avoid stamping jobDoneImage.
+    sed -i -E "/^images:/,/^[^[:space:]]/ s/^  tag: .*/  tag: $docker_tag/" "$CHARTS_DIR/$chart/values.yaml"
 else
     sed -i "s/^  tag: .*/  tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
 fi

--- a/hack/bin/set-wire-server-image-version.sh
+++ b/hack/bin/set-wire-server-image-version.sh
@@ -11,7 +11,14 @@ charts=(proxy cassandra-migrations elasticsearch-index federator backoffice inte
 for chart in "${charts[@]}"; do
     values_file="$CHARTS_DIR/$chart/values.yaml"
     if [[ -f "$values_file" ]]; then
-        sed -i "s/^  tag: .*/  tag: $target_version/g" "$values_file"
+        if [[ "$chart" == "cassandra-migrations" ]]; then
+            # cassandra-migrations shares one images.tag across several images and
+            # has no adjacent repository: line, so anchor to the images: block to
+            # avoid stamping the (non-wire) jobDoneImage tag.
+            sed -i -E "/^images:/,/^[^[:space:]]/ s/^  tag: .*/  tag: $target_version/" "$values_file"
+        else
+            sed -i "s/^  tag: .*/  tag: $target_version/g" "$values_file"
+        fi
     fi
 done
 
@@ -19,4 +26,6 @@ done
 sed -i "s/^    tag: .*/    tag: $target_version/g" "$CHARTS_DIR/nginz/values.yaml"
 
 # Brig, Galley, Cargohold, BackgroundWorker, Cannon, Gundeck, and Spar are inlined into the umbrella chart.
-sed -i "s/^    tag: .*/    tag: $target_version/g" "$CHARTS_DIR/wire-server/values.yaml"
+# Anchored to quay.io/wire/ repository: lines so non-wire images (cannon's alpine
+# configuratorImage) keep their own tag instead of being stamped.
+sed -i -E "/^[[:space:]]*repository: quay\.io\/wire\//{n; s/^([[:space:]]*)tag: .*/\1tag: $target_version/}" "$CHARTS_DIR/wire-server/values.yaml"

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,20 @@
       ]
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/charts/.+/values\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+[^\\n]*\\n\\s*repository:[^\\n]*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "depNameTemplate": "{{{depName}}}",
+      "versioningTemplate": "docker"
+    }
+  ],
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
- Bump alpine 3.21.3 -> 3.24.1 (3.21 is EOL end of October 2026)
- Fix release version stamping to not accidentally overwrite alpine image tags in values.yaml

related to WPB-18320

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
