### PR TITLE
WPB-27912: Deprecate backgroundEffects feature flag at API v17

### DIFF
--- a/changelog.d/0-release-notes/WPB-27912-background-effects
+++ b/changelog.d/0-release-notes/WPB-27912-background-effects
@@ -1,0 +1,9 @@
+* The `backgroundEffects` team feature flag is **deprecated** (WPB-27912). Its
+  default is now **enabled and locked**, and the Helm configuration override for
+  `backgroundEffects` has been removed from `charts/wire-server`. The flag's
+  data type and its public/internal HTTP endpoints are retained for backward
+  compatibility; any Helm overrides for `backgroundEffects` are now ignored and
+  can be removed. The public/internal HTTP endpoints return 404 at API version
+  v17 and remain available through v16; the flag type remains deprecated. The
+  aggregate `GET /feature-configs` and `GET /teams/:tid/features` endpoints
+  continue to include `backgroundEffects` at all API versions, including v17.

--- a/changelog.d/1-api-changes/WPB-27912-background-effects-endpoint
+++ b/changelog.d/1-api-changes/WPB-27912-background-effects-endpoint
@@ -1,0 +1,7 @@
+The `backgroundEffects` team feature endpoints are deprecated and return 404 for
+clients on API version v17: the public `GET`/`PUT /teams/:tid/features/backgroundEffects`
+and the internal legacy lock `PUT /i/teams/:tid/features/backgroundEffects/(un)?locked`.
+They remain available through v16. The aggregate endpoints
+`GET /feature-configs` and `GET /teams/:tid/features` are unaffected and continue
+to include `backgroundEffects` at all API versions: the aggregate feature list is
+version-agnostic, like other version-gated features such as MLS.

--- a/charts/wire-server/templates/galley/configmap.yaml
+++ b/charts/wire-server/templates/galley/configmap.yaml
@@ -256,9 +256,5 @@ data:
         meetings:
           {{- toYaml .settings.featureFlags.meetings | nindent 10 }}
         {{- end }}
-        {{- if .settings.featureFlags.backgroundEffects }}
-        backgroundEffects:
-          {{- toYaml .settings.featureFlags.backgroundEffects | nindent 10 }}
-        {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -341,10 +341,6 @@ galley:
           defaults:
             status: disabled
             lockStatus: locked
-        backgroundEffects:
-          defaults:
-            status: disabled
-            lockStatus: locked
     aws:
       region: "eu-west-1"
     proxy: {}

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -309,7 +309,6 @@ versions, including v17.
 
 The flag now defaults to **enabled and locked** and the Helm configuration
 override has been removed (operators can no longer change it via Helm). The
-`BackgroundEffectsConfig` type carries a `DEPRECATED` pragma. The
 `GET/PUT /teams/:tid/features/backgroundEffects` and internal lock-status
 endpoints return 404 at API version v17; they remain available through v16.
 The aggregate endpoints `GET /feature-configs` and

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -300,19 +300,21 @@ The aggregate list endpoints (`GET /feature-configs`,
 `GET /teams/:tid/features`) continue to include `meetingsPremium` at all API
 versions, including v17.
 
-### Background Effects
+### Background Effects (deprecated)
 
-The `backgroundEffects` feature flag controls whether background effects are available in meetings. It is disabled and locked by default. If you want a different configuration, use the following syntax: 
-```yaml
-backgroundEffects:
-  defaults:
-    status: disabled|enabled
-    lockStatus: locked|unlocked
-```
+> **Deprecated (WPB-27912).** The `backgroundEffects` feature flag no longer
+> affects meeting behaviour. The flag, its data type and its public/internal
+> endpoints are retained for backward compatibility and are scheduled for
+> removal in a future release.
 
-The lock status for individual teams can be changed via the internal API (`PUT /i/teams/:tid/features/backgroundEffects/(un)?locked`).
-
-The feature status for individual teams can be changed via the public API (if the feature is unlocked).
+The flag now defaults to **enabled and locked** and the Helm configuration
+override has been removed (operators can no longer change it via Helm). The
+`BackgroundEffectsConfig` type carries a `DEPRECATED` pragma. The
+`GET/PUT /teams/:tid/features/backgroundEffects` and internal lock-status
+endpoints return 404 at API version v17; they remain available through v16.
+The aggregate endpoints `GET /feature-configs` and
+`GET /teams/:tid/features` continue to include `backgroundEffects` at all API
+versions, including v17.
 
 ### File Sharing
 

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -96,7 +96,7 @@ testNonMemberAccess (Feature featureName) = do
   -- authz check (403 no-team-member) is still exercised.
   let getFeature = Public.getTeamFeature nonMember tid featureName
   resp <-
-    if featureName == "meetingsPremium"
+    if featureName `elem` ["meetingsPremium", "backgroundEffects"]
       then withAPIVersion 16 getFeature
       else getFeature
   assertForbidden resp

--- a/integration/test/Test/FeatureFlags/BackgroundEffects.hs
+++ b/integration/test/Test/FeatureFlags/BackgroundEffects.hs
@@ -17,14 +17,53 @@
 
 module Test.FeatureFlags.BackgroundEffects where
 
+import SetupHelpers (createTeam)
 import Test.FeatureFlags.Util
 import Testlib.Prelude
 
 testPatchBackgroundEffects :: (HasCallStack) => App ()
-testPatchBackgroundEffects = checkPatch OwnDomain "backgroundEffects" enabled
+testPatchBackgroundEffects = withAPIVersion 16 $ checkPatch OwnDomain "backgroundEffects" enabled
 
 testBackgroundEffects :: (HasCallStack) => APIAccess -> App ()
 testBackgroundEffects access =
-  mkFeatureTests "backgroundEffects"
+  withAPIVersion 16
+    $ mkFeatureTests "backgroundEffects"
     & addUpdate enabled
     & runFeatureTests OwnDomain access
+
+-- | WPB-27912: the public backgroundEffects endpoints are gated at v17 (404)
+-- while remaining available through v16. Only the v16 GET is asserted here:
+-- v16 PUT success is covered by 'testBackgroundEffects' (whose runFeatureTests
+-- unlocks the feature first), and a public PUT in this test would 409
+-- feature-locked against the default enabled+locked state.
+testBackgroundEffectsRemovedAtV17 :: (HasCallStack) => App ()
+testBackgroundEffectsRemovedAtV17 = do
+  (owner, tid, _) <- createTeam OwnDomain 0
+  let p = joinHttpPath ["teams", tid, "features", "backgroundEffects"]
+      body = object ["status" .= "enabled", "lockStatus" .= "locked"]
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p >>= submit "GET") $ \resp -> do
+    resp.status `shouldMatchInt` 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p <&> addJSON body >>= submit "PUT") $ \resp -> do
+    resp.status `shouldMatchInt` 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 16) p >>= submit "GET") $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "status" `shouldMatch` "enabled"
+    resp.json %. "lockStatus" `shouldMatch` "locked"
+
+-- | WPB-27912: the aggregate list endpoints 'GET /feature-configs' and
+-- 'GET /teams/:tid/features' are version-agnostic — like 'From'-gated features
+-- (e.g. MLS), they include every feature at every API version. Even though the
+-- dedicated backgroundEffects endpoints 404 at v17, both list endpoints keep
+-- returning the (default enabled+locked) backgroundEffects entry. This test
+-- locks that behaviour in.
+testBackgroundEffectsListedAtV17 :: (HasCallStack) => App ()
+testBackgroundEffectsListedAtV17 = do
+  (owner, tid, _) <- createTeam OwnDomain 0
+  let assertBackgroundEffects resp = do
+        resp.status `shouldMatchInt` 200
+        be <- resp.json %. "backgroundEffects"
+        be %. "status" `shouldMatch` "enabled"
+        be %. "lockStatus" `shouldMatch` "locked"
+      teamFeatures = joinHttpPath ["teams", tid, "features"]
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) "/feature-configs" >>= submit "GET") assertBackgroundEffects
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) teamFeatures >>= submit "GET") assertBackgroundEffects

--- a/integration/test/Test/FeatureFlags/BackgroundEffects.hs
+++ b/integration/test/Test/FeatureFlags/BackgroundEffects.hs
@@ -50,12 +50,10 @@ testBackgroundEffectsRemovedAtV17 = do
     resp.json %. "status" `shouldMatch` "enabled"
     resp.json %. "lockStatus" `shouldMatch` "locked"
 
--- | WPB-27912: the aggregate list endpoints 'GET /feature-configs' and
--- 'GET /teams/:tid/features' are version-agnostic — like 'From'-gated features
--- (e.g. MLS), they include every feature at every API version. Even though the
--- dedicated backgroundEffects endpoints 404 at v17, both list endpoints keep
--- returning the (default enabled+locked) backgroundEffects entry. This test
--- locks that behaviour in.
+-- | Test version agnostic feature endpoints for `backgroundEffects`
+--
+-- Across versions, `backgroundEffects` is always set to `enabled` and `locked` to provide backwards compatibility.
+-- From `V17` on, the feature itself  has been removed.
 testBackgroundEffectsListedAtV17 :: (HasCallStack) => App ()
 testBackgroundEffectsListedAtV17 = do
   (owner, tid, []) <- createTeam OwnDomain 0

--- a/integration/test/Test/FeatureFlags/BackgroundEffects.hs
+++ b/integration/test/Test/FeatureFlags/BackgroundEffects.hs
@@ -58,7 +58,7 @@ testBackgroundEffectsRemovedAtV17 = do
 -- locks that behaviour in.
 testBackgroundEffectsListedAtV17 :: (HasCallStack) => App ()
 testBackgroundEffectsListedAtV17 = do
-  (owner, tid, _) <- createTeam OwnDomain 0
+  (owner, tid, []) <- createTeam OwnDomain 0
   let assertBackgroundEffects resp = do
         resp.status `shouldMatchInt` 200
         be <- resp.json %. "backgroundEffects"

--- a/integration/test/Test/FeatureFlags/BackgroundEffects.hs
+++ b/integration/test/Test/FeatureFlags/BackgroundEffects.hs
@@ -38,13 +38,11 @@ testBackgroundEffects access =
 -- feature-locked against the default enabled+locked state.
 testBackgroundEffectsRemovedAtV17 :: (HasCallStack) => App ()
 testBackgroundEffectsRemovedAtV17 = do
-  (owner, tid, _) <- createTeam OwnDomain 0
+  (owner, tid, []) <- createTeam OwnDomain 0
   let p = joinHttpPath ["teams", tid, "features", "backgroundEffects"]
       body = object ["status" .= "enabled", "lockStatus" .= "locked"]
-  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p >>= submit "GET") $ \resp -> do
-    resp.status `shouldMatchInt` 404
-  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p <&> addJSON body >>= submit "PUT") $ \resp -> do
-    resp.status `shouldMatchInt` 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p >>= submit "GET") $ assertStatus 404
+  bindResponse (baseRequest owner Galley (ExplicitVersion 17) p <&> addJSON body >>= submit "PUT") $ assertStatus 404
   bindResponse (baseRequest owner Galley (ExplicitVersion 16) p >>= submit "GET") $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "status" `shouldMatch` "enabled"

--- a/integration/test/Test/FeatureFlags/Util.hs
+++ b/integration/test/Test/FeatureFlags/Util.hs
@@ -250,7 +250,7 @@ defAllFeatures =
           ],
       "meetings" .= enabled,
       "meetingsPremium" .= enabledLocked,
-      "backgroundEffects" .= disabledLocked,
+      "backgroundEffects" .= enabledLocked,
       "preventAdminlessGroups"
         .= object
           [ "lockStatus" .= "unlocked",

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -100,7 +100,7 @@ type IFeatureAPI =
     :<|> IFeatureStatusLockStatusPut StealthUsersConfig
     :<|> IFeatureStatusLockStatusPut MeetingsConfig
     :<|> Until 'V17 ::> IFeatureStatusLockStatusPut MeetingsPremiumConfig
-    :<|> IFeatureStatusLockStatusPut BackgroundEffectsConfig
+    :<|> Until 'V17 ::> IFeatureStatusLockStatusPut BackgroundEffectsConfig
     -- all feature configs
     :<|> Named
            "feature-configs-internal"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -86,7 +86,8 @@ type FeatureAPI =
     :<|> FeatureAPIGetPut MeetingsConfig
     :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGet MeetingsPremiumConfig
     :<|> Deprecated ::> Until 'V17 ::> FeatureAPIPut MeetingsPremiumConfig
-    :<|> FeatureAPIGetPut BackgroundEffectsConfig
+    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGet BackgroundEffectsConfig
+    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIPut BackgroundEffectsConfig
 
 type VersionedFeatureAPIPut named reqBodyVersion cfg =
   Named

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -86,8 +86,7 @@ type FeatureAPI =
     :<|> FeatureAPIGetPut MeetingsConfig
     :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGet MeetingsPremiumConfig
     :<|> Deprecated ::> Until 'V17 ::> FeatureAPIPut MeetingsPremiumConfig
-    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGet BackgroundEffectsConfig
-    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIPut BackgroundEffectsConfig
+    :<|> Deprecated ::> Until 'V17 ::> FeatureAPIGetPut BackgroundEffectsConfig
 
 type VersionedFeatureAPIPut named reqBodyVersion cfg =
   Named

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -2429,7 +2429,11 @@ instance ToObjectSchema MeetingsPremiumConfig where
 --------------------------------------------------------------------------------
 -- BackgroundEffects Feature
 --
--- Controls whether background effects are available in meetings.
+-- /Deprecated (WPB-27912)./ This feature flag no longer affects meeting
+-- behaviour and is kept solely for API compatibility. It defaults to
+-- /enabled and locked/. Scheduled for removal in a future release.
+
+{-# DEPRECATED BackgroundEffectsConfig "Deprecated (WPB-27912): no longer affects meeting behaviour; kept for API compatibility." #-}
 
 data BackgroundEffectsConfig = BackgroundEffectsConfig
   deriving (Eq, Show, Generic, GSOP.Generic)
@@ -2441,7 +2445,7 @@ instance ToSchema BackgroundEffectsConfig where
   schema = object objectSchema
 
 instance Default (LockableFeature BackgroundEffectsConfig) where
-  def = defLockedFeature
+  def = defLockedFeature {status = FeatureStatusEnabled}
 
 instance IsFeatureConfig BackgroundEffectsConfig where
   type FeatureSymbol BackgroundEffectsConfig = "backgroundEffects"

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -2428,13 +2428,12 @@ instance ToObjectSchema MeetingsPremiumConfig where
 
 --------------------------------------------------------------------------------
 -- BackgroundEffects Feature
---
--- /Deprecated (WPB-27912)./ This feature flag no longer affects meeting
--- behaviour and is kept solely for API compatibility. It defaults to
--- /enabled and locked/. Scheduled for removal in a future release.
 
 {-# DEPRECATED BackgroundEffectsConfig "Deprecated (WPB-27912): no longer affects meeting behaviour; kept for API compatibility." #-}
 
+-- | /Deprecated (WPB-27912)./ This feature flag no longer affects meeting
+-- behaviour and is kept solely for API compatibility. It defaults to
+-- /enabled and locked/. Scheduled for removal in a future release.
 data BackgroundEffectsConfig = BackgroundEffectsConfig
   deriving (Eq, Show, Generic, GSOP.Generic)
   deriving (Arbitrary) via (GenericUniform BackgroundEffectsConfig)

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -86,7 +86,8 @@ featureAPI =
     <@> featureAPIGetPut @MeetingsConfig
     <@> mkNamedAPI @'("get", MeetingsPremiumConfig) getFeature
     <@> mkNamedAPI @'("put", MeetingsPremiumConfig) setFeature
-    <@> featureAPIGetPut @BackgroundEffectsConfig
+    <@> mkNamedAPI @'("get", BackgroundEffectsConfig) getFeature
+    <@> mkNamedAPI @'("put", BackgroundEffectsConfig) setFeature
 
 deprecatedFeatureConfigAPI :: API DeprecatedFeatureAPI GalleyEffects
 deprecatedFeatureConfigAPI =

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -86,8 +86,7 @@ featureAPI =
     <@> featureAPIGetPut @MeetingsConfig
     <@> mkNamedAPI @'("get", MeetingsPremiumConfig) getFeature
     <@> mkNamedAPI @'("put", MeetingsPremiumConfig) setFeature
-    <@> mkNamedAPI @'("get", BackgroundEffectsConfig) getFeature
-    <@> mkNamedAPI @'("put", BackgroundEffectsConfig) setFeature
+    <@> hoistAPI id featureAPIGetPut
 
 deprecatedFeatureConfigAPI :: API DeprecatedFeatureAPI GalleyEffects
 deprecatedFeatureConfigAPI =


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-27912

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)