### PR TITLE
fix: flaky testAddUserNotConnected test ignore stray user.activate event

### DIFF
--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -334,7 +334,8 @@ testAddUserNotConnected = do
         responseJsonError
           =<< localPostCommitBundle (mpSender commit) bundle
             <!! const 403 === statusCode
-      void . liftIO $ WS.assertNoEvent (1 # WS.Second) wss
+      -- Occasionally we observe a user.activate event, so we exclude this case to avoid flakiness.
+      void . liftIO $ WS.assertNoEventExcept (1 # WS.Second) wss $ wsIsEventOfType "user.activate"
       pure err
     liftIO $ Wai.label err @?= "not-connected"
 


### PR DESCRIPTION

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
