### PR TITLE
fix: stop comparing event order in `testMeetingMLSAddParticipant`

### DIFF
--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -88,9 +88,9 @@ testMeetingMLSAddParticipant = do
                            "meeting.member-add",
                            "conversation.mls-welcome"
                          ]
-      case sequenceNotifs of
-        [_, notif, _] -> pure notif
-        _ -> error "expected exactly three meeting-add sequence notifications"
+      case [n | (t, n) <- zip sequenceTypes sequenceNotifs, t == "meeting.member-add"] of
+        (notif : _) -> pure notif
+        [] -> assertFailure "expected a meeting.member-add notification in the add sequence"
 
   assertMeetingNotif memberAddNotif (meeting %. "qualified_id")
   memberAddNotif %. "payload.0.qualified_conversation" `shouldMatch` convQid

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -84,10 +84,10 @@ testMeetingMLSAddParticipant = do
       sequenceNotifs <- replicateM 3 (awaitMatch isMeetingAddSequenceNotif ws)
       sequenceTypes <- for sequenceNotifs $ \notif -> notif %. "payload.0.type" >>= asString
       sequenceTypes
-        `shouldMatch` [ "conversation.member-join",
-                        "meeting.member-add",
-                        "conversation.mls-welcome"
-                      ]
+        `shouldMatchSet` [ "conversation.member-join",
+                           "meeting.member-add",
+                           "conversation.mls-welcome"
+                         ]
       case sequenceNotifs of
         [_, notif, _] -> pure notif
         _ -> error "expected exactly three meeting-add sequence notifications"


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
