### PR TITLE
hip-15: declare the wire-server umbrella chart as imageless

### DIFF
--- a/charts/wire-server/Chart.yaml
+++ b/charts/wire-server/Chart.yaml
@@ -5,6 +5,5 @@ version: 0.0.42
 annotations:
   # must conform to https://github.com/helm/community/blob/main/hips/hip-0015.md
   # The umbrella chart runs no containers of its own; every subchart declares its
-  # own images. Declared explicitly so that "no images" is distinguishable from
-  # "not looked at yet".
+  # own images.
   helm.sh/images: "[]"

--- a/charts/wire-server/Chart.yaml
+++ b/charts/wire-server/Chart.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 description: A Helm chart for wire-server https://github.com/wireapp/wire-server
 name: wire-server
 version: 0.0.42
+annotations:
+  # must conform to https://github.com/helm/community/blob/main/hips/hip-0015.md
+  # The umbrella chart runs no containers of its own; every subchart declares its
+  # own images. Declared explicitly so that "no images" is distinguishable from
+  # "not looked at yet".
+  helm.sh/images: "[]"


### PR DESCRIPTION
Completes HIP-15 for the wire-server chart family on `2025-q2`. #5438 annotated
the subcharts and #5467 added `reaper`; the umbrella chart itself was still
missing a declaration.

https://wearezeta.atlassian.net/browse/WPB-27901

## Why an empty list

`charts/wire-server` runs no containers of its own. Its whole tree is
`Chart.yaml`, `requirements.yaml`, `values.yaml` and `templates/NOTES.txt`.
Every subchart declares its own images.

Tooling that collects `helm.sh/images` cannot distinguish "this chart has no
images" from "nobody has annotated this chart yet" unless the empty case is
declared.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
