### PR TITLE
[WPB-28132] Fix openapi3 docs for oauth scopes.

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-28132-fix-openapi3-docs-for-oauth-scopes
+++ b/changelog.d/3-bug-fixes/WPB-28132-fix-openapi3-docs-for-oauth-scopes
@@ -1,0 +1,1 @@
+Fix openapi3 docs for oauth scopes.

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -41,6 +41,7 @@
 , errors
 , extended
 , extra
+, file-embed
 , filepath
 , generics-sop
 , ghc-prim
@@ -125,6 +126,7 @@
 , wai-websockets
 , websockets
 , wire-message-proto-lens
+, yaml
 , zauth
 }:
 mkDerivation {
@@ -257,6 +259,7 @@ mkDerivation {
     crypton-pem
     currency-codes
     data-default
+    file-embed
     filepath
     hex
     hspec
@@ -274,6 +277,7 @@ mkDerivation {
     QuickCheck
     ram
     random
+    regex-tdfa
     saml2-web-sso
     schema-profunctor
     servant
@@ -292,6 +296,7 @@ mkDerivation {
     vector
     wai
     wire-message-proto-lens
+    yaml
   ];
   license = lib.meta.getLicenseFromSpdxId "AGPL-3.0-only";
 }

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -36,7 +36,6 @@
 , currency-codes
 , data-default
 , deriving-aeson
-, directory
 , deriving-swagger2
 , email-validate
 , errors
@@ -261,7 +260,6 @@ mkDerivation {
     crypton-pem
     currency-codes
     data-default
-    directory
     file-embed
     filepath
     hex

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -36,6 +36,7 @@
 , currency-codes
 , data-default
 , deriving-aeson
+, directory
 , deriving-swagger2
 , email-validate
 , errors
@@ -107,6 +108,7 @@
 , tasty-hspec
 , tasty-hunit
 , tasty-quickcheck
+, template-haskell
 , text
 , these
 , time
@@ -259,6 +261,7 @@ mkDerivation {
     crypton-pem
     currency-codes
     data-default
+    directory
     file-embed
     filepath
     hex
@@ -287,6 +290,7 @@ mkDerivation {
     tasty-hspec
     tasty-hunit
     tasty-quickcheck
+    template-haskell
     text
     time
     types-common

--- a/libs/wire-api/src/Wire/API/OAuth.hs
+++ b/libs/wire-api/src/Wire/API/OAuth.hs
@@ -199,7 +199,7 @@ data OAuthScope
   | ReadSelf
   | WriteConversations
   | WriteConversationsCode
-  deriving (Eq, Show, Generic, Ord)
+  deriving (Eq, Show, Generic, Ord, Bounded, Enum)
   deriving (Arbitrary) via (GenericUniform OAuthScope)
 
 class IsOAuthScope scope where

--- a/libs/wire-api/src/Wire/API/Routes/Public.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public.hs
@@ -31,6 +31,7 @@ module Wire.API.Routes.Public
     ZProvider,
     ZAccess,
     DescriptionOAuthScope,
+    renderOAuthScope,
     ZHostOpt,
     ZHostValue,
     ZAuthServant,
@@ -352,17 +353,19 @@ instance
 
 addScopeDescription :: forall scope. (OAuth.IsOAuthScope scope) => OpenApi -> OpenApi
 addScopeDescription =
-  allOperations
-    . description
-    %~ Just
-      . ( <>
-            "\nOAuth scope: `"
-              <> ( decodeUtf8With lenientDecode . toStrict . toByteString $
-                     OAuth.toOAuthScope @scope
-                 )
-              <> "`"
-        )
-      . fold
+  allOperations . description %~ Just . (<> renderOAuthScope (OAuth.toOAuthScope @scope)) . fold
+
+-- | The snippet 'DescriptionOAuthScope' appends to an operation description.
+--
+-- This is enforced in @charts/nginz/values.yaml@ (search for
+-- @oauth_scope@).  Mismatches are caught in
+-- @Test.Wire.API.Routes.OAuthScopes@.  (This function is exported for
+-- that test only.)
+renderOAuthScope :: OAuth.OAuthScope -> Text
+renderOAuthScope scope =
+  "\nOAuth scope: `"
+    <> (decodeUtf8With lenientDecode . toStrict . toByteString $ scope)
+    <> "`"
 
 instance (HasServer api ctx) => HasServer (DescriptionOAuthScope scope :> api) ctx where
   type ServerT (DescriptionOAuthScope scope :> api) m = ServerT api m

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -534,6 +534,7 @@ type ConversationAPI =
     :<|> Named
            "create-group-conversation"
            ( Summary "Create a new conversation"
+               :> DescriptionOAuthScope 'WriteConversations
                :> From 'V16
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'MLSNonEmptyMemberList
@@ -1150,6 +1151,7 @@ type ConversationAPI =
     :<|> Named
            "get-code"
            ( Summary "Get existing conversation code"
+               :> DescriptionOAuthScope 'WriteConversationsCode
                :> CanThrow 'CodeNotFound
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound

--- a/libs/wire-api/src/Wire/API/Routes/Public/Swagger.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Swagger.hs
@@ -1,0 +1,75 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | The swagger docs for the public API of the development version.
+--
+-- Older versions are frozen and served from the pregenerated JSON files in
+-- @services/brig/docs/@; this is the only version that is still assembled from
+-- the routing tables.  It lives here rather than in brig so that tests in this
+-- package can get at it -- see @Test.Wire.API.Routes.OAuthScopes@.
+module Wire.API.Routes.Public.Swagger
+  ( devVersion,
+    devVersionSwagger,
+  )
+where
+
+import Control.Lens ((.~))
+import Data.OpenApi qualified as S
+import Imports
+import Servant.API (toUrlPiece)
+import Wire.API.Routes.API (serviceSwagger)
+import Wire.API.Routes.Public.Brig (BrigAPITag)
+import Wire.API.Routes.Public.Brig.OAuth (OAuthAPITag)
+import Wire.API.Routes.Public.Cannon (CannonAPITag)
+import Wire.API.Routes.Public.Cargohold (CargoholdAPITag)
+import Wire.API.Routes.Public.Galley (GalleyAPITag)
+import Wire.API.Routes.Public.Gundeck (GundeckAPITag)
+import Wire.API.Routes.Public.Proxy (ProxyAPITag)
+import Wire.API.Routes.Public.Spar (SparAPITag)
+import Wire.API.Routes.Version
+import Wire.API.SwaggerHelper (cleanupSwagger)
+
+-- | The version 'devVersionSwagger' describes.  Must stay in sync with the type
+-- level @\'V17@ below; there is no way to tie the two together, since the
+-- 'S.OpenApi' has to be assembled at a statically known version.
+devVersion :: Version
+devVersion =
+  if maxBound == V17
+    then maxBound
+    else
+      -- if you get this error, you also need to update the version literals below.
+      error "libs/wire-api/src/Wire/API/Routes/Public/Swagger.hs#devVersion: please update to latest api version!"
+
+-- | Note that brig additionally sets @info.description@ from
+-- @services/brig/docs/swagger.md@, which cannot move here: it is embedded
+-- relative to the brig package.  'cleanupSwagger' does not touch
+-- @info.description@, so setting it afterwards is equivalent.
+devVersionSwagger :: S.OpenApi
+devVersionSwagger =
+  ( serviceSwagger @VersionAPITag @'V17
+      <> serviceSwagger @BrigAPITag @'V17
+      <> serviceSwagger @GalleyAPITag @'V17
+      <> serviceSwagger @SparAPITag @'V17
+      <> serviceSwagger @CargoholdAPITag @'V17
+      <> serviceSwagger @CannonAPITag @'V17
+      <> serviceSwagger @GundeckAPITag @'V17
+      <> serviceSwagger @ProxyAPITag @'V17
+      <> serviceSwagger @OAuthAPITag @'V17
+  )
+    & S.info . S.title .~ "Wire-Server API"
+    & S.servers .~ [S.Server ("/" <> toUrlPiece devVersion) Nothing mempty]
+    & cleanupSwagger

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/OAuthScopes.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/OAuthScopes.hs
@@ -44,6 +44,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Yaml qualified as Yaml
 import Imports
+import Language.Haskell.TH (runIO)
 import Servant.API (toUrlPiece)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -95,9 +96,27 @@ enforcedScopes method path =
 
 nginzLocations :: [Location]
 nginzLocations =
-  case Yaml.decodeEither' $(embedFile =<< makeRelativeToProject "../../charts/nginz/values.yaml") of
+  case Yaml.decodeEither' nginzValues of
     Left e -> error $ "charts/nginz/values.yaml: " <> Yaml.prettyPrintParseException e
     Right (NginzLocations ls) -> ls
+
+-- | @charts\/nginz\/values.yaml@, embedded at compile time.
+--
+-- Under nix only this package's own directory is copied into the build sandbox,
+-- so @nix\/wire-server.nix@ splices the chart into @test\/unit\/generated\/@ and
+-- we prefer that copy; a plain cabal build has the whole repository checked out
+-- and reads the real file instead.  The lookup is inline because a top-level
+-- splice cannot call a function defined in the same module.
+nginzValues :: ByteString
+nginzValues =
+  $( do
+       spliced <- makeRelativeToProject "test/unit/generated/nginz-values.yaml"
+       spliced' <- runIO (doesFileExist spliced)
+       embedFile
+         =<< if spliced'
+           then pure spliced
+           else makeRelativeToProject "../../charts/nginz/values.yaml"
+   )
 
 instance A.FromJSON NginzLocations where
   parseJSON = A.withObject "charts/nginz/values.yaml" $ \top -> do

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/OAuthScopes.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/OAuthScopes.hs
@@ -1,0 +1,281 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2025 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Two independent places declare which OAuth scope an endpoint needs, and
+-- nothing keeps them in sync:
+--
+-- 1. @charts/nginz/values.yaml@ -- @oauth_scope:@ on an upstream entry.  This is
+--    what is actually /enforced/: nginz rejects OAuth tokens without the scope.
+-- 2. The servant routing tables -- 'Wire.API.Routes.Public.DescriptionOAuthScope'.
+--    This is only /documentation/: it appends a line to the endpoint description
+--    in the swagger docs and has no effect on request handling.
+--
+-- Forgetting (2) while doing (1) -- or, more commonly, adding a new version of an
+-- endpoint that is already covered by (1) and not carrying the annotation over --
+-- silently produces endpoints that reject OAuth tokens for a scope documented
+-- nowhere.  This module compares the two for the development version, which is
+-- the only one still assembled from the routing tables.
+module Test.Wire.API.Routes.OAuthScopes (tests) where
+
+import Data.Aeson qualified as A
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.ByteString.Conversion (toByteString')
+import Data.FileEmbed (embedFile, makeRelativeToProject)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Data.Yaml qualified as Yaml
+import Imports
+import Servant.API (toUrlPiece)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.Regex.TDFA ((=~))
+import Wire.API.OAuth (OAuthScope)
+import Wire.API.Routes.Public (renderOAuthScope)
+import Wire.API.Routes.Public.Swagger (devVersion, devVersionSwagger)
+import Wire.API.Routes.Version
+
+tests :: TestTree
+tests =
+  testGroup
+    "OAuth scopes (charts/nginz/values.yaml vs. swagger docs)"
+    [ testCase "nginz path patterns avoid PCRE-only constructs" testPatternVocabulary,
+      testCase "every nginz oauth_scope names a real scope" testScopeNamesAreReal,
+      testCase "enforced scopes and documented scopes agree" testScopesAgree
+    ]
+
+--------------------------------------------------------------------------------
+-- what nginz enforces
+
+-- | The locations nginz emits, in the order it emits them.
+--
+-- @charts/nginz/templates/_helpers.tpl@ merges @upstreams@ (minus
+-- @ignored_upstreams@) with the enabled @extra_upstreams@ into a single map, and
+-- @templates/conf/_nginx.conf.tpl@ ranges over that map.  Go template map
+-- iteration is sorted by key, so upstreams are emitted alphabetically and only
+-- the list within one upstream keeps its document order -- which is exactly what
+-- decoding into a 'Map' and taking 'Map.elems' gives us.
+newtype NginzLocations = NginzLocations [Location]
+
+data Location = Location
+  { locPattern :: Text,
+    locScope :: Maybe Text
+  }
+
+-- | The scopes that get an OAuth token past nginz to this endpoint.
+--
+-- Empty when nginz requires no scope, and also when it requires one
+-- not in 'Wire.API.OAuth.OAuthScopes'.  Mistyped scope names are
+-- caught by 'testScopeNamesAreReal'.
+enforcedScopes :: Text -> Text -> Set Text
+enforcedScopes method path =
+  fromMaybe Set.empty $ do
+    loc <- find (`locationMatches` path) nginzLocations
+    base <- locScope loc
+    pure . Set.intersection grantableScopes . Set.fromList $
+      [tier <> ":" <> base | tier <- methodScopeTiers method]
+
+nginzLocations :: [Location]
+nginzLocations =
+  case Yaml.decodeEither' $(embedFile =<< makeRelativeToProject "../../charts/nginz/values.yaml") of
+    Left e -> error $ "charts/nginz/values.yaml: " <> Yaml.prettyPrintParseException e
+    Right (NginzLocations ls) -> ls
+
+instance A.FromJSON NginzLocations where
+  parseJSON = A.withObject "charts/nginz/values.yaml" $ \top -> do
+    conf <- top A..: "nginx_conf"
+    ups <- conf A..: "upstreams"
+    extra <- conf A..:? "extra_upstreams" A..!= Map.empty
+    ignored <- conf A..:? "ignored_upstreams" A..!= []
+    enabled <- conf A..:? "enabled_extra_upstreams" A..!= []
+    pure
+      . NginzLocations
+      . concat
+      . Map.elems
+      $ Map.withoutKeys ups (Set.fromList (ignored :: [Text]))
+        <> Map.restrictKeys extra (Set.fromList (enabled :: [Text]))
+
+instance A.FromJSON Location where
+  parseJSON = A.withObject "nginz upstream entry" $ \o ->
+    Location <$> o A..: "path" <*> o A..:? "oauth_scope"
+
+-- | Does this location capture that path?  nginx anchors regex locations at the
+-- start of the URI but not at the end, so a pattern without a trailing @$@
+-- matches every path with that prefix.
+--
+-- The patterns are PCRE (that is what nginx uses) and we match them with
+-- regex-tdfa, which is POSIX ERE.  The two agree on the handful of constructs
+-- values.yaml actually uses; 'testPatternVocabulary' keeps it that way.
+locationMatches :: Location -> Text -> Bool
+locationMatches loc path =
+  T.unpack (probePath path) =~ T.unpack ("^" <> locPattern loc)
+
+-- | @/conversations/{cnv}/code@ becomes @/conversations/PARAM/code@: the literal
+-- segments still have to match, the captures must not.
+probePath :: Text -> Text
+probePath t =
+  let (before, rest) = T.breakOn "{" t
+   in if T.null rest
+        then before
+        else before <> "PARAM" <> probePath (T.drop 1 (T.dropWhile (/= '}') rest))
+
+pcreOnlyConstructs :: [Text]
+pcreOnlyConstructs = ["(?", "\\", "{", "*?", "+?"]
+
+-- | @oauth_scope: foo@ in values.yaml names a scope without a tier; libzauth
+-- decides which tiers satisfy it from the request method.  See @verify_scope@ in
+-- @libs/libzauth/libzauth/src/oauth.rs@
+methodScopeTiers :: Text -> [Text]
+methodScopeTiers = \case
+  "GET" -> ["read", "write", "admin"]
+  "POST" -> ["write", "admin"]
+  "PUT" -> ["write", "admin"]
+  "DELETE" -> ["admin"]
+  _ -> []
+
+--------------------------------------------------------------------------------
+-- what the swagger docs claim
+
+documentedScopes :: Text -> Set Text
+documentedScopes descr =
+  Set.fromList
+    [ T.decodeUtf8 (toByteString' scope)
+    | scope <- [minBound .. maxBound] :: [OAuthScope],
+      -- Recognise a documented scope by the very string
+      -- 'renderOAuthScope' produces, so that the two cannot drift
+      -- apart.
+      renderOAuthScope scope `T.isInfixOf` descr
+    ]
+
+httpMethods :: [Text]
+httpMethods = ["GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "TRACE"]
+
+-- | @(path, method, description)@ for every operation in a swagger document.
+operations :: A.Value -> [(Text, Text, Text)]
+operations doc = do
+  paths <- maybeToList (object doc >>= KeyMap.lookup "paths" >>= object)
+  (path, pathItem) <- KeyMap.toList paths
+  item <- maybeToList (object pathItem)
+  (method, op) <- KeyMap.toList item
+  let method' = T.toUpper (Key.toText method)
+  guard (method' `elem` httpMethods)
+  pure (Key.toText path, method', fromMaybe "" (object op >>= KeyMap.lookup "description" >>= string))
+  where
+    object = \case A.Object o -> Just o; _ -> Nothing
+    string = \case A.String s -> Just s; _ -> Nothing
+
+--------------------------------------------------------------------------------
+-- the comparison
+
+-- | 'Finding's are interesting iff @fEnforced /= fDocumented@.
+data Finding = Finding
+  { fVersion :: Version,
+    fMethod :: Text,
+    fPath :: Text,
+    fEnforced :: Set Text,
+    fDocumented :: Set Text
+  }
+
+-- | The scopes brig can actually issue.  Anything else is not a scope at all:
+-- 'Wire.API.OAuth.OAuthScopes' fails to parse it, and yields the empty scope set
+-- for the whole request.
+grantableScopes :: Set Text
+grantableScopes =
+  Set.fromList [T.decodeUtf8 (toByteString' s) | s <- [minBound .. maxBound] :: [OAuthScope]]
+
+renderFinding :: Finding -> Text
+renderFinding f =
+  T.intercalate
+    "\t"
+    [ toUrlPiece (fVersion f),
+      fMethod f,
+      fPath f,
+      renderScopes (fEnforced f),
+      renderScopes (fDocumented f)
+    ]
+  where
+    renderScopes s
+      | Set.null s = "-"
+      | otherwise = T.intercalate " " (Set.toAscList s)
+
+findings :: [Finding]
+findings =
+  [ Finding devVersion method path enforced documented
+  | (path, method, descr) <- operations (A.toJSON devVersionSwagger),
+    let enforced = enforcedScopes method path,
+    let documented = documentedScopes descr,
+    enforced /= documented
+  ]
+
+--------------------------------------------------------------------------------
+-- the actual tests
+
+testPatternVocabulary :: Assertion
+testPatternVocabulary =
+  for_ nginzLocations $ \loc ->
+    for_ pcreOnlyConstructs $ \bad ->
+      when (bad `T.isInfixOf` locPattern loc) $
+        assertFailure . T.unpack $
+          "charts/nginz/values.yaml: the path pattern "
+            <> locPattern loc
+            <> " uses '"
+            <> bad
+            <> "', which nginx reads as PCRE but this test matches with regex-tdfa, "
+            <> "i.e. POSIX ERE.  The two may disagree, which would be bad."
+
+-- | 'enforcedScopes' ignores scopes brig cannot issue, so a typo in an
+-- @oauth_scope:@ would otherwise make every endpoint under it drop silently out
+-- of the comparison.  Require that each name is usable at some tier.
+testScopeNamesAreReal :: Assertion
+testScopeNamesAreReal =
+  for_ (nub (mapMaybe locScope nginzLocations)) $ \base ->
+    unless (any (\tier -> (tier <> ":" <> base) `Set.member` grantableScopes) ["read", "write", "admin"]) $
+      assertFailure . T.unpack $
+        "charts/nginz/values.yaml: 'oauth_scope: "
+          <> base
+          <> "' matches no scope in Wire.API.OAuth.OAuthScope at any tier, so no "
+          <> "OAuth token can ever satisfy it and every endpoint under that "
+          <> "location is closed to OAuth.\nEither fix the name, or add the scope."
+
+testScopesAgree :: Assertion
+testScopesAgree = do
+  unless (Set.null actual) . assertFailure . T.unpack . T.unlines $
+    [ "OAuth scope declarations are out of sync.",
+      "",
+      "Columns: version, method, path, accepted by nginz, documented in swagger.",
+      "'-' means no scope. A finding means those last two disagree:",
+      "",
+      "  enforced but not documented  charts/nginz/values.yaml requires a scope the",
+      "                               swagger docs do not mention -- most likely a",
+      "                               missing DescriptionOAuthScope in the routing",
+      "                               table, e.g. on a newly added version of an",
+      "                               endpoint that already had one.",
+      "  documented but not enforced  the swagger docs promise a scope nginz does not",
+      "                               require -- a stale annotation, or a missing",
+      "                               oauth_scope: in charts/nginz/values.yaml.",
+      ""
+    ]
+      <> section "deviations:" actual
+  where
+    actual = Set.fromList (renderFinding <$> findings)
+    section title xs
+      | Set.null xs = []
+      | otherwise = ["  " <> title] <> (("    " <>) <$> Set.toAscList xs) <> [""]

--- a/libs/wire-api/test/unit/Test/Wire/API/Run.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Run.hs
@@ -34,6 +34,7 @@ import Test.Wire.API.Roundtrip.HttpApiData qualified as Roundtrip.HttpApiData
 import Test.Wire.API.Roundtrip.MLS qualified as Roundtrip.MLS
 import Test.Wire.API.Roundtrip.PostgresMarshall as PostgresMarshall
 import Test.Wire.API.Routes qualified as Routes
+import Test.Wire.API.Routes.OAuthScopes qualified as Routes.OAuthScopes
 import Test.Wire.API.Routes.Version qualified as Routes.Version
 import Test.Wire.API.Routes.Version.Wai qualified as Routes.Version.Wai
 import Test.Wire.API.Swagger qualified as Swagger
@@ -63,6 +64,7 @@ main =
         Swagger.tests,
         Roundtrip.CSV.tests,
         Routes.tests,
+        Routes.OAuthScopes.tests,
         Conversation.tests,
         Meeting.tests,
         MLS.tests,

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -219,6 +219,7 @@ library
     Wire.API.Routes.Public.Gundeck
     Wire.API.Routes.Public.Proxy
     Wire.API.Routes.Public.Spar
+    Wire.API.Routes.Public.Swagger
     Wire.API.Routes.Public.Util
     Wire.API.Routes.QualifiedCapture
     Wire.API.Routes.SpecialiseToVersion
@@ -726,6 +727,7 @@ test-suite wire-api-tests
     Test.Wire.API.Roundtrip.MLS
     Test.Wire.API.Roundtrip.PostgresMarshall
     Test.Wire.API.Routes
+    Test.Wire.API.Routes.OAuthScopes
     Test.Wire.API.Routes.Version
     Test.Wire.API.Routes.Version.Wai
     Test.Wire.API.Run
@@ -751,6 +753,7 @@ test-suite wire-api-tests
     , containers             >=0.5
     , crypton
     , data-default
+    , file-embed
     , filepath
     , hex
     , hspec
@@ -764,6 +767,7 @@ test-suite wire-api-tests
     , QuickCheck
     , ram
     , random
+    , regex-tdfa
     , schema-profunctor
     , servant
     , servant-server
@@ -780,6 +784,7 @@ test-suite wire-api-tests
     , vector
     , wai
     , wire-api
+    , yaml
 
   ghc-options:
     -threaded -with-rtsopts=-N -Wunused-packages -Wno-x-partial

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -753,6 +753,7 @@ test-suite wire-api-tests
     , containers             >=0.5
     , crypton
     , data-default
+    , directory
     , file-embed
     , filepath
     , hex
@@ -776,6 +777,7 @@ test-suite wire-api-tests
     , tasty-hspec
     , tasty-hunit
     , tasty-quickcheck
+    , template-haskell
     , text
     , time
     , types-common           >=0.16

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -753,7 +753,6 @@ test-suite wire-api-tests
     , containers             >=0.5
     , crypton
     , data-default
-    , directory
     , file-embed
     , filepath
     , hex

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -159,6 +159,22 @@ let
     inherit hlib mls-test-cli;
   });
 
+  # 'Test.Wire.API.Routes.OAuthScopes' checks the OAuth scopes nginz enforces
+  # against the ones the swagger docs advertise, so it needs
+  # charts/nginz/values.yaml at compile time.  Only a package's own directory is
+  # copied into the build sandbox, so splice the chart in -- and by making it
+  # part of 'src', changing the chart also invalidates the build.
+  wireApiWithNginzChart = hself: hsuper: {
+    wire-api = hlib.overrideCabal hsuper.wire-api (old: {
+      src = pkgs.runCommand "wire-api-src" { } ''
+        cp -r ${old.src} $out
+        chmod -R u+w $out
+        mkdir -p $out/test/unit/generated
+        cp ${../charts/nginz/values.yaml} $out/test/unit/generated/nginz-values.yaml
+      '';
+    });
+  };
+
   executables = hself: hsuper:
     attrsets.genAttrs (builtins.attrNames executablesMap) (e: withCleanedPath hsuper.${e});
 
@@ -173,6 +189,7 @@ let
     overrides = lib.composeManyExtensions [
       pinnedPackages
       (localPackages localMods)
+      wireApiWithNginzChart
       manualOverrides
       executables
       staticExecutables

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -244,21 +244,8 @@ internalEndpointsSwaggerDocsAPIs =
 -- Dual to `internalEndpointsSwaggerDocsAPI`.
 versionedSwaggerDocsAPI :: Servant.Server VersionedSwaggerDocsAPI
 versionedSwaggerDocsAPI (Just (VersionNumber V17)) =
-  swaggerSchemaUIServer $
-    ( serviceSwagger @VersionAPITag @'V17
-        <> serviceSwagger @BrigAPITag @'V17
-        <> serviceSwagger @GalleyAPITag @'V17
-        <> serviceSwagger @SparAPITag @'V17
-        <> serviceSwagger @CargoholdAPITag @'V17
-        <> serviceSwagger @CannonAPITag @'V17
-        <> serviceSwagger @GundeckAPITag @'V17
-        <> serviceSwagger @ProxyAPITag @'V17
-        <> serviceSwagger @OAuthAPITag @'V17
-    )
-      & S.info . S.title .~ "Wire-Server API"
-      & S.info . S.description ?~ $((unTypeCode . embedText) =<< makeRelativeToProject "docs/swagger.md")
-      & S.servers .~ [S.Server ("/" <> toUrlPiece V17) Nothing mempty]
-      & cleanupSwagger
+  swaggerSchemaUIServer devVersionSwaggerserviceSwagger
+    & S.info . S.description ?~ $((unTypeCode . embedText) =<< makeRelativeToProject "docs/swagger.md")
 versionedSwaggerDocsAPI (Just (VersionNumber V16)) = swaggerPregenUIServer $(pregenSwagger V16)
 versionedSwaggerDocsAPI (Just (VersionNumber V15)) = swaggerPregenUIServer $(pregenSwagger V15)
 versionedSwaggerDocsAPI (Just (VersionNumber V14)) = swaggerPregenUIServer $(pregenSwagger V14)

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -55,7 +55,7 @@ import Brig.User.Client qualified as API
 import Cassandra qualified as C
 import Cassandra qualified as Data
 import Control.Error hiding (bool, note)
-import Control.Lens ((.~), (?~))
+import Control.Lens ((?~))
 import Control.Monad.Except
 import Data.Aeson
 import Data.ByteString (fromStrict)
@@ -111,7 +111,6 @@ import Wire.API.Federation.Error
 import Wire.API.Federation.Version qualified as Fed
 import Wire.API.Pagination
 import Wire.API.Properties qualified as Public
-import Wire.API.Routes.API
 import Wire.API.Routes.Bearer
 import Wire.API.Routes.Internal.Brig qualified as BrigInternalAPI
 import Wire.API.Routes.Internal.Cannon qualified as CannonInternalAPI
@@ -123,13 +122,7 @@ import Wire.API.Routes.MultiTablePaging qualified as Public
 import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Routes.Public.Brig
 import Wire.API.Routes.Public.Brig.DomainVerification
-import Wire.API.Routes.Public.Brig.OAuth
-import Wire.API.Routes.Public.Cannon
-import Wire.API.Routes.Public.Cargohold
-import Wire.API.Routes.Public.Galley
-import Wire.API.Routes.Public.Gundeck
-import Wire.API.Routes.Public.Proxy
-import Wire.API.Routes.Public.Spar
+import Wire.API.Routes.Public.Swagger
 import Wire.API.Routes.Public.Util
 import Wire.API.Routes.Version
 import Wire.API.SwaggerHelper (cleanupSwagger)
@@ -244,8 +237,9 @@ internalEndpointsSwaggerDocsAPIs =
 -- Dual to `internalEndpointsSwaggerDocsAPI`.
 versionedSwaggerDocsAPI :: Servant.Server VersionedSwaggerDocsAPI
 versionedSwaggerDocsAPI (Just (VersionNumber V17)) =
-  swaggerSchemaUIServer devVersionSwaggerserviceSwagger
-    & S.info . S.description ?~ $((unTypeCode . embedText) =<< makeRelativeToProject "docs/swagger.md")
+  swaggerSchemaUIServer $
+    devVersionSwagger
+      & S.info . S.description ?~ $((unTypeCode . embedText) =<< makeRelativeToProject "docs/swagger.md")
 versionedSwaggerDocsAPI (Just (VersionNumber V16)) = swaggerPregenUIServer $(pregenSwagger V16)
 versionedSwaggerDocsAPI (Just (VersionNumber V15)) = swaggerPregenUIServer $(pregenSwagger V15)
 versionedSwaggerDocsAPI (Just (VersionNumber V14)) = swaggerPregenUIServer $(pregenSwagger V14)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-28132

This PR fixes two places where the swagger mention of an oauth scope accepted by nginz was forgotten.

It also adds a unit test.  In the future, if anybody changes the latest (dev) version in a way that an oauth scope is either:

- documented, but not enforced,
- enforced, but not documented, or
- enforced, but not part of `data OAuthScope`,

you get a failing test case pointing you to the problem:

```
    every nginz oauth_scope names a real scope:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             FAIL (0.01s)
      Error message: charts/nginz/values.yaml: 'oauth_scope: thisscopedoesntevenexistwhatsgoingon' matches no scope in Wire.API.OAuth.OAuthScope at any tier, so no OAuth token can ever satisfy it and every endpoint under that location is closed to OAuth.
      Either fix the name, or add the scope.

      CallStack (from HasCallStack):
        assertFailure, called at test/unit/Test/Wire/API/Routes/OAuthScopes.hs:298:7 in wire-api-0.1.0-inplace-wire-api-tests:Test.Wire.API.Routes.OAuthScopes
      Use -p '/every nginz oauth_scope names a real scope/' to rerun this test only.
    enforced scopes and documented scopes agree:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            FAIL (0.20s)
      Error message: OAuth scope declarations are out of sync.

      Columns: version, method, path, accepted by nginz, documented in swagger.
      '-' means no scope. A finding means those last two disagree:

        enforced but not documented  charts/nginz/values.yaml requires a scope the
                                     swagger docs do not mention -- most likely a
                                     missing DescriptionOAuthScope in the routing
                                     table, e.g. on a newly added version of an
                                     endpoint that already had one.
        documented but not enforced  the swagger docs promise a scope nginz does not
                                     require -- a stale annotation, or a missing
                                     oauth_scope: in charts/nginz/values.yaml.

        deviations:
          v17	GET	/self	-	read:self
          v17	GET	/teams/notifications	write:conversations	-
          v17	GET	/teams/{tid}	write:conversations	-
          v17	PUT	/teams/{tid}	write:conversations	-



      CallStack (from HasCallStack):
        assertFailure, called at test/unit/Test/Wire/API/Routes/OAuthScopes.hs:307:30 in wire-api-0.1.0-inplace-wire-api-tests:Test.Wire.API.Routes.OAuthScopes
      Use -p '/enforced scopes and documented scopes agree/' to rerun this test only.
```


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)