### PR TITLE
fix: keep hoogle image haddock from hanging in CI

### DIFF
--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -407,7 +407,24 @@ let
   };
   wireServerPackages = (builtins.attrNames (localPackages localModsEnableAll { } { }));
 
-  hoogle = (hPkgs localModsOnlyDocs).hoogleWithPackages (p: builtins.map (e: p.${e}) wireServerPackages);
+  # Haddock for the hoogle image: the image serves the hoogle database and
+  # haddock HTML (nixpkgs hoogle.nix).  The quickjump index is not needed
+  # for hoogle search: galley's haddock has hung indefinitely in CI right
+  # before "Documentation created" (task timed out after 1h10m).  Haddock
+  # (and the -O0 compile) are also forced serial: parallel haddock
+  # (-j$NIX_BUILD_CORES) is the prime deadlock suspect.  This only affects
+  # the hoogle image, not the production docker images (built from
+  # imagesNoDocs, enableDocs = false).
+  hoogleHaddockOverrides = hself: hsuper:
+    builtins.mapAttrs
+      (_: drv:
+        hlib.overrideCabal
+          (hlib.disableParallelBuilding drv)
+          (old: { doHaddockQuickjump = false; }))
+      (lib.genAttrs wireServerPackages (name: hsuper.${name}));
+
+  hoogle = ((hPkgs localModsOnlyDocs).extend hoogleHaddockOverrides).hoogleWithPackages
+    (p: builtins.map (e: p.${e}) wireServerPackages);
 
   # More about dockerTools.streamLayeredImage:
   # https://nixos.org/manual/nixpkgs/unstable/#ssec-pkgs-dockerTools-streamLayeredImage


### PR DESCRIPTION
## Problem
The `upload-hoogle-nix` Concourse job regularly hangs: ~20 min of real build work, then silence until the 1h10m task ...
- Every derivation completes except **galley's haddock**: last output is `galley> Warning: … could not find link dest...
- Cachix exonerated: brig-doc narinfo from the failing run is 200, galley-doc 404 (never finished, never pushed).
- Self-sustaining loop: the docker-image job builds `imagesNoDocs` (`enableDocs = false`), so this job is the only CI...
- Hang site: the single haddock invocation (`--hoogle --quickjump --hyperlink-source -j4`) in final render. No local ...
## Change
`nix/wire-server.nix`: new `hoogleHaddockOverrides` applied via `.extend` to the hoogle package set only:
- `doHaddockQuickjump = false` — quickjump index unused by `hoogle server --local`
- `disableParallelBuilding` — serial haddock (parallel `-j$NIX_BUILD_CORES` is the prime deadlock suspect; also seria...
Scoped to the hoogle image only; production images (`imagesNoDocs`) and dev docs (`haskellPackages`) keep full haddoc...
## Verification
- `nix build -L --fallback .#wireServer.hoogleImage`: **exit 0 in 24m36s** (CI budget ≤ 50m), hyperlinked source intact, incl. `building hoogle ...
- `galley> Documentation created: …galley.txt`, `galley> haddockPhase completed in 1m12s`
- Hoogle DB intact without quickjump: `galley.txt` still contains 36 `Galley.API.Teams` entries
- `nix flake check`: fails identically on clean `develop` (`packages.x86_64-linux.pkgs is not a derivation`) — pre-ex...

