### PR TITLE
[WPB-27953] SCIM: Make role field in user schema comply with RFC.

### DIFF
--- a/changelog.d/0-release-notes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
+++ b/changelog.d/0-release-notes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
@@ -1,4 +1,4 @@
-SCIM: Make role field in user schema comply with RFC.  Any code that processes SCIM users must be changed to follow the standard, instead of the previous Wire implementation.
+SCIM: Make role and entitlements fields in user schema comply with RFC.  Any code that processes SCIM users must be changed to follow the standard, instead of the previous Wire implementation.
 
 Previous User schema (incompatible with RFC):
 
@@ -6,6 +6,7 @@ Previous User schema (incompatible with RFC):
 {
   ...
   "roles": ["member"],
+  "entitlements": ["some entitlement"],
   ...
 }
 ```
@@ -16,6 +17,9 @@ New schema (RFC-compliant):
 {
   ...
   "roles": [{"value" : "member"}],
+  "entitlements": [{"value" : "some entitlement"}],
   ...
 }
 ```
+
+For backwards compatibility, both fields still accept the old bare-string form on input.

--- a/changelog.d/0-release-notes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
+++ b/changelog.d/0-release-notes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
@@ -1,0 +1,21 @@
+SCIM: Make role field in user schema comply with RFC.  Any code that processes SCIM users must be changed to follow the standard, instead of the previous Wire implementation.
+
+Previous User schema (incompatible with RFC):
+
+```
+{
+  ...
+  "roles": ["member"],
+  ...
+}
+```
+
+New schema (RFC-compliant):
+
+```
+{
+  ...
+  "roles": [{"value" : "member"}],
+  ...
+}
+```

--- a/changelog.d/1-api-changes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
+++ b/changelog.d/1-api-changes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
@@ -1,1 +1,1 @@
-SCIM: Make role field in user schema comply with RFC.
+SCIM: Make role and entitlements fields in user schema comply with RFC.

--- a/changelog.d/1-api-changes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
+++ b/changelog.d/1-api-changes/WPB-27953-scim_-make-role-field-in-user-schema-comply-with-rfc
@@ -1,0 +1,1 @@
+SCIM: Make role field in user schema comply with RFC.

--- a/libs/hscim/default.nix
+++ b/libs/hscim/default.nix
@@ -31,7 +31,9 @@
 , mmorph
 , mtl
 , network-uri
+, openapi3
 , retry
+, schema-profunctor
 , scientific
 , servant
 , servant-client
@@ -79,7 +81,9 @@ mkDerivation {
     mmorph
     mtl
     network-uri
+    openapi3
     retry
+    schema-profunctor
     scientific
     servant
     servant-client

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -65,6 +65,7 @@ library
     Web.Scim.Schema.User.Name
     Web.Scim.Schema.User.Phone
     Web.Scim.Schema.User.Photo
+    Web.Scim.Schema.User.Role
     Web.Scim.Schema.UserTypes
     Web.Scim.Server
     Web.Scim.Server.Mock
@@ -114,7 +115,9 @@ library
     , mmorph
     , mtl
     , network-uri
+    , openapi3
     , retry
+    , schema-profunctor
     , scientific
     , servant
     , servant-client

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -61,6 +61,7 @@ library
     Web.Scim.Schema.User.Address
     Web.Scim.Schema.User.Certificate
     Web.Scim.Schema.User.Email
+    Web.Scim.Schema.User.Entitlement
     Web.Scim.Schema.User.IM
     Web.Scim.Schema.User.Name
     Web.Scim.Schema.User.Phone

--- a/libs/hscim/src/Web/Scim/Schema/Common.hs
+++ b/libs/hscim/src/Web/Scim/Schema/Common.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/libs/hscim/src/Web/Scim/Schema/Common.hs
+++ b/libs/hscim/src/Web/Scim/Schema/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -25,11 +26,15 @@ module Web.Scim.Schema.Common where
 import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Parser)
 import qualified Data.CaseInsensitive as CI
 import Data.List (nub, (\\))
+import qualified Data.OpenApi as S
+import Data.Schema (NamedSwaggerDoc, Schema (..), ToSchema (..), mkSchema, swaggerDoc)
 import Data.String.Conversions (cs)
 import Data.Text (Text, pack, unpack)
 import qualified Data.Text as Text
+import Lens.Micro ((&), (?~))
 import qualified Network.URI as Network
 
 data WithId id a = WithId
@@ -66,16 +71,30 @@ instance ToJSON URI where
 
 newtype ScimBool = ScimBool {unScimBool :: Bool}
   deriving stock (Eq, Show, Ord)
-  deriving newtype (ToJSON)
+  deriving (FromJSON, ToJSON) via (Schema ScimBool)
 
-instance FromJSON ScimBool where
-  parseJSON (Bool bl) = pure (ScimBool bl)
-  parseJSON (String str) =
-    case CI.mk str of
-      "true" -> pure (ScimBool True)
-      "false" -> pure (ScimBool False)
-      _ -> fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> cs str
-  parseJSON bad = fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> show bad
+-- | Serialises to a plain JSON boolean; parses either a JSON boolean or the
+-- (case-insensitive) strings @"true"@ / @"false"@.
+instance ToSchema ScimBool where
+  schema = mkSchema desc parse (Just . toJSON . unScimBool)
+    where
+      parse :: Value -> Parser ScimBool
+      parse (Bool bl) = pure (ScimBool bl)
+      parse (String str) =
+        case CI.mk str of
+          "true" -> pure (ScimBool True)
+          "false" -> pure (ScimBool False)
+          _ -> fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> cs str
+      parse bad = fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> show bad
+
+      -- The renderer always produces a JSON boolean, so the schema type is
+      -- @boolean@; the extra string inputs the parser tolerates are documented
+      -- in the description.
+      desc :: NamedSwaggerDoc
+      desc =
+        swaggerDoc @Bool
+          & (S.schema . S.description)
+            ?~ "On input, the JSON strings \"true\" and \"false\" (case-insensitive) are also accepted."
 
 toKeyword :: String -> String
 toKeyword "typ" = "type"

--- a/libs/hscim/src/Web/Scim/Schema/User.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User.hs
@@ -94,6 +94,7 @@ import Web.Scim.Schema.User.IM (IM)
 import Web.Scim.Schema.User.Name (Name)
 import Web.Scim.Schema.User.Phone (Phone)
 import Web.Scim.Schema.User.Photo (Photo)
+import Web.Scim.Schema.User.Role (Role)
 import Web.Scim.Schema.UserTypes
 
 -- | SCIM user record, parametrized with type-level @tag@ (see 'UserTypes').
@@ -120,7 +121,7 @@ data User tag = User
     photos :: [Photo],
     addresses :: [Address],
     entitlements :: [Text],
-    roles :: [Text],
+    roles :: [Role],
     x509Certificates :: [Certificate],
     -- Extra data.
     --

--- a/libs/hscim/src/Web/Scim/Schema/User.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User.hs
@@ -90,6 +90,7 @@ import Web.Scim.Schema.Schema (Schema (..), getSchemaUri)
 import Web.Scim.Schema.User.Address (Address)
 import Web.Scim.Schema.User.Certificate (Certificate)
 import Web.Scim.Schema.User.Email (Email)
+import Web.Scim.Schema.User.Entitlement (Entitlement)
 import Web.Scim.Schema.User.IM (IM)
 import Web.Scim.Schema.User.Name (Name)
 import Web.Scim.Schema.User.Phone (Phone)
@@ -120,7 +121,7 @@ data User tag = User
     ims :: [IM],
     photos :: [Photo],
     addresses :: [Address],
-    entitlements :: [Text],
+    entitlements :: [Entitlement],
     roles :: [Role],
     x509Certificates :: [Certificate],
     -- Extra data.

--- a/libs/hscim/src/Web/Scim/Schema/User/Entitlement.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User/Entitlement.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DerivingVia #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Web.Scim.Schema.User.Entitlement where
+
+import Data.Aeson (FromJSON (..), ToJSON, Value (String))
+import qualified Data.OpenApi as S
+import Data.Schema
+import Data.Text (Text)
+import Web.Scim.Schema.Common (ScimBool (..))
+
+-- | A SCIM @entitlements@ entry. RFC 7643 defines @entitlements@ as a complex,
+-- multi-valued attribute, so each element is an object with (optional)
+-- sub-attributes rather than a bare string.
+data Entitlement = Entitlement
+  { value :: Maybe Text,
+    typ :: Maybe Text,
+    display :: Maybe Text,
+    primary :: Maybe ScimBool
+  }
+  deriving stock (Show, Eq)
+  deriving (ToJSON, S.ToSchema) via (Schema Entitlement)
+
+instance ToSchema Entitlement where
+  schema =
+    object
+      ( Entitlement
+          <$> (value .= maybe_ (optField "value" schema))
+          <*> (typ .= maybe_ (optField "type" schema))
+          <*> (display .= maybe_ (optField "display" schema))
+          <*> (primary .= maybe_ (optField "primary" schema))
+      )
+
+-- | We accept both the RFC-compliant object form (parsed via the schema above)
+-- and a plain string (for backwards compatibility with clients that send
+-- @"entitlements": ["some entitlement"]@).
+instance FromJSON Entitlement where
+  parseJSON (String s) = pure $ Entitlement (Just s) Nothing Nothing Nothing
+  parseJSON v = schemaIn (schema @Entitlement) v

--- a/libs/hscim/src/Web/Scim/Schema/User/Role.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User/Role.hs
@@ -40,11 +40,12 @@ data Role = Role
 instance ToSchema Role where
   schema =
     object
-      $ Role
-      <$> (value .= maybe_ (optField "value" schema))
-      <*> (typ .= maybe_ (optField "type" schema))
-      <*> (display .= maybe_ (optField "display" schema))
-      <*> (primary .= maybe_ (optField "primary" schema))
+      ( Role
+          <$> (value .= maybe_ (optField "value" schema))
+          <*> (typ .= maybe_ (optField "type" schema))
+          <*> (display .= maybe_ (optField "display" schema))
+          <*> (primary .= maybe_ (optField "primary" schema))
+      )
 
 -- | We accept both the RFC-compliant object form (parsed via the schema above)
 -- and a plain string (for backwards compatibility with clients that send

--- a/libs/hscim/src/Web/Scim/Schema/User/Role.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User/Role.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DerivingVia #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Web.Scim.Schema.User.Role where
+
+import Data.Aeson (FromJSON (..), ToJSON, Value (String))
+import qualified Data.OpenApi as S
+import Data.Schema
+import Data.Text (Text)
+import Web.Scim.Schema.Common (ScimBool (..))
+
+-- | A SCIM @roles@ entry. RFC 7643 defines @roles@ as a complex, multi-valued
+-- attribute, so each element is an object with (optional) sub-attributes rather
+-- than a bare string.
+data Role = Role
+  { value :: Maybe Text,
+    typ :: Maybe Text,
+    display :: Maybe Text,
+    primary :: Maybe ScimBool
+  }
+  deriving stock (Show, Eq)
+  deriving (ToJSON, S.ToSchema) via (Schema Role)
+
+instance ToSchema Role where
+  schema =
+    object
+      $ Role
+      <$> (value .= maybe_ (optField "value" schema))
+      <*> (typ .= maybe_ (optField "type" schema))
+      <*> (display .= maybe_ (optField "display" schema))
+      <*> (primary .= maybe_ (optField "primary" schema))
+
+-- | We accept both the RFC-compliant object form (parsed via the schema above)
+-- and a plain string (for backwards compatibility with clients that send
+-- @"roles": ["member"]@).
+instance FromJSON Role where
+  parseJSON (String s) = pure $ Role (Just s) Nothing Nothing Nothing
+  parseJSON v = schemaIn (schema @Role) v

--- a/libs/hscim/test/Test/Schema/UserSpec.hs
+++ b/libs/hscim/test/Test/Schema/UserSpec.hs
@@ -56,6 +56,7 @@ import Web.Scim.Schema.User.IM as IM
 import Web.Scim.Schema.User.Name as Name
 import Web.Scim.Schema.User.Phone as Phone
 import Web.Scim.Schema.User.Photo as Photo
+import Web.Scim.Schema.User.Role as Role
 import Web.Scim.Test.Util
 
 prop_roundtrip :: Property
@@ -176,6 +177,16 @@ spec = do
       toJSON (extendedUser (UserExtraObject "foo")) `shouldBe` extendedUserObjectJson
       eitherDecode (encode extendedUserObjectJson)
         `shouldBe` Right (extendedUser (UserExtraObject "foo"))
+  describe "roles (RFC 7643 complex multi-valued attribute)" $ do
+    it "renders as objects with a 'value' sub-attribute, not bare strings" $
+      toJSON (Role (Just "member") Nothing Nothing Nothing)
+        `shouldBe` [scim| {"value": "member"} |]
+    it "parses the RFC-compliant object form" $
+      eitherDecode "{\"value\":\"member\"}"
+        `shouldBe` Right (Role (Just "member") Nothing Nothing Nothing)
+    it "still parses the legacy bare-string form for backwards compatibility" $
+      eitherDecode "\"member\""
+        `shouldBe` Right (Role (Just "member") Nothing Nothing Nothing)
 
 genName :: Gen Name
 genName =
@@ -321,7 +332,14 @@ completeUser =
             }
         ],
       entitlements = ["sample entitlement"],
-      roles = ["sample role"],
+      roles =
+        [ Role
+            { Role.value = Just "sample role",
+              Role.typ = Nothing,
+              Role.display = Nothing,
+              Role.primary = Nothing
+            }
+        ],
       x509Certificates =
         [ Certificate
             { Certificate.typ = Just "sample certificate type",
@@ -337,7 +355,9 @@ completeUserJson =
   [scim|
 {
   "roles": [
-    "sample role"
+    {
+      "value": "sample role"
+    }
   ],
   "x509Certificates": [
     {

--- a/libs/hscim/test/Test/Schema/UserSpec.hs
+++ b/libs/hscim/test/Test/Schema/UserSpec.hs
@@ -52,6 +52,7 @@ import qualified Web.Scim.Schema.User as User
 import Web.Scim.Schema.User.Address as Address
 import Web.Scim.Schema.User.Certificate as Certificate
 import Web.Scim.Schema.User.Email as Email
+import Web.Scim.Schema.User.Entitlement as Entitlement
 import Web.Scim.Schema.User.IM as IM
 import Web.Scim.Schema.User.Name as Name
 import Web.Scim.Schema.User.Phone as Phone
@@ -117,6 +118,7 @@ spec = do
           let operation = Operation Replace (Just (NormalPath (AttrPath Nothing key Nothing))) (Just upd)
           let patchOp = PatchOp [operation]
           User.applyPatch user patchOp `shouldSatisfy` isRight
+
     it "does not support multi-value attributes" $ do
       let schemas' = []
       let extras = KeyMap.empty
@@ -136,13 +138,14 @@ spec = do
           ("ims", toJSON @[IM] mempty),
           ("photos", toJSON @[Photo] mempty),
           ("addresses", toJSON @[Address] mempty),
-          ("entitlements", toJSON @[Text] mempty),
+          ("entitlements", toJSON @[Entitlement] mempty),
           ("x509Certificates", toJSON @[Certificate] mempty)
         ]
         $ \(key, upd) -> do
           let operation = Operation Replace (Just (NormalPath (AttrPath Nothing key Nothing))) (Just upd)
           let patchOp = PatchOp [operation]
           User.applyPatch user patchOp `shouldSatisfy` isLeft
+
     it "applies patch to `extra`" $ do
       let schemas' = []
       let extras = KeyMap.empty
@@ -187,6 +190,19 @@ spec = do
     it "still parses the legacy bare-string form for backwards compatibility" $
       eitherDecode "\"member\""
         `shouldBe` Right (Role (Just "member") Nothing Nothing Nothing)
+
+  describe "entitlements (RFC 7643 complex multi-valued attribute)" $ do
+    it "renders as objects with a 'value' sub-attribute, not bare strings" $ do
+      toJSON (Entitlement (Just "some entitlement") Nothing Nothing Nothing)
+        `shouldBe` [scim| {"value": "some entitlement"} |]
+
+    it "parses the RFC-compliant object form" $ do
+      eitherDecode "{\"value\":\"some entitlement\"}"
+        `shouldBe` Right (Entitlement (Just "some entitlement") Nothing Nothing Nothing)
+
+    it "still parses the legacy bare-string form for backwards compatibility" $ do
+      eitherDecode "\"some entitlement\""
+        `shouldBe` Right (Entitlement (Just "some entitlement") Nothing Nothing Nothing)
 
 genName :: Gen Name
 genName =
@@ -331,7 +347,14 @@ completeUser =
               Address.primary = Just (ScimBool True)
             }
         ],
-      entitlements = ["sample entitlement"],
+      entitlements =
+        [ Entitlement
+            { Entitlement.value = Just "sample entitlement",
+              Entitlement.typ = Nothing,
+              Entitlement.display = Nothing,
+              Entitlement.primary = Nothing
+            }
+        ],
       roles =
         [ Role
             { Role.value = Just "sample role",
@@ -408,7 +431,9 @@ completeUserJson =
   ],
   "preferredLanguage": "da, en-gb;q=0.8, en;q=0.7",
   "entitlements": [
-    "sample entitlement"
+    {
+      "value": "sample entitlement"
+    }
   ],
   "displayName": "sample displayName",
   "nickName": "sample nickName",

--- a/libs/hscim/test/Test/Schema/UserSpec.hs
+++ b/libs/hscim/test/Test/Schema/UserSpec.hs
@@ -154,40 +154,50 @@ spec = do
       let operation = Operation Replace (Just programmingLanguagePath) (Just (toJSON @Text "haskell"))
       let patchOp = PatchOp [operation]
       User.extra <$> User.applyPatch user patchOp `shouldBe` Right (KeyMap.singleton "programmingLanguage" "haskell")
+
   describe "JSON serialization" $ do
     it "handles all fields" $ do
       require prop_roundtrip
       toJSON completeUser `shouldBe` completeUserJson
       eitherDecode (encode completeUserJson) `shouldBe` Right completeUser
+
     it "has defaults for all optional and multi-valued fields" $ do
       toJSON minimalUser `shouldBe` minimalUserJson
       eitherDecode (encode minimalUserJson) `shouldBe` Right minimalUser
-    it "treats 'null' and '[]' as absence of fields" $
+
+    it "treats 'null' and '[]' as absence of fields" $ do
       eitherDecode (encode minimalUserJsonRedundant)
         `shouldBe` Right minimalUser
+
     it "allows casing variations in field names" $ do
       require $ mk_prop_caseInsensitive genUser
       require $ mk_prop_caseInsensitive (ListResponse.fromList . (: []) <$> genStoredUser)
       eitherDecode (encode minimalUserJsonNonCanonical) `shouldBe` Right minimalUser
-    it "doesn't require the 'schemas' field" $
+
+    it "doesn't require the 'schemas' field" $ do
       eitherDecode (encode minimalUserJsonNoSchemas)
         `shouldBe` Right minimalUser
+
     it "doesn't add 'extra' if it's an empty object" $ do
       toJSON (extendedUser UserExtraEmpty) `shouldBe` extendedUserEmptyJson
       eitherDecode (encode extendedUserEmptyJson)
         `shouldBe` Right (extendedUser UserExtraEmpty)
+
     it "encodes and decodes 'extra' correctly" $ do
       toJSON (extendedUser (UserExtraObject "foo")) `shouldBe` extendedUserObjectJson
       eitherDecode (encode extendedUserObjectJson)
         `shouldBe` Right (extendedUser (UserExtraObject "foo"))
+
   describe "roles (RFC 7643 complex multi-valued attribute)" $ do
-    it "renders as objects with a 'value' sub-attribute, not bare strings" $
+    it "renders as objects with a 'value' sub-attribute, not bare strings" $ do
       toJSON (Role (Just "member") Nothing Nothing Nothing)
         `shouldBe` [scim| {"value": "member"} |]
-    it "parses the RFC-compliant object form" $
+
+    it "parses the RFC-compliant object form" $ do
       eitherDecode "{\"value\":\"member\"}"
         `shouldBe` Right (Role (Just "member") Nothing Nothing Nothing)
-    it "still parses the legacy bare-string form for backwards compatibility" $
+
+    it "still parses the legacy bare-string form for backwards compatibility" $ do
       eitherDecode "\"member\""
         `shouldBe` Right (Role (Just "member") Nothing Nothing Nothing)
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -97,6 +97,7 @@ import qualified Web.Scim.Schema.ResourceType as Scim
 import qualified Web.Scim.Schema.User as Scim
 import qualified Web.Scim.Schema.User as Scim.User (schemas)
 import qualified Web.Scim.Schema.User.Email as Scim.Email
+import qualified Web.Scim.Schema.User.Role as Scim.Role
 import qualified Wire.API.Team.Member as Member
 import Wire.API.Team.Role
 import Wire.API.User
@@ -334,11 +335,13 @@ validateScimUser' errloc midp richInfoLimit user = do
     validateRole =
       Scim.roles <&> \case
         [] -> pure Nothing
-        [role] ->
-          maybe
-            (throw $ badRequest $ "The role '" <> role <> "' is not valid. Valid roles are " <> validRoleNames <> ".")
-            (pure . Just)
-            (fromByteString $ Text.encodeUtf8 role)
+        [role] -> case Scim.Role.value role of
+          Nothing -> throw $ badRequest "A role must have a value."
+          Just roleName ->
+            maybe
+              (throw $ badRequest $ "The role '" <> roleName <> "' is not valid. Valid roles are " <> validRoleNames <> ".")
+              (pure . Just)
+              (fromByteString $ Text.encodeUtf8 roleName)
         (_ : _ : _) -> throw $ badRequest "A user cannot have more than one role."
 
     badRequest :: Text -> Scim.ScimError
@@ -1086,10 +1089,19 @@ synthesizeScimUser info =
           Scim.roles =
             maybe
               []
-              ( (: [])
-                  . Text.decodeUtf8With lenientDecode
-                  . toStrict
-                  . toByteString
+              ( \role ->
+                  [ Scim.Role.Role
+                      { Scim.Role.value =
+                          Just
+                            . Text.decodeUtf8With lenientDecode
+                            . toStrict
+                            . toByteString
+                            $ role,
+                        Scim.Role.typ = Nothing,
+                        Scim.Role.display = Nothing,
+                        Scim.Role.primary = Nothing
+                      }
+                  ]
               )
               (info.role),
           Scim.emails = (\e -> Scim.Email.Email Nothing (Scim.Email.EmailAddress e) Nothing) <$> info.emails

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -337,11 +337,11 @@ validateScimUser' errloc midp richInfoLimit user = do
         [] -> pure Nothing
         [role] -> case Scim.Role.value role of
           Nothing -> throw $ badRequest "A role must have a value."
-          Just roleName ->
+          Just roleNm ->
             maybe
-              (throw $ badRequest $ "The role '" <> roleName <> "' is not valid. Valid roles are " <> validRoleNames <> ".")
+              (throw $ badRequest $ "The role '" <> roleNm <> "' is not valid. Valid roles are " <> validRoleNames <> ".")
               (pure . Just)
-              (fromByteString $ Text.encodeUtf8 roleName)
+              (fromByteString $ Text.encodeUtf8 roleNm)
         (_ : _ : _) -> throw $ badRequest "A user cannot have more than one role."
 
     badRequest :: Text -> Scim.ScimError

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1351,7 +1351,7 @@ specProvisionScimAndSAMLUserWithRole = do
       let testCreateUserWithRole role = do
             scimUser <- do
               u <- ScimT.randomScimUser
-              pure $ u {Scim.roles = [cs $ toByteString $ role]}
+              pure $ u {Scim.roles = ScimT.mkScimRoles [cs $ toByteString $ role]}
             uid <- ScimT.scimUserId <$> ScimT.createUser tok scimUser
             ScimT.checkTeamMembersRole tid owner uid role
       mapM_ testCreateUserWithRole [minBound .. maxBound]
@@ -1366,7 +1366,7 @@ specProvisionScimAndSAMLUserWithRole = do
       (tok, _) <- ScimT.registerIdPAndScimTokenWithMeta
       scimUser <- do
         u <- ScimT.randomScimUser
-        pure $ u {Scim.roles = ["member", "admin"]}
+        pure $ u {Scim.roles = ScimT.mkScimRoles ["member", "admin"]}
       ScimT.createUser' tok scimUser !!! do
         const 400 === statusCode
         const (Just "A user cannot have more than one role.") =~= responseBody
@@ -1374,7 +1374,7 @@ specProvisionScimAndSAMLUserWithRole = do
       (tok, _) <- ScimT.registerIdPAndScimTokenWithMeta
       scimUser <- do
         u <- ScimT.randomScimUser
-        pure $ u {Scim.roles = ["president"]}
+        pure $ u {Scim.roles = ScimT.mkScimRoles ["president"]}
       ScimT.createUser' tok scimUser !!! do
         const 400 === statusCode
         const (Just "The role 'president' is not valid. Valid roles are owner, admin, member, partner.") =~= responseBody
@@ -1383,7 +1383,7 @@ specProvisionScimAndSAMLUserWithRole = do
       scimUserWithDefaultRole <- ScimT.randomScimUser
       uid <- ScimT.scimUserId <$> ScimT.createUser tok scimUserWithDefaultRole
       let testUpdateUserWithRole role = do
-            let scimUserWithRole = scimUserWithDefaultRole {Scim.roles = [cs $ toByteString $ role]}
+            let scimUserWithRole = scimUserWithDefaultRole {Scim.roles = ScimT.mkScimRoles [cs $ toByteString $ role]}
             _ <- ScimT.updateUser tok uid scimUserWithRole
             ScimT.checkTeamMembersRole tid owner uid role
       mapM_ testUpdateUserWithRole [minBound .. maxBound]
@@ -1393,7 +1393,7 @@ specProvisionScimAndSAMLUserWithRole = do
           testUpdateUserWithDefaultRole role = do
             scimUser <- do
               u <- ScimT.randomScimUser
-              pure $ u {Scim.roles = [cs $ toByteString $ role]}
+              pure $ u {Scim.roles = ScimT.mkScimRoles [cs $ toByteString $ role]}
             uid <- ScimT.scimUserId <$> ScimT.createUser tok scimUser
             _ <- ScimT.updateUser tok uid (scimUser {Scim.roles = []})
             ScimT.checkTeamMembersRole tid owner uid role
@@ -1402,14 +1402,14 @@ specProvisionScimAndSAMLUserWithRole = do
       (tok, _) <- ScimT.registerIdPAndScimTokenWithMeta
       scimUser <- ScimT.randomScimUser
       uid <- ScimT.scimUserId <$> ScimT.createUser tok scimUser
-      ScimT.updateUser' tok uid (scimUser {Scim.roles = ["admin", "member"]}) !!! do
+      ScimT.updateUser' tok uid (scimUser {Scim.roles = ScimT.mkScimRoles ["admin", "member"]}) !!! do
         const 400 === statusCode
         const (Just "A user cannot have more than one role.") =~= responseBody
     it "updated user - fail if role name cannot be parsed correctly" $ do
       (tok, _) <- ScimT.registerIdPAndScimTokenWithMeta
       scimUser <- ScimT.randomScimUser
       uid <- ScimT.scimUserId <$> ScimT.createUser tok scimUser
-      ScimT.updateUser' tok uid (scimUser {Scim.roles = ["hamlet"]}) !!! do
+      ScimT.updateUser' tok uid (scimUser {Scim.roles = ScimT.mkScimRoles ["hamlet"]}) !!! do
         const 400 === statusCode
         const (Just "The role 'hamlet' is not valid. Valid roles are owner, admin, member, partner.") =~= responseBody
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -668,7 +668,7 @@ testCreateUserNoIdPInvalidRoles = do
     randomScimUser <&> \u ->
       u
         { Scim.User.externalId = Just $ fromEmail email,
-          Scim.User.roles = cs . toByteString <$> [RoleMember, RoleExternalPartner]
+          Scim.User.roles = mkScimRoles $ cs . toByteString <$> [RoleMember, RoleExternalPartner]
         }
   createUser' tok scimUserTooManyRoles !!! do
     const 400 === statusCode
@@ -677,7 +677,7 @@ testCreateUserNoIdPInvalidRoles = do
     randomScimUser <&> \u ->
       u
         { Scim.User.externalId = Just $ fromEmail email,
-          Scim.User.roles = ["foobar"]
+          Scim.User.roles = mkScimRoles ["foobar"]
         }
   createUser' tok scimUserInvalidRole !!! do
     const 400 === statusCode
@@ -699,7 +699,7 @@ testCreateUserNoIdPWithRole brig tid owner tok role = do
     randomScimUser <&> \u ->
       u
         { Scim.User.externalId = Just $ fromEmail email,
-          Scim.User.roles = [cs $ toByteString role]
+          Scim.User.roles = mkScimRoles [cs $ toByteString role]
         }
   scimStoredUser <- createUser tok scimUser
   let userid = scimUserId scimStoredUser
@@ -713,7 +713,7 @@ testCreateUserNoIdPWithRole brig tid owner tok role = do
     -- FUTUREWORK: if this is not the desired behavior, have to handle this in the `getUser` handler:
     -- - if the user has a pending invitation, we have to look up the role in the invitation table
     --   by doing an rpc to brig
-    liftIO $ Scim.User.roles usr `shouldBe` [cs $ toByteString defaultRole]
+    liftIO $ scimRoleValues (Scim.User.roles usr) `shouldBe` [cs $ toByteString defaultRole]
     -- now external ID can differ from email, so emails are also returned
     liftIO $ (\(Scim.Email.Email _ e _) -> Scim.Email.unEmailAddress e) <$> Scim.User.emails usr `shouldBe` [email]
     liftIO $ Scim.User.externalId usr `shouldBe` (Just (fromEmail email))
@@ -1975,7 +1975,7 @@ testUpdateUserRole = do
         randomScimUser <&> \u ->
           u
             { Scim.User.externalId = Just $ fromEmail email,
-              Scim.User.roles = [cs $ toByteString initialRole]
+              Scim.User.roles = mkScimRoles [cs $ toByteString initialRole]
             }
       scimStoredUser <- createUser tok scimUser
       let userid = scimUserId scimStoredUser
@@ -1987,7 +1987,7 @@ testUpdateUserRole = do
         Just inviteeCode <- call $ getInvitationCode brig tid inv.invitationId
         registerInvitation email userName inviteeCode True
       checkTeamMembersRole tid owner userid initialRole
-      _ <- updateUser tok userid (scimUser {Scim.User.roles = cs . toByteString <$> maybeToList mUpdatedRole})
+      _ <- updateUser tok userid (scimUser {Scim.User.roles = mkScimRoles $ cs . toByteString <$> maybeToList mUpdatedRole})
       checkTeamMembersRole tid owner userid targetRoleExpected
 
 ----------------------------------------------------------------------------
@@ -2210,7 +2210,7 @@ createScimUserWithRole brig tid owner tok initialRole = do
     randomScimUser <&> \u ->
       u
         { Scim.User.externalId = Just $ fromEmail email,
-          Scim.User.roles = [cs $ toByteString initialRole]
+          Scim.User.roles = mkScimRoles [cs $ toByteString initialRole]
         }
   scimStoredUser <- createUser tok scimUser
   let userid = scimUserId scimStoredUser

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -62,12 +62,21 @@ import qualified Web.Scim.Schema.User as Scim
 import qualified Web.Scim.Schema.User as Scim.User
 import qualified Web.Scim.Schema.User.Email as Scim.Email
 import qualified Web.Scim.Schema.User.Phone as Phone
+import qualified Web.Scim.Schema.User.Role as Scim.Role
 import qualified Wire.API.Team.Member as Member
 import Wire.API.Team.Role (Role, defaultRole)
 import Wire.API.User
 import Wire.API.User.IdentityProvider hiding (handle, team)
 import Wire.API.User.RichInfo
 import Wire.API.User.Scim
+
+-- | Build a SCIM @roles@ list (RFC 7643 complex form) from plain role-name strings.
+mkScimRoles :: [Text] -> [Scim.Role.Role]
+mkScimRoles = map (\v -> Scim.Role.Role (Just v) Nothing Nothing Nothing)
+
+-- | Extract the role-name strings from a SCIM @roles@ list.
+scimRoleValues :: [Scim.Role.Role] -> [Text]
+scimRoleValues = mapMaybe Scim.Role.value
 
 -- | Take apart a 'ValidScimId', using 'SAML.UserRef' if available, otherwise 'Email'.
 runValidScimIdEither :: (SAML.UserRef -> a) -> (EmailAddress -> a) -> ValidScimId -> a
@@ -162,7 +171,7 @@ randomScimUserWithSubjectAndRichInfo richInfo = do
           Scim.User.externalId = Just externalId,
           Scim.User.emails = [],
           Scim.User.phoneNumbers = phones,
-          Scim.User.roles = ["member"]
+          Scim.User.roles = mkScimRoles ["member"]
           -- if we don't add this role here explicitly, some tests may show confusing failures
           -- involving [] or null being changed to ["member"] during a create or update
           -- operation.
@@ -724,7 +733,7 @@ setDefaultRoleAndEmailsIfEmpty :: Scim.User.User a -> Scim.User.User a
 setDefaultRoleAndEmailsIfEmpty u =
   u
     { Scim.User.roles = case Scim.User.roles u of
-        [] -> [cs $ toByteString' defaultRole]
+        [] -> mkScimRoles [cs $ toByteString' defaultRole]
         xs -> xs,
       -- when the emails field is empty, we try to populate it with the externalId
       Scim.User.emails = case Scim.User.emails u of


### PR DESCRIPTION
Fixes #5435 

This changes the `"role"` field in the `User` schema.  The release notes contain a warning about this with instructions how to re-align code.  If anybody is impacted by this change, they are in violation of the RFC as we were and should follow the release note instructions.  To make things as backwards-compatible as can be, the new code parses both `"member"` and `{"value": "member"}` as a role.

https://wearezeta.atlassian.net/browse/WPB-27953

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)