### PR TITLE
multi-ingress: Use webapp CSP headers

### DIFF
--- a/changelog.d/3-bug-fixes/multi-ingress-csp-host-scoping
+++ b/changelog.d/3-bug-fixes/multi-ingress-csp-host-scoping
@@ -1,0 +1,1 @@
+Fixed Content Security Policy header scoping in multi-ingress Kubernetes configuration. CSP headers set via the Ingress nginx configuration-snippet are now properly scoped to exclude the webapp domain, preventing conflicts with the webapp's own CSP headers that are set independently.

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -14,8 +14,9 @@ metadata:
     {{/* In the non-multi-ingress (default) case, frontend apps (webapp,
     account-pages, team-settings) set CSP headers on their own. Implementing
     this for multi-ingress would have been much work (due to some framework
-    specifics). Thus, we are setting an approximation of the webapp's CSP
-    headers here. The SAML flow would be broken by setting these headers, so we
+    specifics). Thus, we are setting an approximation of CSP headers here; for
+    all services/apps besides the webapp that provides multi-ingress support
+    for CSP. The SAML flow would be broken by setting these headers, so we
     leave them out for it. This is fine, because in the default case they
     aren't set for any backend API endpoint as well.
 
@@ -37,9 +38,18 @@ metadata:
     `/sso/finalize-login` is at the time of writing also used in Kalium,
     however not versioned. Though, because it is technically possible to use
     the endpoint versioned as well, it cannot hurt to be prepared for this.
+
+    N.B. the nginx config language does not support complex if-expressions -
+    like nested if-s. So, we need to fallback to a more clumsy approach.
     */}}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($uri !~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon\.ico$") {
+      if ($http_host = "{{ .Values.config.dns.webapp }}") {
+        set $skip_csp 1;
+      }
+      if ($uri ~ "^(/v[0-9]+)?/sso/(finalize-login|initiate-login)(/[a-zA-Z0-9-]*)?$|^/favicon\.ico$") {
+        set $skip_csp 1;
+      }
+      if ($skip_csp != 1) {
         set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
         {{if .Values.websockets.enabled}}
         set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";


### PR DESCRIPTION
The webapp provides several config settings for CSP headers. Duplicating them here would be pretty tedious and confusing.
As the webapp provides multi-ingress support: Use it!

Ticket: https://wearezeta.atlassian.net/browse/WPB-27931

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
