### PR TITLE
[WPB-18127] Move email template completeness tests from brig to wire-subsystems.

### DIFF
--- a/changelog.d/5-internal/WPB-18127-move-email-template-completeness-tests-from-brig-to-wire-subsystems
+++ b/changelog.d/5-internal/WPB-18127-move-email-template-completeness-tests-from-brig-to-wire-subsystems
@@ -1,0 +1,1 @@
+Move email template completeness tests from brig to wire-subsystems.

--- a/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
+++ b/libs/wire-subsystems/src/Wire/EmailSubsystem/Template.hs
@@ -39,6 +39,7 @@ import System.Logger (field, msg, val)
 import Wire.API.Locale
 import Wire.API.User.EmailAddress (EmailAddress)
 import Wire.EmailSubsystem.Templates.Team
+import Wire.EmailSubsystem.Templates.User
 
 -- | Lookup a localised item from a 'Localised' structure.
 forLocale ::
@@ -252,3 +253,99 @@ loadTeamTemplates tOptions templatesDir defLocale sender = readLocalesDir defLoc
     tExistingUrl = template tOptions.tExistingUserInvitationUrl
     readTemplate' = readTemplateWithDefault templatesDir defLocale "team"
     readText' = readTextWithDefault templatesDir defLocale "team"
+
+-- | URL templates needed to render the user email templates. These are plain
+-- 'Text' 'Data.Text.Template.template' strings, mirroring the corresponding
+-- Brig configuration fields; 'loadUserTemplates' turns them into 'Template's.
+data UserTemplateOpts = UserTemplateOpts
+  { -- | Activation URL template
+    activationUrl :: !Text,
+    -- | Team activation URL template
+    teamActivationUrl :: !Text,
+    -- | Password reset URL template
+    passwordResetUrl :: !Text,
+    -- | Deletion URL template
+    deletionUrl :: !Text
+  }
+  deriving stock (Show, Generic)
+
+loadUserTemplates :: UserTemplateOpts -> FilePath -> Locale -> EmailAddress -> IO (Localised UserTemplates)
+loadUserTemplates opts templatesDir defLocale sender = readLocalesDir defLocale templatesDir "user" $ \fp ->
+  UserTemplates
+    <$> ( VerificationEmailTemplate activationUrl
+            <$> readTemplate' fp "email/verification-subject.txt"
+            <*> readTemplate' fp "email/verification.txt"
+            <*> readTemplate' fp "email/verification.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( ActivationEmailTemplate activationUrl
+            <$> readTemplate' fp "email/activation-subject.txt"
+            <*> readTemplate' fp "email/activation.txt"
+            <*> readTemplate' fp "email/activation.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( ActivationEmailTemplate activationUrl
+            <$> readTemplate' fp "email/update-subject.txt"
+            <*> readTemplate' fp "email/update.txt"
+            <*> readTemplate' fp "email/update.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( TeamActivationEmailTemplate teamActivationUrl
+            <$> readTemplate' fp "email/team-activation-subject.txt"
+            <*> readTemplate' fp "email/team-activation.txt"
+            <*> readTemplate' fp "email/team-activation.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( PasswordResetEmailTemplate passwordResetUrl
+            <$> readTemplate' fp "email/password-reset-subject.txt"
+            <*> readTemplate' fp "email/password-reset.txt"
+            <*> readTemplate' fp "email/password-reset.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( DeletionEmailTemplate deletionUrl
+            <$> readTemplate' fp "email/deletion-subject.txt"
+            <*> readTemplate' fp "email/deletion.txt"
+            <*> readTemplate' fp "email/deletion.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( NewClientEmailTemplate
+            <$> readTemplate' fp "email/new-client-subject.txt"
+            <*> readTemplate' fp "email/new-client.txt"
+            <*> readTemplate' fp "email/new-client.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( SecondFactorVerificationEmailTemplate
+            <$> readTemplate' fp "email/verification-login-subject.txt"
+            <*> readTemplate' fp "email/verification-login.txt"
+            <*> readTemplate' fp "email/verification-login.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( SecondFactorVerificationEmailTemplate
+            <$> readTemplate' fp "email/verification-scim-token-subject.txt"
+            <*> readTemplate' fp "email/verification-scim-token.txt"
+            <*> readTemplate' fp "email/verification-scim-token.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+    <*> ( SecondFactorVerificationEmailTemplate
+            <$> readTemplate' fp "email/verification-delete-team-subject.txt"
+            <*> readTemplate' fp "email/verification-delete-team.txt"
+            <*> readTemplate' fp "email/verification-delete-team.html"
+            <*> pure sender
+            <*> readText' fp "email/sender.txt"
+        )
+  where
+    activationUrl = template opts.activationUrl
+    teamActivationUrl = template opts.teamActivationUrl
+    passwordResetUrl = template opts.passwordResetUrl
+    deletionUrl = template opts.deletionUrl
+    readTemplate' = readTemplateWithDefault templatesDir defLocale "user"
+    readText' = readTextWithDefault templatesDir defLocale "user"

--- a/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateFixtures.hs
+++ b/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateFixtures.hs
@@ -1,0 +1,79 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Shared fixtures for tests that render email templates from the on-disk
+-- templates shipped with this package. The URL templates and branding here
+-- mirror the shape of the corresponding Brig configuration.
+module Wire.EmailSubsystem.TemplateFixtures where
+
+import Data.Map qualified as Map
+import Imports
+import Text.Email.Parser (unsafeEmailAddress)
+import Wire.API.Locale
+import Wire.API.User.EmailAddress (EmailAddress)
+import Wire.EmailSubsystem.Template
+import Wire.EmailSubsystem.Templates.Team
+import Wire.EmailSubsystem.Templates.User
+
+teamOpts :: TeamOpts
+teamOpts =
+  TeamOpts
+    { tInvitationUrl = "https://example.com/join/?team-code=${code}",
+      tExistingUserInvitationUrl = "https://example.com/accept-invitation/?team-code=${code}",
+      tActivationUrl = "https://example.com/verify/?key=${key}&code=${code}",
+      tCreatorWelcomeUrl = "https://example.com/creator-welcome-website",
+      tMemberWelcomeUrl = "https://example.com/member-welcome-website"
+    }
+
+userTemplateOpts :: UserTemplateOpts
+userTemplateOpts =
+  UserTemplateOpts
+    { activationUrl = "https://example.com/verify/?key=${key}&code=${code}",
+      teamActivationUrl = teamOpts.tActivationUrl,
+      passwordResetUrl = "https://example.com/reset/?key=${key}&code=${code}",
+      deletionUrl = "https://example.com/d/?key=${key}&code=${code}"
+    }
+
+defLocale :: Locale
+defLocale = Locale ((fromJust . parseLanguage) "en") Nothing
+
+emailSender :: EmailAddress
+emailSender = unsafeEmailAddress "wire" "example.com"
+
+branding :: Map Text Text
+branding =
+  Map.fromList
+    [ ("brand", "Wire Test"),
+      ("brand_url", "https://wire.example.com"),
+      ("brand_label_url", "wire.example.com"),
+      ("brand_logo", "https://wire.example.com/p/img/email/logo-email-black.png"),
+      ("brand_service", "Wire Service Provider"),
+      ("copyright", "© WIRE SWISS GmbH"),
+      ("misuse", "misuse@wire.example.com"),
+      ("legal", "https://wire.example.com/legal/"),
+      ("forgot", "https://wire.example.com/forgot/"),
+      ("support", "https://support.wire.com/")
+    ]
+
+-- | Load the on-disk team templates. Relies on the test suite running with the
+-- package directory as its working directory (as @cabal test@ does).
+loadTestTeamTemplates :: IO (Localised TeamTemplates)
+loadTestTeamTemplates = loadTeamTemplates teamOpts "templates" defLocale emailSender
+
+-- | Load the on-disk user templates. See 'loadTestTeamTemplates'.
+loadTestUserTemplates :: IO (Localised UserTemplates)
+loadTestUserTemplates = loadUserTemplates userTemplateOpts "templates" defLocale emailSender

--- a/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/TemplateSpec.hs
@@ -1,10 +1,22 @@
-module API.Template (tests) where
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import Bilge
-import Brig.Options
-import Brig.Team.Template (loadTeamTemplatesWithBrigOpts)
-import Brig.Template
-import Brig.User.Template (loadUserTemplates)
+module Wire.EmailSubsystem.TemplateSpec (spec) where
+
 import Data.Code
 import Data.Id
 import Data.Json.Util
@@ -18,9 +30,7 @@ import Imports
 import Network.Mail.Mime
 import Polysemy
 import Polysemy.Output
-import Test.Tasty
-import Test.Tasty.HUnit
-import Util
+import Test.Hspec
 import Wire.API.Locale
 import Wire.API.User (InvitationCode (InvitationCode, fromInvitationCode))
 import Wire.API.User.Activation
@@ -30,57 +40,43 @@ import Wire.API.User.Password
 import Wire.API.User.Profile
 import Wire.EmailSubsystem.Interpreter
 import Wire.EmailSubsystem.Template
+import Wire.EmailSubsystem.TemplateFixtures
 import Wire.EmailSubsystem.Templates.Team
 import Wire.EmailSubsystem.Templates.User
 
--- FUTUREWORK: This does not have to be an integration test. It could be
--- covered by unit tests in wire-subsystems. Then, the helper functions can be
--- privatized.
-tests :: Opts -> Manager -> IO TestTree
-tests opts m = do
-  team <- liftIO $ loadTeamTemplatesWithBrigOpts opts
-  user <- liftIO $ loadUserTemplates opts
-  let teamTemplates = Map.assocs $ uncurry Map.insert team.locDefault team.locOther
-      userTemplates = Map.assocs $ uncurry Map.insert user.locDefault user.locOther
-      b = genTemplateBrandingMap opts.emailSMS.general.templateBranding
-  pure $
-    testGroup
-      "email templates"
-      [ testGroup
-          "team"
-          $ fmap
-            ( \(loc, ts) ->
-                testGroup
-                  (show loc)
-                  [ test m "team invitation" $ testTeamInvitationEmail b ts,
-                    test m "team invitation existing user" $ testTeamInvitationEmailExistingUser b ts,
-                    test m "member welcome" $ testMemberWelcomeEmail b ts,
-                    test m "new team owner welcome" $ testNewTeamOwnerWelcomeEmail b ts
-                  ]
-            )
-            teamTemplates,
-        testGroup "user" $
-          fmap
-            ( \(loc, ts) ->
-                testGroup
-                  (show loc)
-                  [ test m "password reset email" $ testPasswordResetEmail b ts,
-                    test m "verification email" $ testVerificationEmail b ts,
-                    test m "team deletion verification email" $ testTeamDeletionVerificationEmail b ts,
-                    test m "scim token verification email" $ testScimTokenVerificationEmail b ts,
-                    test m "login verification email" $ testLoginVerificationEmail b ts,
-                    test m "new client email" $ testNewClientEmail b loc ts,
-                    test m "account deletion email" $ testAccountDeletionEmail b ts,
-                    test m "activation email" $ testActivationEmail b ts,
-                    test m "activation email update" $ testActivationEmailUpdate b ts,
-                    test m "team activation email" $ testTeamActivationEmail b ts
-                  ]
-            )
-            userTemplates
-      ]
+-- | Insert the default locale into the map of other locales, giving the full
+-- set of locales that ship templates. Each is exercised below.
+byLocale :: Localised a -> [(Locale, a)]
+byLocale l = Map.assocs $ uncurry Map.insert l.locDefault l.locOther
 
-testTeamInvitationEmailExistingUser :: (HasCallStack) => Map Text Text -> TeamTemplates -> Http ()
-testTeamInvitationEmailExistingUser branding templates = do
+spec :: Spec
+spec = do
+  teamTemplates <- runIO loadTestTeamTemplates
+  userTemplates <- runIO loadTestUserTemplates
+  describe "email templates" $ do
+    describe "team" $
+      for_ (byLocale teamTemplates) $ \(loc, ts) ->
+        describe (show loc) $ do
+          it "team invitation" $ testTeamInvitationEmail ts
+          it "team invitation existing user" $ testTeamInvitationEmailExistingUser ts
+          it "member welcome" $ testMemberWelcomeEmail ts
+          it "new team owner welcome" $ testNewTeamOwnerWelcomeEmail ts
+    describe "user" $
+      for_ (byLocale userTemplates) $ \(loc, ts) ->
+        describe (show loc) $ do
+          it "password reset email" $ testPasswordResetEmail ts
+          it "verification email" $ testVerificationEmail ts
+          it "team deletion verification email" $ testTeamDeletionVerificationEmail ts
+          it "scim token verification email" $ testScimTokenVerificationEmail ts
+          it "login verification email" $ testLoginVerificationEmail ts
+          it "new client email" $ testNewClientEmail loc ts
+          it "account deletion email" $ testAccountDeletionEmail ts
+          it "activation email" $ testActivationEmail ts
+          it "activation email update" $ testActivationEmailUpdate ts
+          it "team activation email" $ testTeamActivationEmail ts
+
+testTeamInvitationEmailExistingUser :: (HasCallStack) => TeamTemplates -> Expectation
+testTeamInvitationEmailExistingUser templates = do
   let tpl = templates.existingUserInvitationEmail
       (errs, (mail, url)) = run $ runOutputList @Text $ renderInvitationEmail input tpl branding
       input =
@@ -90,12 +86,12 @@ testTeamInvitationEmailExistingUser branding templates = do
             invInvCode = InvitationCode {fromInvitationCode = fromRight undefined (validate "ZoMX0xs=")},
             invInviter = fromJust $ emailAddressText "inviter@example.com"
           }
-  liftIO $ mail.mailFrom.addressEmail @?= (fromEmail tpl.invitationEmailSender)
-  liftIO $ url @?= "https://example.com/accept-invitation/?team-code=ZoMX0xs="
+  mail.mailFrom.addressEmail `shouldBe` fromEmail tpl.invitationEmailSender
+  url `shouldBe` "https://example.com/accept-invitation/?team-code=ZoMX0xs="
   assertNoErrors errs
 
-testTeamInvitationEmail :: (HasCallStack) => Map Text Text -> TeamTemplates -> Http ()
-testTeamInvitationEmail branding templates = do
+testTeamInvitationEmail :: (HasCallStack) => TeamTemplates -> Expectation
+testTeamInvitationEmail templates = do
   let tpl = templates.invitationEmail
       (errs, (mail, url)) = run $ runOutputList @Text $ renderInvitationEmail input tpl branding
       input =
@@ -105,12 +101,12 @@ testTeamInvitationEmail branding templates = do
             invInvCode = InvitationCode {fromInvitationCode = fromRight undefined (validate "ZoMX0xs=")},
             invInviter = fromJust $ emailAddressText "inviter@example.com"
           }
-  liftIO $ mail.mailFrom.addressEmail @?= (fromEmail tpl.invitationEmailSender)
-  liftIO $ url @?= "https://example.com/join/?team-code=ZoMX0xs="
+  mail.mailFrom.addressEmail `shouldBe` fromEmail tpl.invitationEmailSender
+  url `shouldBe` "https://example.com/join/?team-code=ZoMX0xs="
   assertNoErrors errs
 
-testMemberWelcomeEmail :: (HasCallStack) => Map Text Text -> TeamTemplates -> Http ()
-testMemberWelcomeEmail branding templates = do
+testMemberWelcomeEmail :: (HasCallStack) => TeamTemplates -> Expectation
+testMemberWelcomeEmail templates = do
   let tpl = templates.memberWelcomeEmail
       to = fromJust $ emailAddressText "test@example.com"
       tid = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000")
@@ -118,8 +114,8 @@ testMemberWelcomeEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderMemberWelcomeMail to tid tname tpl branding
   assertNoErrors errs
 
-testNewTeamOwnerWelcomeEmail :: (HasCallStack) => Map Text Text -> TeamTemplates -> Http ()
-testNewTeamOwnerWelcomeEmail branding templates = do
+testNewTeamOwnerWelcomeEmail :: (HasCallStack) => TeamTemplates -> Expectation
+testNewTeamOwnerWelcomeEmail templates = do
   let tpl = templates.newTeamOwnerWelcomeEmail
       to = fromJust $ emailAddressText "test@example.com"
       tid = Id (fromJust $ UUID.fromString "123e4567-e89b-12d3-a456-426614174000")
@@ -128,8 +124,8 @@ testNewTeamOwnerWelcomeEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderNewTeamOwnerWelcomeEmail to tid tname name tpl branding
   assertNoErrors errs
 
-testPasswordResetEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testPasswordResetEmail branding templates = do
+testPasswordResetEmail :: (HasCallStack) => UserTemplates -> Expectation
+testPasswordResetEmail templates = do
   let tpl = templates.passwordResetEmail
       to = fromJust $ emailAddressText "test@example.com"
       key = mkPasswordResetKey (Id UUID.nil)
@@ -137,8 +133,8 @@ testPasswordResetEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderPwResetMail to key code tpl branding
   assertNoErrors errs
 
-testVerificationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testVerificationEmail branding templates = do
+testVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testVerificationEmail templates = do
   let tpl = templates.verificationEmail
       to = fromJust $ emailAddressText "test@example.com"
       key = ActivationKey . Ascii.unsafeFromText $ "key"
@@ -146,32 +142,32 @@ testVerificationEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderVerificationMail to key code tpl branding
   assertNoErrors errs
 
-testTeamDeletionVerificationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testTeamDeletionVerificationEmail branding templates = do
+testTeamDeletionVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testTeamDeletionVerificationEmail templates = do
   let tpl = templates.verificationTeamDeletionEmail
       to = fromJust $ emailAddressText "test@example.com"
       code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
       (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
   assertNoErrors errs
 
-testScimTokenVerificationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testScimTokenVerificationEmail branding templates = do
+testScimTokenVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testScimTokenVerificationEmail templates = do
   let tpl = templates.verificationScimTokenEmail
       to = fromJust $ emailAddressText "test@example.com"
       code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
       (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
   assertNoErrors errs
 
-testLoginVerificationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testLoginVerificationEmail branding templates = do
+testLoginVerificationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testLoginVerificationEmail templates = do
   let tpl = templates.verificationLoginEmail
       to = fromJust $ emailAddressText "test@example.com"
       code = Value . unsafeRange . Ascii.unsafeFromText $ "code"
       (errs, _) = run $ runOutputList @Text $ renderSecondFactorVerificationEmail to code tpl branding
   assertNoErrors errs
 
-testActivationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testActivationEmail branding templates = do
+testActivationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testActivationEmail templates = do
   let tpl = templates.activationEmail
       to = fromJust $ emailAddressText "test@example.com"
       name = Name "name"
@@ -180,8 +176,8 @@ testActivationEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderActivationMail to name key code tpl branding
   assertNoErrors errs
 
-testActivationEmailUpdate :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testActivationEmailUpdate branding templates = do
+testActivationEmailUpdate :: (HasCallStack) => UserTemplates -> Expectation
+testActivationEmailUpdate templates = do
   let tpl = templates.activationEmailUpdate
       to = fromJust $ emailAddressText "test@example.com"
       name = Name "name"
@@ -190,8 +186,8 @@ testActivationEmailUpdate branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderActivationMail to name key code tpl branding
   assertNoErrors errs
 
-testTeamActivationEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testTeamActivationEmail branding templates = do
+testTeamActivationEmail :: (HasCallStack) => UserTemplates -> Expectation
+testTeamActivationEmail templates = do
   let tpl = templates.teamActivationEmail
       to = fromJust $ emailAddressText "test@example.com"
       name = Name "name"
@@ -201,8 +197,8 @@ testTeamActivationEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderTeamActivationMail to name teamName key code tpl branding
   assertNoErrors errs
 
-testNewClientEmail :: (HasCallStack) => Map Text Text -> Locale -> UserTemplates -> Http ()
-testNewClientEmail branding loc templates = do
+testNewClientEmail :: (HasCallStack) => Locale -> UserTemplates -> Expectation
+testNewClientEmail loc templates = do
   let tpl = templates.newClientEmail
       to = fromJust $ emailAddressText "test@example.com"
       name = Name "name"
@@ -222,8 +218,8 @@ testNewClientEmail branding loc templates = do
       (errs, _) = run $ runOutputList @Text $ renderNewClientEmail to name loc client tpl branding
   assertNoErrors errs
 
-testAccountDeletionEmail :: (HasCallStack) => Map Text Text -> UserTemplates -> Http ()
-testAccountDeletionEmail branding templates = do
+testAccountDeletionEmail :: (HasCallStack) => UserTemplates -> Expectation
+testAccountDeletionEmail templates = do
   let tpl = templates.deletionEmail
       to = fromJust $ emailAddressText "test@example.com"
       name = Name "name"
@@ -232,7 +228,7 @@ testAccountDeletionEmail branding templates = do
       (errs, _) = run $ runOutputList @Text $ renderDeletionEmail to name key code tpl branding
   assertNoErrors errs
 
-assertNoErrors :: [Text] -> Http ()
+assertNoErrors :: (HasCallStack) => [Text] -> Expectation
 assertNoErrors errs =
-  liftIO $
-    assertBool ("The following variables were not replaced: " <> show (nub errs)) (null errs)
+  unless (null errs) $
+    expectationFailure ("The following variables were not replaced: " <> show (nub errs))

--- a/libs/wire-subsystems/test/unit/Wire/SAMLEmailSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/SAMLEmailSubsystem/InterpreterSpec.hs
@@ -39,6 +39,7 @@ import Wire.EmailSending
 import Wire.EmailSubsystem qualified as Email
 import Wire.EmailSubsystem.Interpreter
 import Wire.EmailSubsystem.Template
+import Wire.EmailSubsystem.TemplateFixtures
 import Wire.EmailSubsystem.Templates.Team
 import Wire.GalleyAPIAccess
 import Wire.MockInterpreters
@@ -76,32 +77,9 @@ spec = do
         flip zip ((replicate 5 enTextParts) ++ (replicate 2 deTextParts)) $
           parseLocalUnsafe <$> ["en", "en-EN", "en-GB", "es", "es-ES", "de", "de_DE"]
       parseLocalUnsafe = fromMaybe (error "Unknown locale") . parseLocale
-      teamOpts =
-        TeamOpts
-          { tInvitationUrl = "https://example.com/join/?team-code=${code}",
-            tExistingUserInvitationUrl = "https://example.com/accept-invitation/?team-code=${code}",
-            tActivationUrl = "https://example.com/verify/?key=${key}&code=${code}",
-            tCreatorWelcomeUrl = "https://example.com/creator-welcome-website",
-            tMemberWelcomeUrl = "https://example.com/member-welcome-website"
-          }
-      defLocale = Locale ((fromJust . parseLanguage) "en") Nothing
-      emailSender = unsafeEmailAddress "wire" "example.com"
-      branding =
-        Map.fromList
-          [ ("brand", "Wire Test"),
-            ("brand_url", "https://wire.example.com"),
-            ("brand_label_url", "wire.example.com"),
-            ("brand_logo", "https://wire.example.com/p/img/email/logo-email-black.png"),
-            ("brand_service", "Wire Service Provider"),
-            ("copyright", "© WIRE SWISS GmbH"),
-            ("misuse", "misuse@wire.example.com"),
-            ("legal", "https://wire.example.com/legal/"),
-            ("forgot", "https://wire.example.com/forgot/"),
-            ("support", "https://support.wire.com/")
-          ]
 
   -- Run duplicated IO tasks here to save some time
-  teamTemplates :: Localised TeamTemplates <- runIO $ loadTeamTemplates teamOpts "templates" defLocale emailSender
+  teamTemplates :: Localised TeamTemplates <- runIO loadTestTeamTemplates
   newCerts <- runIO $ X509.readCertificates "test/resources/saml/certs.store"
 
   describe "SendSAMLIdPChanged" $ do
@@ -118,7 +96,7 @@ spec = do
               storedUser' = patchStoredUser storedUser teamId userLocale uid
               notif = IdPCreated (Just uid) idp'
 
-          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -134,7 +112,7 @@ spec = do
           let idp' = patchIdP idp teamId
               storedUser' = patchStoredUser storedUser teamId userLocale uid
               notif = IdPDeleted uid idp'
-          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -167,7 +145,7 @@ spec = do
                     )
               storedUser' = patchStoredUser storedUser teamId userLocale uid
               notif = IdPUpdated uid idpOld' idpNew'
-          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -186,7 +164,7 @@ spec = do
               teamMember :: TeamMember = mkTeamMember uid (rolePermissions role) Nothing UserLegalHoldDisabled
               teamMap :: Map TeamId [TeamMember] = Map.singleton teamId [teamMember]
 
-          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -201,7 +179,7 @@ spec = do
               teamMember :: TeamMember = mkTeamMember uid (rolePermissions role) Nothing UserLegalHoldDisabled
               teamMap :: Map TeamId [TeamMember] = Map.singleton teamId [teamMember]
 
-          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters [storedUser'] teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -220,7 +198,7 @@ spec = do
                   )
                   users
 
-          (mails, logs, _res) <- runInterpreters (fst <$> users) teamMap teamTemplates branding $ do
+          (mails, logs, _res) <- runInterpreters (fst <$> users) teamMap teamTemplates $ do
             sendSAMLIdPChanged notif
 
           assertNoWarnLogs logs
@@ -339,7 +317,6 @@ runInterpreters ::
   [StoredUser] ->
   Map TeamId [TeamMember] ->
   Localised TeamTemplates ->
-  Map Text Text ->
   Sem
     '[ SAMLEmailSubsystem,
        TeamSubsystem,
@@ -357,7 +334,7 @@ runInterpreters ::
      ]
     a ->
   IO ([Mail], [(Level, LByteString)], a)
-runInterpreters users teamMap teamTemplates branding action = do
+runInterpreters users teamMap teamTemplates action = do
   lr <- newLogRecorder
   (mails, res) <-
     runM

--- a/libs/wire-subsystems/wire-subsystems.cabal
+++ b/libs/wire-subsystems/wire-subsystems.cabal
@@ -635,6 +635,8 @@ test-suite wire-subsystems-tests
     Wire.ConversationSubsystem.InterpreterSpec
     Wire.ConversationSubsystem.MessageSpec
     Wire.ConversationSubsystem.One2OneSpec
+    Wire.EmailSubsystem.TemplateFixtures
+    Wire.EmailSubsystem.TemplateSpec
     Wire.EnterpriseLoginSubsystem.InterpreterSpec
     Wire.FederationSubsystem.InternalsSpec
     Wire.HashPassword.InterpreterSpec

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -350,7 +350,6 @@ executable brig-integration
     API.Team
     API.Team.Util
     API.TeamUserSearch
-    API.Template
     API.User
     API.User.Account
     API.User.Auth

--- a/services/brig/src/Brig/User/Template.hs
+++ b/services/brig/src/Brig/User/Template.hs
@@ -18,94 +18,23 @@
 module Brig.User.Template (loadUserTemplates) where
 
 import Brig.Options qualified as Opt
-import Data.Text.Template
 import Imports
-import Wire.EmailSubsystem.Template hiding (readTemplate, readText)
+import Wire.EmailSubsystem.Template hiding (loadUserTemplates)
+import Wire.EmailSubsystem.Template qualified as EmailTemplate
 import Wire.EmailSubsystem.Templates.User
 
 loadUserTemplates :: Opt.Opts -> IO (Localised UserTemplates)
-loadUserTemplates o = readLocalesDir defLocale templateDir "user" $ \fp ->
-  UserTemplates
-    <$> ( VerificationEmailTemplate activationUrl
-            <$> readTemplate fp "email/verification-subject.txt"
-            <*> readTemplate fp "email/verification.txt"
-            <*> readTemplate fp "email/verification.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( ActivationEmailTemplate activationUrl
-            <$> readTemplate fp "email/activation-subject.txt"
-            <*> readTemplate fp "email/activation.txt"
-            <*> readTemplate fp "email/activation.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( ActivationEmailTemplate activationUrl
-            <$> readTemplate fp "email/update-subject.txt"
-            <*> readTemplate fp "email/update.txt"
-            <*> readTemplate fp "email/update.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( TeamActivationEmailTemplate teamActivationUrl
-            <$> readTemplate fp "email/team-activation-subject.txt"
-            <*> readTemplate fp "email/team-activation.txt"
-            <*> readTemplate fp "email/team-activation.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( PasswordResetEmailTemplate passwordResetUrl
-            <$> readTemplate fp "email/password-reset-subject.txt"
-            <*> readTemplate fp "email/password-reset.txt"
-            <*> readTemplate fp "email/password-reset.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( DeletionEmailTemplate deletionUserUrl
-            <$> readTemplate fp "email/deletion-subject.txt"
-            <*> readTemplate fp "email/deletion.txt"
-            <*> readTemplate fp "email/deletion.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( NewClientEmailTemplate
-            <$> readTemplate fp "email/new-client-subject.txt"
-            <*> readTemplate fp "email/new-client.txt"
-            <*> readTemplate fp "email/new-client.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( SecondFactorVerificationEmailTemplate
-            <$> readTemplate fp "email/verification-login-subject.txt"
-            <*> readTemplate fp "email/verification-login.txt"
-            <*> readTemplate fp "email/verification-login.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( SecondFactorVerificationEmailTemplate
-            <$> readTemplate fp "email/verification-scim-token-subject.txt"
-            <*> readTemplate fp "email/verification-scim-token.txt"
-            <*> readTemplate fp "email/verification-scim-token.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
-    <*> ( SecondFactorVerificationEmailTemplate
-            <$> readTemplate fp "email/verification-delete-team-subject.txt"
-            <*> readTemplate fp "email/verification-delete-team.txt"
-            <*> readTemplate fp "email/verification-delete-team.html"
-            <*> pure emailSender
-            <*> readText fp "email/sender.txt"
-        )
+loadUserTemplates o =
+  EmailTemplate.loadUserTemplates
+    userTemplateOpts
+    o.emailSMS.general.templateDir
+    (Opt.defaultTemplateLocale o.settings)
+    o.emailSMS.general.emailSender
   where
-    gOptions = o.emailSMS.general
-    uOptions = o.emailSMS.user
-    tOptions = o.emailSMS.team
-    emailSender = gOptions.emailSender
-    activationUrl = template uOptions.activationUrl
-    teamActivationUrl = template tOptions.tActivationUrl
-    passwordResetUrl = template uOptions.passwordResetUrl
-    deletionUserUrl = template uOptions.deletionUrl
-    defLocale = Opt.defaultTemplateLocale o.settings
-    templateDir = gOptions.templateDir
-    readTemplate = readTemplateWithDefault templateDir defLocale "user"
-    readText = readTextWithDefault templateDir defLocale "user"
+    userTemplateOpts =
+      UserTemplateOpts
+        { activationUrl = o.emailSMS.user.activationUrl,
+          teamActivationUrl = o.emailSMS.team.tActivationUrl,
+          passwordResetUrl = o.emailSMS.user.passwordResetUrl,
+          deletionUrl = o.emailSMS.user.deletionUrl
+        }

--- a/services/brig/test/integration/Run.hs
+++ b/services/brig/test/integration/Run.hs
@@ -29,7 +29,6 @@ import API.Search qualified as Search
 import API.Settings qualified as Settings
 import API.Team qualified as Team
 import API.TeamUserSearch qualified as TeamUserSearch
-import API.Template qualified
 import API.User qualified as User
 import Bilge hiding (header, host, port)
 import Bilge qualified
@@ -146,7 +145,6 @@ runTests iConf brigOpts otherArgs = do
   browseTeam <- TeamUserSearch.tests brigOpts mg g b
   federationEnd2End <- Federation.End2end.spec brigOpts mg b g ch c f brigTwo galleyTwo ch2 cannonTwo
   federationEndpoints <- API.Federation.tests mg brigOpts b fedBrigClient
-  emailTemplates <- API.Template.tests brigOpts mg
 
   let smtp = SMTP.tests mg lg
       oauthAPI = API.OAuth.tests mg db b n brigOpts
@@ -166,8 +164,7 @@ runTests iConf brigOpts otherArgs = do
         federationEndpoints,
         smtp,
         oauthAPI,
-        federationEnd2End,
-        emailTemplates
+        federationEnd2End
       ]
   where
     mkRequest (Endpoint h p) = Bilge.host (encodeUtf8 h) . Bilge.port p


### PR DESCRIPTION
Refactoring PR for making #5243 easier to implement.

What can be run as unit test should not be run as integration test.  Rendering email templates is clearly unit-testable, so I moved `/services/brig/test/integration/API/Template.hs` to `/libs/wire-subsystems/test/unit/Wire/EmailSubsystem/`.  Prior art: `/libs/wire-subsystems/test/unit/Wire/SAMLEmailSubsystem/InterpreterSpec.hs`, from which I moved some code into a new fixtures module; `loadTeamTemplates`, which inspired `loadUserTemplates`.

https://wearezeta.atlassian.net/browse/WPB-18127

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)