### PR TITLE
Disable and LOCK preventAdminlessGroups

### DIFF
--- a/changelog.d/0-release-notes/disable-preventAdminlessGroups.md
+++ b/changelog.d/0-release-notes/disable-preventAdminlessGroups.md
@@ -1,0 +1,3 @@
+The _prevent adminless groups_ feature has known bugs. Disable and lock it by
+Helm configuration for now. Development of this feature will continue, it
+should just not be used in production as-is.

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -260,9 +260,10 @@ galley:
               allowed_to_open_channels: team-members
             lockStatus: locked
         preventAdminlessGroups:
+          # This feature has known errors. Thus, it must stay disabled for now.
           defaults:
             status: disabled
-            lockStatus: unlocked
+            lockStatus: locked
             config:
               promotionStrategy: alphabetical
               deletionTimeoutDuration: 7d

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -420,6 +420,17 @@ galley:
           defaults:
             status: enabled
             lockStatus: unlocked
+        preventAdminlessGroups:
+          # FUTUREWORK: This feature should be unlocked in the main
+          # `values.yaml` file. It is just disabled & locked there due to open
+          # bugs.
+          defaults:
+            status: disabled
+            lockStatus: unlocked
+            config:
+              promotionStrategy: alphabetical
+              deletionTimeoutDuration: 7d
+              reminderTimeoutDurations: [2d, 4d, 6d]
     journal:
       endpoint: http://fake-aws-sqs:4568
       queueName: integration-team-events.fifo


### PR DESCRIPTION
The feature has known bugs and should thus not be used in production.

This commit unblocks releasing wire-server while letting us quickly resume development on this feature afterwards.

Ticket: https://wearezeta.atlassian.net/browse/WPB-28230

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
