### PR TITLE
cannon: log unavailable gundeck

### DIFF
--- a/changelog.d/5-internal/cannon-log-register-remote-presence-failure
+++ b/changelog.d/5-internal/cannon-log-register-remote-presence-failure
@@ -1,0 +1,4 @@
+Cannon now logs an error when registering a client's remote presence with
+Gundeck fails, so operators can tell this apart from an actual
+websocket/network issue (e.g. `PongTimeout` caused by Gundeck losing its Redis
+connection).

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -48,11 +48,18 @@ wsapp k c e pc = runWS e (go `catches` ioErrors k c)
         ws <- mkWebSocket conn
         debug $ client (key2bytes k) ~~ "websocket" .= connIdent ws
         registerLocal k ws
-        registerRemote k c `onException` (unregisterLocal k ws >> close k ws)
+        registerRemote k c `onException` (logRegisterRemoteError ws >> unregisterLocal k ws >> close k ws)
         timeout (maxLifetime * 1_000_000) (continue ws k) `finally` terminate k ws >>= \case
           Nothing ->
             Logger.info $ msg (val "websocket reached max lifetime") . client (key2bytes k)
           Just () -> pure ()
+    logRegisterRemoteError ws =
+      Logger.err $
+        logKey k
+          . client (key2bytes k)
+          ~~ "websocket"
+          .= connIdent ws
+          ~~ msg (val "Registering remote presence at Gundeck failed. Check Gundeck.")
 
 continue :: (MonadLogger m, MonadUnliftIO m) => Websocket -> Key -> m ()
 continue ws k = do

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -48,7 +48,11 @@ wsapp k c e pc = runWS e (go `catches` ioErrors k c)
         ws <- mkWebSocket conn
         debug $ client (key2bytes k) ~~ "websocket" .= connIdent ws
         registerLocal k ws
-        registerRemote k c `onException` (logRegisterRemoteError ws >> unregisterLocal k ws >> close k ws)
+        registerRemote k c
+          `onException` ( logRegisterRemoteError ws
+                            >> unregisterLocal k ws
+                            >> close k ws
+                        )
         timeout (maxLifetime * 1_000_000) (continue ws k) `finally` terminate k ws >>= \case
           Nothing ->
             Logger.info $ msg (val "websocket reached max lifetime") . client (key2bytes k)


### PR DESCRIPTION
The new log line looks like e.g. this:
```
[cannon@example.com] E, request=97c1c701-45f0-423b-a06c-c953db932893, user=690ae35c-507f-406f-a79d-a1a1d248854e, conn=f5c36345-8ee2-46a4-8130-72440dac5b72, client=690ae35c-507f-406f-a79d-a1a1d248854e.f5c36345-8ee2-46a4-8130-72440dac5b72, websocket=13097857098907479422, Registering remote presence at Gundeck failed. Check Gundeck.
```

For later re-use, a small python script that just attaches to the WebSocket: https://gist.github.com/supersven/cfd1047a29394959059ff897861fa5c1

Ticket: https://wearezeta.atlassian.net/browse/WPB-26298

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
