### PR TITLE
WPB-27857: exclude the initiator from Wire Meetings lifecycle events

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-27857
+++ b/changelog.d/3-bug-fixes/WPB-27857
@@ -1,0 +1,1 @@
+Wire Meetings lifecycle events (meeting.create, meeting.update, meeting.delete) are no longer delivered to the user who triggered the action, consistent with how other event types avoid echoing back to the originator. Previously the creator/updater/deleter received their own meeting event.

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -10,7 +10,7 @@ import qualified Data.Text.Encoding as Text
 import Data.Time.Clock
 import qualified Data.Time.Format as Time
 import MLS.Util
-import Notifications (isConvCreateMeetingNotif, isConvDeleteMeetingNotif, isMeetingCreateNotif, isMeetingDeleteNotif, isMeetingMemberAddNotif, isMeetingUpdateNotif, isMemberJoinNotif, isWelcomeNotif)
+import Notifications (isConvCreateMeetingNotif, isConvDeleteMeetingNotif, isMeetingMemberAddNotif, isMemberJoinNotif, isWelcomeNotif)
 import SetupHelpers
 import System.Timeout (timeout)
 import Testlib.Prelude
@@ -32,8 +32,8 @@ testMeetingCreate = do
       assertSuccess resp
       void $ awaitMatch isConvCreateMeetingNotif ws
       m <- getJSON 201 resp
-      createNotif <- awaitMatch isMeetingCreateNotif ws
-      assertMeetingNotif createNotif (m %. "qualified_id")
+      -- meeting.create is not delivered to the initiator (WPB-27857)
+      assertNoEvent 1 ws
       pure m
 
   meeting %. "title" `shouldMatch` ("Team Standup" :: String)
@@ -261,8 +261,8 @@ testMeetingRecurrence = do
   r2 <- withWebSocket owner $ \ws -> do
     resp <- putMeeting owner domain meetingId updatedMeeting
     assertSuccess resp
-    updateNotif <- awaitMatch isMeetingUpdateNotif ws
-    assertMeetingNotif updateNotif (object ["id" .= meetingId, "domain" .= domain])
+    -- meeting.update is not delivered to the initiator (WPB-27857)
+    assertNoEvent 1 ws
     pure resp
 
   updated <- getJSON 200 r2
@@ -506,11 +506,9 @@ testMeetingDelete = do
   withWebSocket owner $ \ws -> do
     deleteMeeting owner domain meetingId >>= assertStatus 200
     void $ awaitMatch isConvDeleteMeetingNotif ws
-    deleteNotif <- awaitMatch isMeetingDeleteNotif ws
-    assertMeetingNotif deleteNotif (object ["id" .= meetingId, "domain" .= domain])
-    -- A meeting conversation must emit `conversation.delete-meeting`, never the
-    -- plain `conversation.delete` (EdConvDelete). After the two events above the
-    -- socket should be quiet; any leaked delete would surface here.
+    -- meeting.delete is not delivered to the initiator (WPB-27857). The
+    -- conversation.delete-meeting event above is the only event the
+    -- initiator receives; the socket should be quiet afterwards.
     assertNoEvent 1 ws
   getMeeting owner domain meetingId >>= assertStatus 404
 

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -540,14 +540,16 @@ testMeetingLifecycleEventsDeliveredToMembers = do
   createGroup def ownerClient convId
   void $ createAddCommit ownerClient convId [participant] >>= sendAndConsumeCommitBundle
 
-  -- The non-initiator member receives 'meeting.update' (the initiator does not).
+  -- The non-initiator member receives 'meeting.update'; the initiator-exclusion
+  -- half of WPB-27857 is asserted in 'testMeetingRecurrence'.
   updateNotif <-
     withWebSocket participant $ \ws -> do
       putMeeting owner domain meetingId (object ["title" .= "Updated Lifecycle Meeting"]) >>= assertSuccess
       awaitMatch isMeetingUpdateNotif ws
   assertMeetingNotif updateNotif (meeting %. "qualified_id")
 
-  -- The non-initiator member receives 'meeting.delete'.
+  -- The non-initiator member receives 'meeting.delete'. The preceding
+  -- 'conversation.delete-meeting' event is expected and skipped by 'awaitMatch'.
   deleteNotif <-
     withWebSocket participant $ \ws -> do
       deleteMeeting owner domain meetingId >>= assertStatus 200

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -10,7 +10,7 @@ import qualified Data.Text.Encoding as Text
 import Data.Time.Clock
 import qualified Data.Time.Format as Time
 import MLS.Util
-import Notifications (isConvCreateMeetingNotif, isConvDeleteMeetingNotif, isMeetingMemberAddNotif, isMemberJoinNotif, isWelcomeNotif)
+import Notifications (isConvCreateMeetingNotif, isConvDeleteMeetingNotif, isMeetingDeleteNotif, isMeetingMemberAddNotif, isMeetingUpdateNotif, isMemberJoinNotif, isWelcomeNotif)
 import SetupHelpers
 import System.Timeout (timeout)
 import Testlib.Prelude
@@ -511,6 +511,48 @@ testMeetingDelete = do
     -- initiator receives; the socket should be quiet afterwards.
     assertNoEvent 1 ws
   getMeeting owner domain meetingId >>= assertStatus 404
+
+-- | WPB-27857: the meeting initiator no longer receives its own lifecycle
+-- events, but other members of the meeting conversation still do. At creation
+-- time the conversation's only local member is the creator, so 'meeting.create'
+-- has no other recipient (the multi-member path is covered at the unit level in
+-- "Wire.MeetingsSubsystem.InterpreterSpec"); here we verify that a member who
+-- joined after creation still receives 'meeting.update' and 'meeting.delete'.
+testMeetingLifecycleEventsDeliveredToMembers :: (HasCallStack) => App ()
+testMeetingLifecycleEventsDeliveredToMembers = do
+  (owner, _tid, [participant]) <- createTeam OwnDomain 2
+  ownerClient <- createMLSClient def owner
+  participantClient <- createMLSClient def participant
+  _ <- uploadNewKeyPackage def participantClient
+  now <- liftIO getCurrentTime
+  let startTime = addUTCTime 3600 now
+      endTime = addUTCTime 7200 now
+      newMeeting = defaultMeetingJson "Lifecycle Meeting" startTime endTime []
+
+  meeting <- postMeetings owner newMeeting >>= getJSON 201
+  (meetingId, domain) <- getMeetingIdAndDomain meeting
+
+  -- Add the second team member to the meeting conversation via MLS, so that
+  -- they are among the recipients of subsequent lifecycle events.
+  convQid <- meeting %. "qualified_conversation"
+  conv <- getConversation owner convQid >>= getJSON 200
+  convId <- objConvId conv
+  createGroup def ownerClient convId
+  void $ createAddCommit ownerClient convId [participant] >>= sendAndConsumeCommitBundle
+
+  -- The non-initiator member receives 'meeting.update' (the initiator does not).
+  updateNotif <-
+    withWebSocket participant $ \ws -> do
+      putMeeting owner domain meetingId (object ["title" .= "Updated Lifecycle Meeting"]) >>= assertSuccess
+      awaitMatch isMeetingUpdateNotif ws
+  assertMeetingNotif updateNotif (meeting %. "qualified_id")
+
+  -- The non-initiator member receives 'meeting.delete'.
+  deleteNotif <-
+    withWebSocket participant $ \ws -> do
+      deleteMeeting owner domain meetingId >>= assertStatus 200
+      awaitMatch isMeetingDeleteNotif ws
+  assertMeetingNotif deleteNotif (meeting %. "qualified_id")
 
 testMeetingDeleteNotFound :: (HasCallStack) => App ()
 testMeetingDeleteNotFound = do

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Notification.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Notification.hs
@@ -54,7 +54,7 @@ mkMeetingEventPush now qUser conn recipients qConvId mTeamId meetingType qMeetin
               evtTime = now,
               evtTeam = mTeamId
             },
-      recipients,
+      recipients = filter ((/= qUnqualified qUser) . recipientUserId) recipients,
       route = PushV2.RouteDirect,
       conn
     }

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -52,13 +52,13 @@ import Wire.API.Team.Permission (fullPermissions)
 import Wire.ConversationSubsystem
 import Wire.FeaturesConfigSubsystem
 import Wire.GalleyAPIAccess (GalleyAPIAccess)
-import Wire.MeetingNotifier (MeetingNotifier)
+import Wire.MeetingNotifier (MeetingNotifier, notifyMeetingEvent)
 import Wire.MeetingNotifier.Interpreter (interpretMeetingNotifier)
 import Wire.MeetingsStore qualified as Store
 import Wire.MeetingsSubsystem
 import Wire.MeetingsSubsystem.Interpreter
 import Wire.MockInterpreters
-import Wire.NotificationSubsystem (NotificationSubsystem, Push (..))
+import Wire.NotificationSubsystem (NotificationSubsystem, Push (..), Recipient (recipientUserId))
 import Wire.Sem.Logger.TinyLog (discardTinyLogs)
 import Wire.Sem.Now (Now)
 import Wire.Sem.Random (Random)
@@ -1451,6 +1451,25 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       case result of
         Left err -> fail $ "Error: " <> show err
         Right pushes -> extractMeetingEvents pushes `shouldBe` []
+
+    it "does not deliver lifecycle events to the meeting initiator" $ do
+      let members =
+            [ newMember uid1,
+              newMember uid2
+            ]
+          meetingId = Id $ read "00000000-0000-0000-0000-000000000070"
+          convId = Id $ read "00000000-0000-0000-0000-000000000071"
+          qMeetingId = Qualified meetingId (Domain "wire.com")
+          qConvId = Qualified convId (Domain "wire.com")
+      result <-
+        runTestStack now gen Map.empty def $ do
+          _ <- notifyMeetingEvent zUser1 Nothing members qConvId Nothing MeetingEvent.Create qMeetingId
+          get @[Push]
+      case result of
+        Left err -> fail $ "Error: " <> show err
+        Right pushes -> do
+          let recipientIds = map (.recipientUserId) (concatMap (.recipients) pushes)
+          recipientIds `shouldBe` [uid2]
 
 -- | Synchronize with 'Wire.MeetingsSubsystem.Interpreter.startTimeTolerance'
 expectedStartTimeTolerance :: NominalDiffTime


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27857

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
