### PR TITLE
fix: stop using broken addTeamMemberInternal in testCreateOne2OneWith

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -197,6 +197,7 @@ library
     Test.NginxZAuthModule
     Test.Notifications
     Test.OAuth
+    Test.One2OneTeamConv
     Test.PasswordReset
     Test.Presence
     Test.Property

--- a/integration/test/Test/One2OneTeamConv.hs
+++ b/integration/test/Test/One2OneTeamConv.hs
@@ -1,0 +1,91 @@
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.One2OneTeamConv where
+
+import API.Galley
+import Control.Retry (constantDelay, limitRetries, retrying)
+import Notifications (isTeamMemberJoinNotif)
+import SetupHelpers
+import Testlib.Prelude
+
+-- | Team member roles that the one2one team conversation test is parametrized
+-- over (the standard non-owner roles). Each constructor is enumerated into a
+-- separate test case by the test discovery machinery, mirroring the way the
+-- original galley test invoked @testCreateOne2OneWithMembers@ once per role.
+data One2OneRole = One2OneMember | One2OnePartner
+  deriving stock (Generic, Eq, Show)
+
+-- | Map a parametrized role to the team-role string accepted by
+-- 'createTeamMember' (see @Wire.API.Team.Role@: @member@, @partner@). The
+-- original galley test covered @RoleMember@ and @RoleExternalPartner@.
+one2OneRoleName :: One2OneRole -> String
+one2OneRoleName = \case
+  One2OneMember -> "member"
+  One2OnePartner -> "partner"
+
+-- | An owner adds a second team member with the given role and creates a
+-- binding one2one team conversation with them. Ported from
+-- @services/galley/test/integration/API/Teams.hs@
+-- (@testCreateOne2OneWithMembers@).
+testCreateOne2OneWithMembers :: (HasCallStack) => One2OneRole -> App ()
+testCreateOne2OneWithMembers memberRole = do
+  (owner, tid, []) <- createTeam OwnDomain 1
+  teamMember <-
+    withWebSockets [owner] $ \[wsOwner] -> do
+      m <- createTeamMember owner def {role = one2OneRoleName memberRole}
+      -- The owner is notified of the new member joining the team. This mirrors
+      -- @checkTeamMemberJoin@ in the galley test suite.
+      memberJoin <- awaitMatch isTeamMemberJoinNotif wsOwner
+      memberJoin %. "payload.0.team" `shouldMatch` tid
+      memberJoin %. "payload.0.data.user" `shouldMatch` objId m
+      -- The original test additionally asserts a @team.update@ event via the
+      -- galley SQS team-event queue (@assertTeamUpdate tid 2 [owner]@). That
+      -- queue is galley-test-specific and has no websocket / Testlib
+      -- equivalent (galley only pushes @team.member-join@ over websockets on a
+      -- member join), so we verify the updated team membership directly.
+      bindResponse (getTeamMembers owner tid) $ \resp -> do
+        resp.status `shouldMatchInt` 200
+        members <- resp.json %. "members" >>= asList
+        length members `shouldMatchInt` 2
+      pure m
+  -- Creating the one2one team conversation is eventually consistent: retry
+  -- while the response is not 201, mirroring @retryWhileN 10 repeatIf@ in the
+  -- original test.
+  bindResponse
+    ( retrying
+        (constantDelay 500_000 <> limitRetries 10)
+        (\_ resp -> pure (resp.status /= 201))
+        (const (postOne2OneConversation owner teamMember tid ""))
+    )
+    $ \resp -> resp.status `shouldMatchInt` 201
+  -- Recreating the one2one is a no-op and returns 200.
+  bindResponse (postOne2OneConversation owner teamMember tid "") $ \resp ->
+    resp.status `shouldMatchInt` 200
+
+-- | Two owners each create their own binding team. Attempting to create a
+-- one2one team conversation with a member of a different (binding) team fails
+-- with @non-binding-team-members@. Ported from
+-- @testCreateOne2OneFailForNonTeamMembers@.
+testCreateOne2OneFailForNonTeamMembers :: (HasCallStack) => App ()
+testCreateOne2OneFailForNonTeamMembers = do
+  (owner1, tid1, []) <- createTeam OwnDomain 1
+  (owner2, _tid2, []) <- createTeam OwnDomain 1
+  postOne2OneConversation owner1 owner2 tid1 ""
+    >>= assertLabel 403 "non-binding-team-members"

--- a/integration/test/Test/One2OneTeamConv.hs
+++ b/integration/test/Test/One2OneTeamConv.hs
@@ -72,11 +72,11 @@ testCreateOne2OneWithMembers memberRole = do
     ( retrying
         (constantDelay 500_000 <> limitRetries 10)
         (\_ resp -> pure (resp.status /= 201))
-        (const (postOne2OneConversation owner teamMember tid ""))
+        (const (postOne2OneConversation owner teamMember tid "chit-chat"))
     )
     $ \resp -> resp.status `shouldMatchInt` 201
   -- Recreating the one2one is a no-op and returns 200.
-  bindResponse (postOne2OneConversation owner teamMember tid "") $ \resp ->
+  bindResponse (postOne2OneConversation owner teamMember tid "chit-chat") $ \resp ->
     resp.status `shouldMatchInt` 200
 
 -- | Two owners each create their own binding team. Attempting to create a
@@ -87,5 +87,5 @@ testCreateOne2OneFailForNonTeamMembers :: (HasCallStack) => App ()
 testCreateOne2OneFailForNonTeamMembers = do
   (owner1, tid1, []) <- createTeam OwnDomain 1
   (owner2, _tid2, []) <- createTeam OwnDomain 1
-  postOne2OneConversation owner1 owner2 tid1 ""
+  postOne2OneConversation owner1 owner2 tid1 "chit-chat"
     >>= assertLabel 403 "non-binding-team-members"

--- a/integration/test/Test/One2OneTeamConv.hs
+++ b/integration/test/Test/One2OneTeamConv.hs
@@ -20,7 +20,6 @@
 module Test.One2OneTeamConv where
 
 import API.Galley
-import Control.Retry (constantDelay, limitRetries, retrying)
 import Notifications (isTeamMemberJoinNotif)
 import SetupHelpers
 import Testlib.Prelude
@@ -66,15 +65,8 @@ testCreateOne2OneWithMembers memberRole = do
         length members `shouldMatchInt` 2
       pure m
   -- Creating the one2one team conversation is eventually consistent: retry
-  -- while the response is not 201, mirroring @retryWhileN 10 repeatIf@ in the
-  -- original test.
-  bindResponse
-    ( retrying
-        (constantDelay 500_000 <> limitRetries 10)
-        (\_ resp -> pure (resp.status /= 201))
-        (const (postOne2OneConversation owner teamMember tid "chit-chat"))
-    )
-    $ \resp -> resp.status `shouldMatchInt` 201
+  -- until it returns 201.
+  eventually $ postOne2OneConversation owner teamMember tid "chit-chat" >>= assertStatus 201
   -- Recreating the one2one is a no-op and returns 200.
   bindResponse (postOne2OneConversation owner teamMember tid "chit-chat") $ \resp ->
     resp.status `shouldMatchInt` 200

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -442,6 +442,11 @@ testAddTeamMemberInternal = do
   let p1 = Util.symmPermissions [GetBilling] -- permissions are irrelevant on internal endpoint
   mem1 <- newTeamMember' p1 <$> Util.randomUser
   WS.bracketRN c [owner, mem1 ^. userId] $ \[wsOwner, wsMem1] -> do
+    -- This test directly exercises the internal @POST /i/teams/:tid/members@
+    -- endpoint (formerly @Util.addTeamMemberInternal@). It is intentionally
+    -- inlined rather than exposed as a reusable helper because that endpoint
+    -- bypasses the invitation flow and must not be reused by other tests
+    -- (https://wearezeta.atlassian.net/browse/SQSERVICES-471).
     g <- viewGalley
     post
       ( g

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -400,17 +400,18 @@ testCreateOne2OneFailForNonTeamMembers = do
 
 testCreateOne2OneWithMembers ::
   (HasCallStack) =>
-  -- | Role of the user who creates the conversation
+  -- | Role of the team member added to the team
   Role ->
   TestM ()
-testCreateOne2OneWithMembers (rolePermissions -> perms) = do
+testCreateOne2OneWithMembers role = do
   c <- view tsCannon
   (owner, tid) <- Util.createBindingTeam
-  mem1 <- newTeamMember' perms <$> Util.randomUser
-  WS.bracketR c (mem1 ^. userId) $ \wsMem1 -> do
-    Util.addTeamMemberInternal tid (mem1 ^. userId) (mem1 ^. permissions) (mem1 ^. invitation)
-    checkTeamMemberJoin tid (mem1 ^. userId) wsMem1
-    assertTeamUpdate "team member join" tid 2 [owner]
+  mem1 <-
+    WS.bracketR c owner $ \wsOwner -> do
+      mem <- Util.addUserToTeamWithRole (Just role) owner tid
+      checkTeamMemberJoin tid (mem ^. userId) wsOwner
+      assertTeamUpdate "team member join" tid 2 [owner]
+      pure mem
   void $ retryWhileN 10 repeatIf (Util.createOne2OneTeamConv owner (mem1 ^. userId) Nothing tid)
   -- Recreating a One2One is a no-op, returns a 200
   Util.createOne2OneTeamConv owner (mem1 ^. userId) Nothing tid !!! const 200 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -106,9 +106,6 @@ tests s =
         [test s "the list should be truncated" testUncheckedListTeamMembers],
       test s "enable/disable SSO" testEnableSSOPerTeam,
       test s "enable/disable Custom Search Visibility" testEnableTeamSearchVisibilityPerTeam,
-      test s "create 1-1 conversation between non-team members (fail)" testCreateOne2OneFailForNonTeamMembers,
-      test s "create 1-1 conversation between binding team members" (testCreateOne2OneWithMembers RoleMember),
-      test s "create 1-1 conversation between binding team members as partner" (testCreateOne2OneWithMembers RoleExternalPartner),
       test s "poll team-level event queue" testTeamQueue,
       test s "add new team member internal" testAddTeamMemberInternal,
       test s "remove aka delete team member (binding, owner has passwd)" (testRemoveBindingTeamMember True),
@@ -379,46 +376,6 @@ testEnableTeamSearchVisibilityPerTeam = do
   Util.putTeamSearchVisibilityAvailableInternal tid FeatureStatusDisabled
   getSearchVisibilityCheck SearchVisibilityStandard
 
-testCreateOne2OneFailForNonTeamMembers :: TestM ()
-testCreateOne2OneFailForNonTeamMembers = do
-  owner <- Util.randomUser
-  let p1 = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
-  let p2 = Util.symmPermissions [CreateConversation, AddRemoveConvMember, AddTeamMember]
-  mem1 <- newTeamMember' p1 <$> Util.randomUser
-  mem2 <- newTeamMember' p2 <$> Util.randomUser
-  Util.connectUsers owner ((mem1 ^. userId) :| [mem2 ^. userId])
-  -- Both have a binding team but not the same team
-  owner1 <- Util.randomUser
-  tid1 <- Util.createBindingTeamInternal "foo" owner1
-  assertTeamActivate "create team" tid1
-  owner2 <- Util.randomUser
-  tid2 <- Util.createBindingTeamInternal "foo" owner2
-  assertTeamActivate "create another team" tid2
-  Util.createOne2OneTeamConv owner1 owner2 Nothing tid1 !!! do
-    const 403 === statusCode
-    const "non-binding-team-members" === (Error.label . responseJsonUnsafeWithMsg "error label")
-
-testCreateOne2OneWithMembers ::
-  (HasCallStack) =>
-  -- | Role of the team member added to the team
-  Role ->
-  TestM ()
-testCreateOne2OneWithMembers role = do
-  c <- view tsCannon
-  (owner, tid) <- Util.createBindingTeam
-  mem1 <-
-    WS.bracketR c owner $ \wsOwner -> do
-      mem <- Util.addUserToTeamWithRole (Just role) owner tid
-      checkTeamMemberJoin tid (mem ^. userId) wsOwner
-      assertTeamUpdate "team member join" tid 2 [owner]
-      pure mem
-  void $ retryWhileN 10 repeatIf (Util.createOne2OneTeamConv owner (mem1 ^. userId) Nothing tid)
-  -- Recreating a One2One is a no-op, returns a 200
-  Util.createOne2OneTeamConv owner (mem1 ^. userId) Nothing tid !!! const 200 === statusCode
-  where
-    repeatIf :: ResponseLBS -> Bool
-    repeatIf r = statusCode r /= 201
-
 -- | At the time of writing this test, the only event sent to this queue is 'MemberJoin'.
 testTeamQueue :: TestM ()
 testTeamQueue = do
@@ -485,7 +442,13 @@ testAddTeamMemberInternal = do
   let p1 = Util.symmPermissions [GetBilling] -- permissions are irrelevant on internal endpoint
   mem1 <- newTeamMember' p1 <$> Util.randomUser
   WS.bracketRN c [owner, mem1 ^. userId] $ \[wsOwner, wsMem1] -> do
-    Util.addTeamMemberInternal tid (mem1 ^. userId) (mem1 ^. permissions) (mem1 ^. invitation)
+    g <- viewGalley
+    post
+      ( g
+          . paths ["i", "teams", toByteString' tid, "members"]
+          . json (Member.mkNewTeamMember (mem1 ^. userId) (mem1 ^. permissions) (mem1 ^. invitation))
+      )
+      !!! const 200 === statusCode
     liftIO . void $ mapConcurrently (checkJoinEvent tid (mem1 ^. userId)) [wsOwner, wsMem1]
     assertTeamUpdate "team member join" tid 2 [owner]
   void $ Util.getTeamMemberInternal tid (mem1 ^. userId)
@@ -737,29 +700,26 @@ testAddTeamMemberToConv :: TestM ()
 testAddTeamMemberToConv = do
   personalUser <- Util.randomUser
   (ownerT1, qOwnerT1) <- Util.randomUserTuple
-  let p = Util.symmPermissions [AddRemoveConvMember]
-  mem1T1 <- Util.randomUser
-  qMem1T1 <- Qualified mem1T1 <$> viewFederationDomain
-  mem2T1 <- Util.randomUser
-  qMem2T1 <- Qualified mem2T1 <$> viewFederationDomain
-
-  let pEmpty = Util.symmPermissions []
-  mem3T1 <- Util.randomUser
-  qMem3T1 <- Qualified mem3T1 <$> viewFederationDomain
-
-  mem4T1 <- newTeamMember' pEmpty <$> Util.randomUser
-  qMem4T1 <- Qualified (mem4T1 ^. userId) <$> viewFederationDomain
   (ownerT2, qOwnerT2) <- Util.randomUserTuple
-  mem1T2 <- newTeamMember' p <$> Util.randomUser
-  qMem1T2 <- Qualified (mem1T2 ^. userId) <$> viewFederationDomain
-  Util.connectUsers ownerT1 (mem1T1 :| [mem2T1, mem3T1, ownerT2, personalUser])
   tidT1 <- createBindingTeamInternal "foo" ownerT1
-  do
-    Util.addTeamMemberInternal tidT1 mem1T1 p Nothing
-    Util.addTeamMemberInternal tidT1 mem2T1 p Nothing
-    Util.addTeamMemberInternal tidT1 mem3T1 pEmpty Nothing
+  let p = Util.symmPermissions [AddRemoveConvMember]
+      pEmpty = Util.symmPermissions []
+  mem1T1 <- addMemberWithPermissions ownerT1 tidT1 p
+  qMem1T1 <- Qualified mem1T1 <$> viewFederationDomain
+  mem2T1 <- addMemberWithPermissions ownerT1 tidT1 p
+  qMem2T1 <- Qualified mem2T1 <$> viewFederationDomain
+  mem3T1 <- addMemberWithPermissions ownerT1 tidT1 pEmpty
+  qMem3T1 <- Qualified mem3T1 <$> viewFederationDomain
+  mem4T1 <- Util.randomUser
+  qMem4T1 <- Qualified mem4T1 <$> viewFederationDomain
   tidT2 <- Util.createBindingTeamInternal "foo" ownerT2
-  Util.addTeamMemberInternal tidT2 (mem1T2 ^. userId) (mem1T2 ^. permissions) (mem1T2 ^. invitation)
+  mem1T2 <- addMemberWithPermissions ownerT2 tidT2 p
+  qMem1T2 <- Qualified mem1T2 <$> viewFederationDomain
+  -- ownerT1 is connected across teams to ownerT2 and personally to
+  -- personalUser. Same-team members (mem1T1/mem2T1/mem3T1) need no explicit
+  -- connection: same-binding-team connection requests are rejected (403), and
+  -- every assertion involving them is satisfied by the same-team condition.
+  Util.connectUsers ownerT1 (ownerT2 :| [personalUser])
   -- Team owners create new regular team conversation:
   cidT1 <- Util.createTeamConv ownerT1 tidT1 [] (Just "blaa") Nothing Nothing
   qcidT1 <- Qualified cidT1 <$> viewFederationDomain
@@ -792,7 +752,7 @@ testAddTeamMemberToConv = do
   Util.assertConvMember qMem1T2 cidT1
   -- Still, they cannot add random members without a connection from T1, despite the conversation being "hosted" there
   Util.postMembers ownerT2 (pure qMem4T1) qcidT1 !!! const 403 === statusCode
-  Util.assertNotConvMember (mem4T1 ^. userId) cidT1
+  Util.assertNotConvMember mem4T1 cidT1
   -- Now let's look at convs hosted on team2
   -- ownerT2 *is* connected to ownerT1
   Util.postMembers ownerT2 (pure qOwnerT1) qcidT2 !!! const 200 === statusCode
@@ -800,7 +760,7 @@ testAddTeamMemberToConv = do
   -- and mem1T2 is on the same team, but mem1T1 is *not*
   Util.postMembers ownerT2 (qMem1T2 :| [qMem1T1]) qcidT2 !!! const 403 === statusCode
   Util.assertNotConvMember mem1T1 cidT2
-  Util.assertNotConvMember (mem1T2 ^. userId) cidT2
+  Util.assertNotConvMember mem1T2 cidT2
   -- mem1T2 is on the same team, so that is fine too
   Util.postMembers ownerT2 (pure qMem1T2) qcidT2 !!! const 200 === statusCode
   Util.assertConvMember qMem1T2 cidT2
@@ -824,6 +784,12 @@ testAddTeamMemberToConv = do
   -- Users *can* add across teams if *connected*
   Util.postMembers ownerT1 (pure qOwnerT2) qcidPersonal !!! const 200 === statusCode
   Util.assertConvMember qOwnerT2 cidPersonal
+  where
+    addMemberWithPermissions :: UserId -> TeamId -> Permissions -> TestM UserId
+    addMemberWithPermissions inviter tid perms = do
+      mem <- Util.addUserToTeamWithRole (Just RoleMember) inviter tid
+      Util.updateTeamMemberPermissions inviter mem tid perms
+      pure (mem ^. userId)
 
 testUpdateTeamConv ::
   -- | Team role of the user who creates the conversation
@@ -1146,9 +1112,9 @@ testDeleteTeamConv = do
   (tid, owner, _) <- Util.createBindingTeamWithMembers 2
   qOwner <- Qualified owner <$> viewFederationDomain
   let p = Util.symmPermissions [P.DeleteConversation]
-  member <- newTeamMember' p <$> Util.randomUser
+  member <- Util.addUserToTeamWithRole (Just RoleMember) owner tid
   qMember <- Qualified (member ^. userId) <$> viewFederationDomain
-  Util.addTeamMemberInternal tid (member ^. userId) (member ^. permissions) Nothing
+  Util.updateTeamMemberPermissions owner member tid p
   let members = [qOwner, qMember]
   extern <- Util.randomUser
   qExtern <- Qualified extern <$> viewFederationDomain

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -108,8 +108,7 @@ data IsWorking = Working | NotWorking
 testCreateLegalHoldTeamSettings :: TestM ()
 testCreateLegalHoldTeamSettings = withTeam $ \owner tid -> do
   putLHWhitelistTeam tid !!! const 200 === statusCode
-  member <- randomUser
-  addTeamMemberInternal tid member (rolePermissions RoleMember) Nothing
+  member <- (^. userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
   -- Random port, hopefully nothing is runing here!
   brokenService <- newLegalHoldService 4242
   -- not allowed to create if team is not whitelisted
@@ -165,8 +164,8 @@ testCreateLegalHoldTeamSettings = withTeam $ \owner tid -> do
 testRemoveLegalHoldFromTeam :: TestM ()
 testRemoveLegalHoldFromTeam = do
   (owner, tid) <- createBindingTeam
-  member <- randomUser
-  addTeamMemberInternal tid member noPermissions Nothing
+  memberTm <- addUserToTeamWithRole (Just RoleMember) owner tid
+  updateTeamMemberPermissions owner memberTm tid noPermissions
   -- fails if LH for team is disabled
   deleteSettings (Just defPassword) owner tid !!! testResponse 403 (Just "legalhold-disable-unimplemented")
 
@@ -180,12 +179,12 @@ testAddTeamUserTooLargeWithLegalholdWhitelisted = withTeam $ \owner tid -> do
 
 testCannotCreateLegalHoldDeviceOldAPI :: TestM ()
 testCannotCreateLegalHoldDeviceOldAPI = do
-  member <- randomUser
+  nonMember <- randomUser
   (owner, tid) <- createBindingTeam
   -- user without team can't add LH device
-  tryout member
+  tryout nonMember
   -- team member can't add LH device
-  addTeamMemberInternal tid member (rolePermissions RoleMember) Nothing
+  member <- (^. userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
   tryout member
   -- team owner can't add LH device
   tryout owner

--- a/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
@@ -93,8 +93,7 @@ data IsWorking = Working | NotWorking
 testCreateLegalHoldTeamSettings :: TestM ()
 testCreateLegalHoldTeamSettings = do
   (owner, tid) <- createBindingTeam
-  member <- randomUser
-  addTeamMemberInternal tid member (rolePermissions RoleMember) Nothing
+  member <- (^. Team.userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
   -- Random port, hopefully nothing is runing here!
   brokenService <- newLegalHoldService 4242
   -- not allowed to create if team setting is disabled
@@ -150,8 +149,9 @@ testRemoveLegalHoldFromTeam :: TestM ()
 testRemoveLegalHoldFromTeam = do
   (owner, tid) <- createBindingTeam
   stranger <- randomUser
-  member <- randomUser
-  addTeamMemberInternal tid member noPermissions Nothing
+  memberTm <- addUserToTeamWithRole (Just RoleMember) owner tid
+  updateTeamMemberPermissions owner memberTm tid noPermissions
+  let member = memberTm ^. Team.userId
   -- fails if LH for team is disabled
   deleteSettings (Just defPassword) owner tid !!! testResponse 403 (Just "legalhold-not-enabled")
   withDummyTestServiceForTeam' owner tid $ \lhPort chan -> do
@@ -228,12 +228,12 @@ testAddTeamUserTooLargeWithLegalhold = do
 
 testCannotCreateLegalHoldDeviceOldAPI :: TestM ()
 testCannotCreateLegalHoldDeviceOldAPI = do
-  member <- randomUser
+  nonMember <- randomUser
   (owner, tid) <- createBindingTeam
   -- user without team can't add LH device
-  tryout member
+  tryout nonMember
   -- team member can't add LH device
-  addTeamMemberInternal tid member (rolePermissions RoleMember) Nothing
+  member <- (^. Team.userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
   tryout member
   -- team owner can't add LH device
   tryout owner
@@ -257,8 +257,7 @@ testCannotCreateLegalHoldDeviceOldAPI = do
 testGetTeamMembersIncludesLHStatus :: TestM ()
 testGetTeamMembersIncludesLHStatus = do
   (owner, tid) <- createBindingTeam
-  member <- randomUser
-  addTeamMemberInternal tid member (rolePermissions RoleMember) Nothing
+  member <- (^. Team.userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
 
   let findMemberStatus :: [TeamMember] -> Maybe UserLegalHoldStatus
       findMemberStatus ms =

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -246,8 +246,7 @@ createBindingTeamWithNMembersWithHandles withHandles n = do
   (owner, tid) <- createBindingTeam
   setHandle owner
   mems <- replicateM n $ do
-    member1 <- randomUser
-    addTeamMemberInternal tid member1 (Team.rolePermissions RoleMember) Nothing
+    member1 <- (^. Team.userId) <$> addUserToTeamWithRole (Just RoleMember) owner tid
     setHandle member1
     pure member1
   pure (owner, tid, mems)
@@ -410,17 +409,6 @@ getTeamMemberInternal tid mid = do
   r <- get (g . paths ["i", "teams", toByteString' tid, "members", toByteString' mid]) <!! const 200 === statusCode
   responseJsonError r
 
--- | FUTUREWORK: do not use this, it's broken!!  use 'addUserToTeam' instead!  https://wearezeta.atlassian.net/browse/SQSERVICES-471
-addTeamMemberInternal :: (HasCallStack) => TeamId -> UserId -> Permissions -> Maybe (UserId, UTCTimeMillis) -> TestM ()
-addTeamMemberInternal tid muid mperms mmbinv = addTeamMemberInternal' tid muid mperms mmbinv !!! const 200 === statusCode
-
--- | FUTUREWORK: do not use this, it's broken!!  use 'addUserToTeam' instead!  https://wearezeta.atlassian.net/browse/SQSERVICES-471
-addTeamMemberInternal' :: (HasCallStack) => TeamId -> UserId -> Permissions -> Maybe (UserId, UTCTimeMillis) -> TestM ResponseLBS
-addTeamMemberInternal' tid muid mperms mmbinv = do
-  g <- viewGalley
-  let payload = json (mkNewTeamMember muid mperms mmbinv)
-  post (g . paths ["i", "teams", toByteString' tid, "members"] . payload)
-
 addUserToTeam :: (HasCallStack) => UserId -> TeamId -> TestM TeamMember
 addUserToTeam = addUserToTeamWithRole Nothing
 
@@ -465,9 +453,23 @@ addUserToTeamWithSSO hasEmail tid = do
   getTeamMember uid tid uid
 
 makeOwner :: (HasCallStack) => UserId -> TeamMember -> TeamId -> TestM ()
-makeOwner owner mem tid = do
+makeOwner owner mem tid = updateTeamMemberPermissions owner mem tid fullPermissions
+
+-- | Update an existing team member's permissions via the public
+-- @PUT /teams/:tid/members@ endpoint. Use this together with
+-- 'addUserToTeamWithRole' when a test needs a member with custom
+-- 'Permissions' that do not correspond to a 'Role' (the invitation flow
+-- only accepts a 'Role').
+updateTeamMemberPermissions ::
+  (HasCallStack) =>
+  UserId ->
+  TeamMember ->
+  TeamId ->
+  Permissions ->
+  TestM ()
+updateTeamMemberPermissions owner mem tid perms = do
   galley <- viewGalley
-  let changeMember = mkNewTeamMember (mem ^. Team.userId) fullPermissions (mem ^. Team.invitation)
+  let changeMember = mkNewTeamMember (mem ^. Team.userId) perms (mem ^. Team.invitation)
   put
     ( galley
         . paths ["teams", toByteString' tid, "members"]
@@ -686,29 +688,6 @@ updateTeamConv zusr convid upd = do
         . zType "access"
         . json upd
     )
-
-createOne2OneTeamConv :: UserId -> UserId -> Maybe Text -> TeamId -> TestM ResponseLBS
-createOne2OneTeamConv u1 u2 n tid = do
-  g <- viewGalley
-  let conv =
-        NewConv
-          [u2]
-          []
-          (n >>= checked)
-          mempty
-          Nothing
-          (Just $ ConvTeamInfo tid)
-          Nothing
-          Nothing
-          roleNameWireAdmin
-          BaseProtocolProteusTag
-          GroupConversation
-          False
-          Nothing
-          False
-          Nothing
-          def
-  post $ g . path "/one2one-conversations" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConv ::
   UserId ->


### PR DESCRIPTION

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
