### PR TITLE
backport[2025-q2]: reaper: updating kubectl image, detection script, rbac

### DIFF
--- a/changelog.d/0-release-notes/reaper-image-and-rbac
+++ b/changelog.d/0-release-notes/reaper-image-and-rbac
@@ -1,29 +1,12 @@
-The `reaper` chart no longer grants itself `cluster-admin`, and no longer uses an
-unmaintained container image. Two operator-visible changes:
+The `reaper` chart no longer grants itself `cluster-admin` and no longer uses an
+unmaintained container image. Upgrading is a drop-in `helm upgrade`; no manual steps.
 
-* **RBAC.** The chart used to create a fixed-name `ClusterRoleBinding` (`reaper-role`)
-  binding its ServiceAccount to `cluster-admin`, which gave the pod read access to every
-  Secret in the cluster. It now creates a namespaced `Role`/`RoleBinding` granting only
-  `get`, `list`, `watch` and `delete` on pods, bound to a `<release>-reaper`
-  ServiceAccount. (`watch` is required because `kubectl delete pod` waits for the pod to
-  disappear and opens a watch to do so.)
-  `helm upgrade` removes the old `ClusterRoleBinding` and the old `reaper-role`
-  ServiceAccount.
+Two cases need action:
 
-* **Image.** The default image changed from `docker.io/bitnamilegacy/kubectl:1.32.4`
-  to `docker.io/alpine/kubectl:1.36.3`. Operators overriding `image` in their values must
-  update the override; note the image must contain a POSIX shell at `/bin/sh`, so
-  distroless kubectl images do not work.
-  `image.digest`, `image.pullPolicy` and `imagePullSecrets` are now supported, and
-  `image.registry` may be set to `""` for an unqualified repository. Operators mirroring
-  images into a private registry for airgapped installs need to add the new image.
+* If you override `image` in your values, update the override: the default changed from
+  `docker.io/bitnamilegacy/kubectl:1.32.4` to `docker.io/alpine/kubectl:1.36.3`. The
+  image must contain a POSIX shell at `/bin/sh` — distroless kubectl images do not work.
+* If you mirror images into a private registry (airgapped installs), add the new image.
 
-The reaper also distinguishes "could not reach the API" from "there are no matching pods"
-in its logs, and includes the underlying error. Previously both cases printed
-`Failed to list pods. Skipping this iteration...`, so a reaper that could not list pods at
-all was indistinguishable from an idle one.
-
-The container now runs as uid/gid 65534 with a read-only root filesystem, has resource
-requests and limits, and honours `nodeSelector`, `tolerations` and `affinity`. The poll
-interval is configurable via `checkIntervalSeconds` and defaults to 15s, down from one
-pod list per second against the API server.
+See `charts/reaper/README.md` for the image settings, the RBAC the chart now creates,
+and the rest of the changes.

--- a/changelog.d/0-release-notes/reaper-image-and-rbac
+++ b/changelog.d/0-release-notes/reaper-image-and-rbac
@@ -1,0 +1,29 @@
+The `reaper` chart no longer grants itself `cluster-admin`, and no longer uses an
+unmaintained container image. Two operator-visible changes:
+
+* **RBAC.** The chart used to create a fixed-name `ClusterRoleBinding` (`reaper-role`)
+  binding its ServiceAccount to `cluster-admin`, which gave the pod read access to every
+  Secret in the cluster. It now creates a namespaced `Role`/`RoleBinding` granting only
+  `get`, `list`, `watch` and `delete` on pods, bound to a `<release>-reaper`
+  ServiceAccount. (`watch` is required because `kubectl delete pod` waits for the pod to
+  disappear and opens a watch to do so.)
+  `helm upgrade` removes the old `ClusterRoleBinding` and the old `reaper-role`
+  ServiceAccount.
+
+* **Image.** The default image changed from `docker.io/bitnamilegacy/kubectl:1.32.4`
+  to `docker.io/alpine/kubectl:1.36.3`. Operators overriding `image` in their values must
+  update the override; note the image must contain a POSIX shell at `/bin/sh`, so
+  distroless kubectl images do not work.
+  `image.digest`, `image.pullPolicy` and `imagePullSecrets` are now supported, and
+  `image.registry` may be set to `""` for an unqualified repository. Operators mirroring
+  images into a private registry for airgapped installs need to add the new image.
+
+The reaper also distinguishes "could not reach the API" from "there are no matching pods"
+in its logs, and includes the underlying error. Previously both cases printed
+`Failed to list pods. Skipping this iteration...`, so a reaper that could not list pods at
+all was indistinguishable from an idle one.
+
+The container now runs as uid/gid 65534 with a read-only root filesystem, has resource
+requests and limits, and honours `nodeSelector`, `tolerations` and `affinity`. The poll
+interval is configurable via `checkIntervalSeconds` and defaults to 15s, down from one
+pod list per second against the API server.

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -3,3 +3,8 @@ version: 0.0.42
 name: reaper
 appVersion: 0.1.0
 description: A helm charts to restart cannons if redis-ephemeal has died
+annotations:
+  # must conform to https://github.com/helm/community/blob/main/hips/hip-0015.md
+  helm.sh/images: |
+    - name: kubectl
+      image: docker.io/alpine/kubectl:1.36.3

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -40,3 +40,32 @@ RBAC
 
 The chart creates a namespaced `Role`/`RoleBinding` granting `get`, `list`, `watch` and
 `delete` on pods, bound to a `<release>-reaper` ServiceAccount.
+
+`watch` is required even though the script never watches anything explicitly:
+`kubectl delete pod` blocks until the pod is gone and opens a watch to do so. Without it
+the reaper deletes the first cannon and then hangs, without crashing.
+
+Earlier versions bound the ServiceAccount to `cluster-admin` through a fixed-name
+`ClusterRoleBinding`, which gave the pod read access to every Secret in the cluster.
+`helm upgrade` removes that binding and the old `reaper-role` ServiceAccount. Because
+nothing is cluster-scoped any more and all names are release-scoped, several reaper
+releases can now coexist in one cluster; previously a second release failed to install
+with a `ClusterRoleBinding` ownership conflict.
+
+Runtime
+-------
+
+The container runs as uid/gid 65534 with a read-only root filesystem and has resource
+requests and limits. `nodeSelector`, `tolerations` and `affinity` are honoured.
+
+`checkIntervalSeconds` (default `15`) controls how long the script waits between checks.
+Earlier versions listed pods once per second.
+
+Logs distinguish a failure to reach the API from "there are no matching pods", and
+include the underlying error:
+
+    Failed to list pods: Error from server (Forbidden): ... Skipping this iteration...
+    No cannon pods found. Doing nothing...
+
+Both cases previously printed `Failed to list pods. Skipping this iteration...`, so a
+reaper that could not list pods at all looked exactly like an idle one.

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -14,3 +14,29 @@ messages. Here, this reaper will check that the `redis-ephemeral` pod is older t
 other `cannon`; if that is not the case, it kills the `cannon`s forcing clients to
 reconnect.
 
+Image
+-----
+
+The reaper runs `scripts/reaper.sh` through `kubectl`, so `image` must point at a
+kubectl image that **contains a POSIX shell** at `/bin/sh`. Distroless kubectl images
+do not ship one and the pod will fail to start. The script itself is POSIX sh, so
+busybox `ash` is enough, bash not required.
+
+The image is fully configurable:
+
+```yaml
+image:
+  registry: docker.io      # set to "" for an unqualified repository
+  repository: alpine/kubectl
+  tag: 1.36.3
+  digest: ""               # e.g. "sha256:..."; takes precedence over tag
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: my-pull-secret
+```
+
+RBAC
+----
+
+The chart creates a namespaced `Role`/`RoleBinding` granting `get`, `list`, `watch` and
+`delete` on pods, bound to a `<release>-reaper` ServiceAccount.

--- a/charts/reaper/scripts/reaper.sh
+++ b/charts/reaper/scripts/reaper.sh
@@ -1,25 +1,32 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # See the readme of the reaper chart.
+#
+# This is POSIX sh on purpose: the only actively maintained kubectl images that
+# ship busybox ash, not bash.
 
 # we loop forever, and on transient errors sleep and try again.
 # setting -e would crash the pod on transient e.g. network errors, which isn't useful.
-set -uo pipefail
+set -u
+# shellcheck disable=SC3040 # busybox ash supports pipefail
+set -o pipefail
 
-USAGE="$0 <NAMESPACE>"
+USAGE="$0 <NAMESPACE> [INTERVAL_SECONDS]"
 NAMESPACE="${1:?$USAGE}"
+INTERVAL="${2:-15}"
 
-echo "Using namespace: $NAMESPACE"
+echo "Using namespace: $NAMESPACE, check interval: ${INTERVAL}s"
 
 kill_all_cannons() {
   echo "Killing all cannons"
-  CANNON_PODS=$(kubectl -n "$NAMESPACE" get pods 2>/dev/null \
-    | grep -e "cannon" \
-    | awk '{ print $1 }') || {
-    echo "Failed to list cannon pods. Skipping this iteration..."
+  RAW_PODS=$(kubectl -n "$NAMESPACE" get pods 2>&1) || {
+    echo "Failed to list cannon pods: $RAW_PODS. Skipping this iteration..."
     return
   }
+  CANNON_PODS=$(echo "$RAW_PODS" | grep -e "cannon" | awk '{ print $1 }') || CANNON_PODS=""
 
+  # A here-document rather than a pipeline, so the loop runs in the current
+  # shell and the `exit 1` below actually terminates the script.
   while IFS= read -r cannon; do
     if [ -n "$cannon" ]; then
       echo "Deleting $cannon"
@@ -29,29 +36,33 @@ kill_all_cannons() {
         exit 1
       }
     fi
-  done <<< "$CANNON_PODS"
+  done <<EOF
+$CANNON_PODS
+EOF
 }
 
 while true; do
-  # Gather all pods that contain "cannon" or "redis-ephemeral", sorted by creation time
-  ALL_PODS=$(kubectl -n "$NAMESPACE" get pods --sort-by=.metadata.creationTimestamp 2>/dev/null \
-    | grep -e "cannon" -e "redis-ephemeral") || {
-      echo "Failed to list pods. Skipping this iteration..."
-      sleep 60
-      continue
+  # List first, filter second. Folding both into one pipeline made an API failure.
+  RAW_PODS=$(kubectl -n "$NAMESPACE" get pods --sort-by=.metadata.creationTimestamp 2>&1) || {
+    echo "Failed to list pods: $RAW_PODS. Skipping this iteration..."
+    sleep "$INTERVAL"
+    continue
   }
+
+  # Gather all pods that contain "cannon" or "redis-ephemeral", sorted by creation time
+  ALL_PODS=$(echo "$RAW_PODS" | grep -e "cannon" -e "redis-ephemeral") || ALL_PODS=""
 
   # Check if we have any cannon pods at all
   if ! echo "$ALL_PODS" | grep -q "cannon"; then
     echo "No cannon pods found. Doing nothing..."
-    sleep 60
+    sleep "$INTERVAL"
     continue
   fi
 
   # Check if we have any redis-ephemeral pods at all
   if ! echo "$ALL_PODS" | grep -q "redis-ephemeral"; then
     echo "No redis-ephemeral pod found. Doing nothing..."
-    sleep 60
+    sleep "$INTERVAL"
     continue
   fi
 
@@ -61,17 +72,18 @@ while true; do
 
   if [ -z "$FIRST_POD" ]; then
     echo "Could not determine the oldest pod from the list. Doing nothing..."
-    sleep 60
+    sleep "$INTERVAL"
     continue
   fi
 
-  if [[ "$FIRST_POD" =~ "redis-ephemeral" ]]; then
-    echo "redis-ephemeral is the oldest pod, all good."
-  else
-    kill_all_cannons
-  fi
+  case "$FIRST_POD" in
+    *redis-ephemeral*)
+      echo "redis-ephemeral is the oldest pod, all good."
+      ;;
+    *)
+      kill_all_cannons
+      ;;
+  esac
 
-  echo "Sleep 1"
-  sleep 1
+  sleep "$INTERVAL"
 done
-

--- a/charts/reaper/templates/_helpers.tpl
+++ b/charts/reaper/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}
+
+{{- define "includeSecurityContext" -}}
+  {{- (semverCompare ">= 1.24-0" (include "kubeVersion" .)) -}}
+{{- end -}}
+
+{{/* Fully qualified image reference, digest taking precedence over tag. */}}
+{{- define "reaper.image" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if .Values.image.registry -}}
+{{- $repository = printf "%s/%s" .Values.image.registry .Values.image.repository -}}
+{{- end -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repository (.Values.image.tag | toString) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Release-scoped name for the ServiceAccount, Role and RoleBinding. */}}
+{{- define "reaper.serviceAccountName" -}}
+{{- printf "%s-reaper" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -18,8 +18,16 @@ spec:
       labels:
         app: reaper
         release: {{ .Release.Name }}
+      annotations:
+        # Ensure changes to the script cause a redeployment upon `helm upgrade`
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: reaper-role
+      serviceAccountName: {{ include "reaper.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"
@@ -29,12 +37,38 @@ spec:
               app: reaper
       containers:
         - name: reaper
-          image: bitnamilegacy/kubectl:1.32.2
-          command: ["/app/reaper.sh", "{{ .Release.Namespace }}"]
+          image: {{ include "reaper.image" . | quote }}
+          imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+          command: ["/bin/sh", "/app/reaper.sh", "{{ .Release.Namespace }}", "{{ .Values.checkIntervalSeconds }}"]
+        {{- if eq (include "includeSecurityContext" .) "true" }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+        {{- end }}
+          env:
+            # kubectl writes its discovery cache below $HOME; the root
+            # filesystem is read-only, so point it at the emptyDir.
+            - name: HOME
+              value: /tmp
           volumeMounts:
             - name: reaper-script
               mountPath: /app
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: reaper-script
           configMap:
@@ -43,4 +77,5 @@ spec:
             items:
               - key: reaper.sh
                 path: reaper.sh
-
+        - name: tmp
+          emptyDir: {}

--- a/charts/reaper/templates/rbac.yaml
+++ b/charts/reaper/templates/rbac.yaml
@@ -1,17 +1,38 @@
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: reaper-role
-subjects:
-- kind: ServiceAccount
-  name: reaper-role
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: reaper-role
+  name: {{ include "reaper.serviceAccountName" . }}
+  labels:
+    app: reaper
+    release: {{ .Release.Name }}
+---
+# The reaper only ever lists and deletes pods in its own namespace, so a
+# namespaced Role is sufficient.
+# `watch` is required even though the script never watches anything explicitly.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "reaper.serviceAccountName" . }}
+  labels:
+    app: reaper
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "reaper.serviceAccountName" . }}
+  labels:
+    app: reaper
+    release: {{ .Release.Name }}
+roleRef:
+  kind: Role
+  name: {{ include "reaper.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "reaper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/reaper/values.yaml
+++ b/charts/reaper/values.yaml
@@ -1,9 +1,45 @@
+image:
+  # The reaper executes a shell script through kubectl, so this image must
+  # contain a POSIX shell at /bin/sh. Distroless kubectl images do not
+  # ship one and the pod will fail to start with them.
+  #
+  # Set `registry` to "" to use an unqualified repository (e.g. when mirroring
+  # into a registry configured as the daemon default).
+  registry: docker.io
+  repository: alpine/kubectl
+  tag: 1.36.3
+  # Optional: pin by digest (e.g. "sha256:abc..."). Takes precedence over `tag`.
+  digest: ""
+  pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
+# How long to wait between two checks, in seconds. The condition this chart
+# watches for (a redis-ephemeral restart) is rare, so there is no reason to poll
+# the API server aggressively.
+checkIntervalSeconds: 15
+
+resources:
+  requests:
+    memory: 32Mi
+    cpu: 10m
+  limits:
+    memory: 64Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Applied as the container securityContext. runAsUser/runAsGroup are set
+# explicitly because alpine/kubectl runs as root by default.
 podSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
Backport of #5444 to `2025-q2`.

https://wearezeta.atlassian.net/browse/WPB-27995

The gov bundle consumes charts built from this branch, so `reaper` was the last
chart in the wire-server family still missing its HIP-15 `helm.sh/images`
annotation after #5438. Backporting the whole change rather than the annotation
alone also removes the `cluster-admin` binding and the unmaintained
`bitnamilegacy` image from the gov line.

## Changes

Cherry-picked unchanged from #5444; all files are byte-identical to `develop`.

* **Image** — `docker.io/bitnamilegacy/kubectl:1.32.2` → `docker.io/alpine/kubectl:1.36.3`,
  now configurable (`registry`/`repository`/`tag`/`digest`/`pullPolicy`) instead of
  hardcoded in the template. `scripts/reaper.sh` rewritten in POSIX sh.
* **RBAC** — `ClusterRoleBinding` to `cluster-admin` replaced by a namespaced `Role`
  granting `get`, `list`, `watch`, `delete` on pods. All names release-scoped.
* **HIP-15** — `helm.sh/images` annotation added, completing the set started in #5438.
* **Other** — `podSecurityContext` actually applied, uid/gid 65534, read-only root
  filesystem, resource requests/limits, `nodeSelector`/`tolerations`/`affinity`,
  configmap checksum annotation, configurable poll interval (was one pod LIST per
  second), clearer log messages.

## Conflicts

Two, both because `2025-q2` predates the values-driven image introduced on `develop`:
`values.yaml` and `templates/deployment.yaml`. Resolved by taking the incoming side of
each hunk; the resulting chart matches `develop` exactly.

## Testing

The change itself was verified end to end on `sde-dev-1` in #5444 (upgrade path, RBAC
boundary, functional reap, rollback, multi-namespace).

For the backport: `helm lint` passes, `shellcheck` clean on the rewritten script, and
the rendered output has the expected image, namespaced Role/RoleBinding with no
cluster-scoped objects, and the security context applied.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
