### PR TITLE
NewStoredUser: Remove handle

### DIFF
--- a/changelog.d/3-bug-fixes/reject-duplicate-handles
+++ b/changelog.d/3-bug-fixes/reject-duplicate-handles
@@ -1,0 +1,4 @@
+SCIM: Avoid assigning an already claimed handle to a user.
+
+Before this if SCIM created a user with a handle already claimed by another user
+the handle would get stored for the user even if the overall SCIM call fails.

--- a/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/AppSubsystem/Interpreter.hs
@@ -138,7 +138,7 @@ createAppImpl lusr tid newApp = do
   pure
     CreatedApp
       { user =
-          let usr :: User = newStoredUserToUser (tUntagged (qualifyAs lusr u))
+          let usr :: User = newStoredUserToUser (tUntagged (qualifyAs lusr u)) Nothing
               mbApp :: Maybe AppInfo = Just $ storedAppToAppInfo app
               lh = UserLegalHoldDisabled -- FUTUREWORK: this needs to be changed as soon as apps can be put under LH.
            in mkUserProfile EmailVisibleIfOnTeam usr mbApp lh,
@@ -276,7 +276,6 @@ appNewStoredUser creator new = do
         country = loc.lCountry,
         providerId = Nothing,
         serviceId = Nothing,
-        handle = Nothing,
         expires = Nothing,
         teamId = creator.teamId,
         managedBy = defaultManagedBy,

--- a/libs/wire-subsystems/src/Wire/StoredUser.hs
+++ b/libs/wire-subsystems/src/Wire/StoredUser.hs
@@ -205,7 +205,6 @@ data NewStoredUser = NewStoredUser
     country :: Maybe Country,
     providerId :: Maybe ProviderId,
     serviceId :: Maybe ServiceId,
-    handle :: Maybe Handle,
     teamId :: Maybe TeamId,
     managedBy :: ManagedBy,
     supportedProtocols :: Set BaseProtocolTag,
@@ -238,7 +237,6 @@ deriving instance
       Maybe Country,
       Maybe ProviderId,
       Maybe ServiceId,
-      Maybe Handle,
       Maybe TeamId,
       ManagedBy,
       Set BaseProtocolTag,
@@ -268,7 +266,7 @@ newStoredUserToStoredUser new =
       country = new.country,
       providerId = new.providerId,
       serviceId = new.serviceId,
-      handle = new.handle,
+      handle = Nothing,
       teamId = new.teamId,
       managedBy = Just new.managedBy,
       supportedProtocols = Just new.supportedProtocols,
@@ -277,8 +275,8 @@ newStoredUserToStoredUser new =
 
 -- This saves the identity from `NewStoredUser` even if the user is
 -- not activated.
-newStoredUserToUser :: Qualified NewStoredUser -> User
-newStoredUserToUser (Qualified new domain) =
+newStoredUserToUser :: Qualified NewStoredUser -> Maybe Handle -> User
+newStoredUserToUser (Qualified new domain) mbHandle =
   User
     { userQualifiedId = Qualified new.id domain,
       userType = new.userType,
@@ -292,7 +290,7 @@ newStoredUserToUser (Qualified new domain) =
       userStatus = new.status,
       userLocale = Locale new.language new.country,
       userService = newServiceRef <$> new.serviceId <*> new.providerId,
-      userHandle = new.handle,
+      userHandle = mbHandle,
       userExpire = new.expires,
       userTeam = new.teamId,
       userManagedBy = new.managedBy,

--- a/libs/wire-subsystems/src/Wire/UserStore/Cassandra.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore/Cassandra.hs
@@ -443,8 +443,8 @@ insertUser :: PrepQuery W (TupleType NewStoredUser) ()
 insertUser =
   "INSERT INTO user (id, user_type, name, text_status, picture, assets, email, sso_id, \
   \accent_id, password, activated, status, expires, language, \
-  \country, provider, service, handle, team, managed_by, supported_protocols, searchable) \
-  \VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+  \country, provider, service, team, managed_by, supported_protocols, searchable) \
+  \VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 insertServiceUser :: PrepQuery W (ProviderId, ServiceId, BotId, ConvId, Maybe TeamId) ()
 insertServiceUser =

--- a/libs/wire-subsystems/src/Wire/UserStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/UserStore/Postgres.hs
@@ -81,8 +81,7 @@ type InsertUserRow =
   ( UserId, Name, Maybe TextStatus, Pict, Maybe EmailAddress,
     Maybe UserSSOId, ColourId, Maybe Password, Bool, AccountStatus,
     Maybe UTCTimeMillis, Language, Maybe Country, Maybe ProviderId, Maybe ServiceId,
-    Maybe Handle, Maybe TeamId, ManagedBy, Set BaseProtocolTag, Bool,
-    UserType
+    Maybe TeamId, ManagedBy, Set BaseProtocolTag, Bool, UserType
   )
 type
   SelectUserRow =
@@ -165,7 +164,6 @@ createUserImpl new mbConv =
         new.country,
         new.providerId,
         new.serviceId,
-        new.handle,
         new.teamId,
         new.managedBy,
         new.supportedProtocols,
@@ -181,14 +179,12 @@ createUserImpl new mbConv =
            (id, name, text_status, picture, email,
            sso_id, accent_id, password, activated, account_status,
            expires, language, country, provider, service,
-           handle, team, managed_by, supported_protocols, searchable,
-           user_type)
+           team, managed_by, supported_protocols, searchable, user_type)
            VALUES
            ($1 :: uuid, $2 :: text, $3 :: text?, $4 :: jsonb, $5 :: text?,
             $6 :: jsonb?, $7 :: integer, $8 :: text?, $9 :: boolean, $10 :: integer,
             $11 :: timestamptz?, $12 :: text, $13 :: text?, $14 :: uuid?, $15 :: uuid?,
-            $16 :: text?, $17 :: uuid?, $18 :: integer, $19 :: integer, $20 :: boolean,
-            $21 :: integer)
+            $16 :: uuid?, $17 :: integer, $18 :: integer, $19 :: boolean, $20 :: integer)
            ON CONFLICT (id) DO UPDATE
            SET name = EXCLUDED.name,
                text_status = EXCLUDED.text_status,
@@ -204,7 +200,6 @@ createUserImpl new mbConv =
                country = EXCLUDED.country,
                provider = EXCLUDED.provider,
                service = EXCLUDED.service,
-               handle = EXCLUDED.handle,
                team = EXCLUDED.team,
                managed_by = EXCLUDED.managed_by,
                supported_protocols = EXCLUDED.supported_protocols,

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -239,9 +239,9 @@ createUserSpar new = do
       tid = newUserSparTeamId new
 
   -- Create account
-  account <- lift $ newStoredUser new' Nothing (Just tid) handle'
+  account <- lift $ newStoredUser new' Nothing (Just tid)
   domain <- viewFederationDomain
-  let u = newStoredUserToUser (Qualified account domain)
+  let u = newStoredUserToUser (Qualified account domain) handle'
   lift . liftSem $ do
     let uid = account.id
 
@@ -488,9 +488,9 @@ createUserWith normalizeScimDisplayName rateLimitKey new = do
         traverse
           (liftSem . HashPassword.hashPassword8 rateLimitKey)
           new'.newUserPassword
-      newStoredUser new' {newUserPassword = mHashedPassword} mbInv tid mbHandle
+      newStoredUser new' {newUserPassword = mHashedPassword} mbInv tid
   domain <- viewFederationDomain
-  let u = newStoredUserToUser (Qualified account domain)
+  let u = newStoredUserToUser (Qualified account domain) mbHandle
   let uid = account.id
   lift . liftSem $ do
     Log.debug $ field "user" (toByteString uid) . field "action" (val "User.createUser")
@@ -661,7 +661,7 @@ createUserInviteViaScim (NewUserScimInvitation tid uid extId loc name email _) =
   lift . liftSem $ do
     UserStore.createUser account Nothing
     InvitationStore.insertPendingScimUser tid email uid
-  newStoredUserToUser . Qualified account <$> viewFederationDomain
+  flip newStoredUserToUser Nothing . Qualified account <$> viewFederationDomain
 
 -- | docs/reference/user/registration.md {#RefRestrictRegistration}.
 checkRestrictedUserCreation :: NewUser password -> ExceptT RegisterError (AppT r) ()

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -28,7 +28,6 @@ where
 import Brig.App
 import Brig.Options
 import Control.Error
-import Data.Handle (Handle)
 import Data.Id
 import Data.Json.Util (toUTCTimeMillis)
 import Data.Range (fromRange)
@@ -43,18 +42,12 @@ import Wire.StoredUser
 -- | Preconditions:
 --
 -- 1. @newUserUUID u == Just inv || isNothing (newUserUUID u)@.
--- 2. If @isJust@, @mbHandle@ must be claimed by user with id @inv@.
---
--- Condition (2.) is essential for maintaining handle uniqueness.  It is guaranteed by the
--- fact that we're setting getting @mbHandle@ from table @"user"@, and when/if it was added
--- there, it was claimed properly.
 newStoredUser ::
   NewUser Password ->
   Maybe InvitationId ->
   Maybe TeamId ->
-  Maybe Handle ->
   AppT r NewStoredUser
-newStoredUser u inv tid mbHandle = do
+newStoredUser u inv tid = do
   defLoc <- defaultUserLocale <$> asks (.settings)
   uid <-
     Id <$> do
@@ -103,7 +96,6 @@ newStoredUser u inv tid mbHandle = do
           country = l.lCountry,
           providerId = Nothing,
           serviceId = Nothing,
-          handle = mbHandle,
           expires = e,
           teamId = tid,
           managedBy = managedBy,
@@ -136,7 +128,6 @@ newStoredUserViaScim uid externalId tid locale name email = do
         country = loc.lCountry,
         providerId = Nothing,
         serviceId = Nothing,
-        handle = Nothing,
         expires = Nothing,
         teamId = Just tid,
         managedBy = ManagedByScim,

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -846,7 +846,6 @@ addBot zuid zcon cid add = do
             country = locale.lCountry,
             serviceId = Just sid,
             providerId = Just pid,
-            handle = Nothing,
             teamId = Nothing,
             managedBy = ManagedByWire,
             supportedProtocols = defSupportedProtocols,


### PR DESCRIPTION
The cassandra interpreter was storing the handle without "claiming" it, expecting the caller to make a subsequent call to claim the handle.

The postgresql interpreter was claiming it unsafely, so it'd throw a 500 if the handle was already claimed.

Removing the handle from this type seems the more correct way where the calling party must make a subsequent call to claim the handle and deal with this partial failure in creating a user.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
