### PR TITLE
Fix integration test cleanup on federation instance V2.

### DIFF
--- a/changelog.d/5-internal/WPB---fix-integration-test-cleanup-on-federation-instance-v2
+++ b/changelog.d/5-internal/WPB---fix-integration-test-cleanup-on-federation-instance-v2
@@ -1,0 +1,1 @@
+Fix integration test cleanup on federation instance V2.

--- a/charts/integration/templates/configmap.yaml
+++ b/charts/integration/templates/configmap.yaml
@@ -102,6 +102,13 @@ data:
       adminPort: 15672
       vHost: /
 
+    rabbitmq-v2:
+      host: rabbitmq.wire-federation-v2.svc.cluster.local
+      port: 5671
+      adminHost: rabbitmq.wire-federation-v2.svc.cluster.local
+      adminPort: 15672
+      vHost: /
+
     backendTwo:
 
       brig:

--- a/integration/test/Testlib/Env.hs
+++ b/integration/test/Testlib/Env.hs
@@ -140,6 +140,7 @@ mkGlobalEnv cfgFile = do
         gRabbitMQConfig = intConfig.rabbitmq,
         gRabbitMQConfigV0 = intConfig.rabbitmqV0,
         gRabbitMQConfigV1 = intConfig.rabbitmqV1,
+        gRabbitMQConfigV2 = intConfig.rabbitmqV2,
         gTempDir = tempDir,
         gTimeOutSeconds = timeOutSeconds,
         gDNSMockServerConfig = intConfig.dnsMockServer,

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -177,7 +177,7 @@ runTests tests mXMLOutput cfg = do
             pure (TestSuiteReport [TestCaseReport qname TestSuccess tm])
       writeChan output Nothing
       wait displayThread
-      deleteFederationV0AndV1Queues genv
+      deleteFederationVQueues genv
       printReport report
       mapM_ (saveXMLReport report) mXMLOutput
       when (any (\testCase -> testCase.result /= TestSuccess) report.cases) $
@@ -216,8 +216,8 @@ runMigrations = do
       (_, _, _, ph) <- liftIO $ createProcess cp
       void $ liftIO $ waitForProcess ph
 
-deleteFederationV0AndV1Queues :: GlobalEnv -> IO ()
-deleteFederationV0AndV1Queues env = do
+deleteFederationVQueues :: GlobalEnv -> IO ()
+deleteFederationVQueues env = do
   let testDomains = env.gDomain1 : env.gDomain2 : env.gDynamicDomains
   putStrLn "Attempting to delete federation V0 queues..."
   (mV0User, mV0Pass) <- readCredsFromEnvWithSuffix "V0"
@@ -228,6 +228,11 @@ deleteFederationV0AndV1Queues env = do
   (mV1User, mV1Pass) <- readCredsFromEnvWithSuffix "V1"
   fromMaybe (putStrLn "No or incomplete credentials for fed V1 RabbitMQ") $
     deleteFederationQueues testDomains env.gRabbitMQConfigV1 <$> mV1User <*> mV1Pass
+
+  putStrLn "Attempting to delete federation V2 queues..."
+  (mV2User, mV2Pass) <- readCredsFromEnvWithSuffix "V2"
+  fromMaybe (putStrLn "No or incomplete credentials for fed V2 RabbitMQ") $
+    deleteFederationQueues testDomains env.gRabbitMQConfigV2 <$> mV2User <*> mV2Pass
   where
     readCredsFromEnvWithSuffix :: String -> IO (Maybe Text, Maybe Text)
     readCredsFromEnvWithSuffix suffix =

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -141,6 +141,7 @@ data GlobalEnv = GlobalEnv
     gRabbitMQConfig :: RabbitMqAdminOpts,
     gRabbitMQConfigV0 :: RabbitMqAdminOpts,
     gRabbitMQConfigV1 :: RabbitMqAdminOpts,
+    gRabbitMQConfigV2 :: RabbitMqAdminOpts,
     gTempDir :: FilePath,
     gTimeOutSeconds :: Int,
     gDNSMockServerConfig :: DNSMockServerConfig,
@@ -160,6 +161,7 @@ data IntegrationConfig = IntegrationConfig
     rabbitmq :: RabbitMqAdminOpts,
     rabbitmqV0 :: RabbitMqAdminOpts,
     rabbitmqV1 :: RabbitMqAdminOpts,
+    rabbitmqV2 :: RabbitMqAdminOpts,
     cassandra :: CassandraConfig,
     dnsMockServer :: DNSMockServerConfig,
     cellsEventQueue :: String
@@ -180,6 +182,7 @@ instance FromJSON IntegrationConfig where
         <*> o .: fromString "rabbitmq"
         <*> o .: fromString "rabbitmq-v0"
         <*> o .: fromString "rabbitmq-v1"
+        <*> o .: fromString "rabbitmq-v2"
         <*> o .: fromString "cassandra"
         <*> o .: fromString "dnsMockServer"
         <*> o .: fromString "cellsEventQueue"

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -187,6 +187,13 @@ rabbitmq-v1:
   adminPort: 15672
   vHost: federation-v1
 
+rabbitmq-v2:
+  host: localhost
+  port: 5671
+  adminHost: localhost
+  adminPort: 15672
+  vHost: federation-v2
+
 cassandra:
   host: 127.0.0.1
   port: 9042


### PR DESCRIPTION
See also: https://github.com/zinfra/cailleach/pull/4807

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)