### PR TITLE
WPB-28272: Make meeting tzid updatable via PUT /meetings/{domain}/{id}

### DIFF
--- a/changelog.d/1-api-changes/WPB-28272
+++ b/changelog.d/1-api-changes/WPB-28272
@@ -1,0 +1,2 @@
+`PUT /meetings/{domain}/{id}` now accepts an optional `tzid` field to update a
+meeting's IANA time zone.

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -353,7 +353,7 @@ testMeetingUpdateTzid = do
   fetched2 %. "tzid" `shouldMatch` ("America/New_York" :: String)
   fetched2 %. "title" `shouldMatch` ("Renamed" :: String)
 
-  putMeeting owner domain meetingId (object ["tzid" .= ("not-a-zone" :: String)]) >>= assertStatus 400
+  putMeeting owner domain meetingId (object ["tzid" .= ("not-a-zone" :: String)]) >>= assertLabel 400 "bad-request"
 
 testMeetingListEmpty :: (HasCallStack) => App ()
 testMeetingListEmpty = do

--- a/integration/test/Test/Meetings.hs
+++ b/integration/test/Test/Meetings.hs
@@ -329,6 +329,32 @@ testMeetingUpdateUnauthorized = do
 
   putMeeting otherUser domain meetingId update >>= assertStatus 404
 
+-- | WPB-28272: PUT /meetings/{domain}/{id} accepts an optional @tzid@ and
+-- updates the stored time zone; omitting it (as legacy clients do) keeps the
+-- stored value; an invalid tzid is rejected at decode time.
+testMeetingUpdateTzid :: (HasCallStack) => App ()
+testMeetingUpdateTzid = do
+  (owner, _tid, _members) <- createTeam OwnDomain 1
+  now <- liftIO getCurrentTime
+  let newMeeting = defaultMeetingJson "Tzid Meeting" (addUTCTime 3600 now) (addUTCTime 7200 now) []
+  meeting <- postMeetings owner newMeeting >>= getJSON 201
+  (meetingId, domain) <- getMeetingIdAndDomain meeting
+  meeting %. "tzid" `shouldMatch` ("Europe/Berlin" :: String)
+
+  updated <- putMeeting owner domain meetingId (object ["tzid" .= ("America/New_York" :: String)]) >>= getJSON 200
+  updated %. "tzid" `shouldMatch` ("America/New_York" :: String)
+  updated %. "title" `shouldMatch` ("Tzid Meeting" :: String)
+
+  fetched <- getMeeting owner domain meetingId >>= getJSON 200
+  fetched %. "tzid" `shouldMatch` ("America/New_York" :: String)
+
+  putMeeting owner domain meetingId (object ["title" .= ("Renamed" :: String)]) >>= assertStatus 200
+  fetched2 <- getMeeting owner domain meetingId >>= getJSON 200
+  fetched2 %. "tzid" `shouldMatch` ("America/New_York" :: String)
+  fetched2 %. "title" `shouldMatch` ("Renamed" :: String)
+
+  putMeeting owner domain meetingId (object ["tzid" .= ("not-a-zone" :: String)]) >>= assertStatus 400
+
 testMeetingListEmpty :: (HasCallStack) => App ()
 testMeetingListEmpty = do
   (owner, _tid, _members) <- createTeam OwnDomain 1

--- a/libs/wire-api/src/Wire/API/Meeting.hs
+++ b/libs/wire-api/src/Wire/API/Meeting.hs
@@ -303,15 +303,18 @@ instance ToSchema Frequency where
           element "yearly" Yearly
         ]
 
--- | Request to update an existing meeting. Updates carry no @tzid@ (it is
--- immutable after creation); @end_time@ is optional on both eras, so a single
--- type serves V17 ('UpdateMeeting') and V16 ('UpdateMeetingV16').
+-- | Request to update an existing meeting. @tzid@ is optional: 'Just' sets
+-- the meeting's IANA time zone, while omitting it (as legacy V15\/V16
+-- clients, whose request shape carries no @tzid@, always do) leaves the
+-- stored time zone unchanged; @end_time@ is optional on both eras, so a
+-- single type serves V17 ('UpdateMeeting') and V16 ('UpdateMeetingV16').
 data UpdateMeeting = UpdateMeeting
   { startTime :: Maybe UTCTime,
     endTime :: Maybe UTCTime,
     title :: Maybe (Range 1 256 Text),
     -- | 'Just x' means "set 'recurrence' to 'x', meaning set to a value or unset it"
-    recurrence :: Maybe (Maybe Recurrence)
+    recurrence :: Maybe (Maybe Recurrence),
+    tzid :: Maybe TimeZone
   }
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema UpdateMeeting)
@@ -327,6 +330,7 @@ instance ToSchema UpdateMeeting where
         <*> (.endTime) .= maybe_ (optField "end_time" utcTimeSchema)
         <*> (.title) .= maybe_ (optField "title" schema)
         <*> (.recurrence) .= fmap Just (maybe_ (maybe_ (optField' "recurrence" schema)))
+        <*> (.tzid) .= maybe_ (optField "tzid" schema)
 
 instance ToSchema Recurrence where
   schema =

--- a/libs/wire-subsystems/src/Wire/MeetingsStore.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsStore.hs
@@ -166,6 +166,7 @@ data MeetingsStore m a where
     Maybe (Range 1 256 Text) ->
     Maybe UTCTime ->
     Maybe UTCTime ->
+    Maybe TimeZone ->
     Maybe (Maybe Recurrence) ->
     MeetingsStore m (Maybe StoredMeeting)
   DeleteMeeting ::

--- a/libs/wire-subsystems/src/Wire/MeetingsStore/Postgres.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsStore/Postgres.hs
@@ -36,7 +36,7 @@ import Hasql.Statement
 import Hasql.TH
 import Imports
 import Polysemy
-import Wire.API.Meeting (Recurrence, TimeZone)
+import Wire.API.Meeting (Recurrence, TimeZone, renderTimeZone)
 import Wire.API.PostgresMarshall (PostgresMarshall (..), PostgresUnmarshall (..), dimapPG)
 import Wire.API.User.Identity (EmailAddress, fromEmail)
 import Wire.MeetingsStore
@@ -49,8 +49,8 @@ interpretMeetingsStoreToPostgres =
   interpret $ \case
     CreateMeeting title creator startTime endTime tzid recurrence convId emails trial ->
       createMeetingImpl title creator startTime endTime tzid recurrence convId emails trial
-    UpdateMeeting meetingId title startDate endTime schedule ->
-      updateMeetingImpl meetingId title startDate endTime schedule
+    UpdateMeeting meetingId title startDate endTime tzid schedule ->
+      updateMeetingImpl meetingId title startDate endTime tzid schedule
     DeleteMeeting meetingId ->
       deleteMeetingImpl meetingId
     GetMeeting meetingId ->
@@ -132,6 +132,7 @@ type UpdateStoredMeetingWithRecurrenceTuple =
   ( Maybe Text, -- title
     Maybe UTCTime, -- start_time
     Maybe UTCTime, -- end_time
+    Maybe Text, -- tzid
     Maybe Text, -- recurrence_frequency
     Maybe Int32, -- recurrence_interval
     Maybe UTCTime, -- recurrence_until
@@ -142,16 +143,18 @@ type UpdateMeetingWithRecurrenceTuple =
   ( Maybe (Range 1 256 Text), -- title
     Maybe UTCTime, -- start_time
     Maybe UTCTime, -- end_time
+    Maybe TimeZone, -- tzid
     Maybe Recurrence, -- recurrence
     MeetingId -- meeting id
   )
 
 instance PostgresMarshall UpdateStoredMeetingWithRecurrenceTuple UpdateMeetingWithRecurrenceTuple where
-  postgresMarshall (mTitle, mStartTime, mEndTime, recurrence, id') =
+  postgresMarshall (mTitle, mStartTime, mEndTime, mTzid, recurrence, id') =
     let (rFreq, rInterval, rUntil) = postgresMarshall recurrence
      in ( fromRange <$> mTitle,
           mStartTime,
           mEndTime,
+          renderTimeZone <$> mTzid,
           rFreq,
           rInterval,
           rUntil,
@@ -162,6 +165,7 @@ type UpdateStoredMeetingWithoutRecurrenceTuple =
   ( Maybe Text, -- title
     Maybe UTCTime, -- start_time
     Maybe UTCTime, -- end_time
+    Maybe Text, -- tzid
     UUID -- meeting id
   )
 
@@ -169,14 +173,16 @@ type UpdateMeetingWithoutRecurrenceTuple =
   ( Maybe (Range 1 256 Text), -- title
     Maybe UTCTime, -- start_time
     Maybe UTCTime, -- end_time
+    Maybe TimeZone, -- tzid
     MeetingId -- meeting id
   )
 
 instance {-# OVERLAPPING #-} PostgresMarshall UpdateStoredMeetingWithoutRecurrenceTuple UpdateMeetingWithoutRecurrenceTuple where
-  postgresMarshall (mTitle, mStartTime, mEndTime, id') =
+  postgresMarshall (mTitle, mStartTime, mEndTime, mTzid, id') =
     ( fromRange <$> mTitle,
       mStartTime,
       mEndTime,
+      renderTimeZone <$> mTzid,
       toUUID id'
     )
 
@@ -186,14 +192,15 @@ updateMeetingImpl ::
   Maybe (Range 1 256 Text) ->
   Maybe UTCTime ->
   Maybe UTCTime ->
+  Maybe TimeZone ->
   Maybe (Maybe Recurrence) ->
   Sem r (Maybe StoredMeeting)
-updateMeetingImpl meetingId mTitle mStartDate mEndTime mRecurrence = do
+updateMeetingImpl meetingId mTitle mStartDate mEndTime mTzid mRecurrence = do
   case mRecurrence of
     Nothing ->
-      runStatement (mTitle, mStartDate, mEndTime, meetingId) updateWithoutRecurrenceStatement
+      runStatement (mTitle, mStartDate, mEndTime, mTzid, meetingId) updateWithoutRecurrenceStatement
     Just recurrence ->
-      runStatement (mTitle, mStartDate, mEndTime, recurrence, meetingId) updateWithRecurrenceStatement
+      runStatement (mTitle, mStartDate, mEndTime, mTzid, recurrence, meetingId) updateWithRecurrenceStatement
   where
     updateWithRecurrenceStatement :: Statement UpdateMeetingWithRecurrenceTuple (Maybe StoredMeeting)
     updateWithRecurrenceStatement =
@@ -207,11 +214,12 @@ updateMeetingImpl meetingId mTitle mStartDate mEndTime mRecurrence = do
           SET title = COALESCE($1 :: text?, title),
               start_time = COALESCE($2 :: timestamptz?, start_time),
               end_time = COALESCE($3 :: timestamptz?, end_time),
-              recurrence_frequency = $4 :: text? :: recurrence_frequency,
-              recurrence_interval = $5 :: int4?,
-              recurrence_until = $6 :: timestamptz?,
+              tzid = COALESCE($4 :: text?, tzid),
+              recurrence_frequency = $5 :: text? :: recurrence_frequency,
+              recurrence_interval = $6 :: int4?,
+              recurrence_until = $7 :: timestamptz?,
               updated_at = NOW()
-          WHERE id = ($7 :: uuid)
+          WHERE id = ($8 :: uuid)
           RETURNING
             id :: uuid, title :: text, creator :: uuid,
             start_time :: timestamptz, end_time :: timestamptz, tzid :: text,
@@ -232,8 +240,9 @@ updateMeetingImpl meetingId mTitle mStartDate mEndTime mRecurrence = do
           SET title = COALESCE($1 :: text?, title),
               start_time = COALESCE($2 :: timestamptz?, start_time),
               end_time = COALESCE($3 :: timestamptz?, end_time),
+              tzid = COALESCE($4 :: text?, tzid),
               updated_at = NOW()
-          WHERE id = ($4 :: uuid)
+          WHERE id = ($5 :: uuid)
           RETURNING
             id :: uuid, title :: text, creator :: uuid,
             start_time :: timestamptz, end_time :: timestamptz, tzid :: text,

--- a/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
+++ b/libs/wire-subsystems/src/Wire/MeetingsSubsystem/Interpreter.hs
@@ -247,7 +247,7 @@ updateMeetingImpl ::
 updateMeetingImpl zUser connId meetingId update validityPeriod pastEditPeriod = do
   maybeTeamId <- TeamSubsystem.internalGetOneUserTeam (tUnqualified zUser)
   checkMeetingsEnabled maybeTeamId
-  when (isNothing update.title && isNothing update.startTime && isNothing update.endTime && isNothing update.recurrence) $
+  when (isNothing update.title && isNothing update.startTime && isNothing update.endTime && isNothing update.recurrence && isNothing update.tzid) $
     throw EmptyUpdate
 
   runMaybeT $ do
@@ -278,15 +278,17 @@ updateMeetingImpl zUser connId meetingId update validityPeriod pastEditPeriod = 
           update.title
           update.startTime
           update.endTime
+          update.tzid
           update.recurrence
     conv <- MaybeT $ getMeetingConversationOrFail meetingId updatedMeeting.conversationId
     lift $ notifyMeetingEvent zUser (Just connId) conv.localMembers (Qualified conv.id_ (tDomain zUser)) maybeTeamId MeetingEvent.Update meetingId
     pure $ storedMeetingToMeetingWithConversation zUser conv updatedMeeting
 
--- | V16 update path: 'API.UpdateMeetingV16' is now 'API.UpdateMeeting' (both
+-- | V16 update path: 'API.UpdateMeetingV16' is 'API.UpdateMeeting' (both
 -- carry an optional @end_time@), so this delegates straight through to the
--- shared update implementation and re-shapes the result. @tzid@ is immutable,
--- so the legacy time zone is not needed here.
+-- shared update implementation and re-shapes the result. The legacy request
+-- shape carries no @tzid@ from V15\/V16 clients, and an omitted @tzid@ leaves
+-- the stored time zone unchanged, so no legacy time zone injection is needed.
 updateMeetingV16Impl ::
   ( Member Store.MeetingsStore r,
     Member ConversationSubsystem r,

--- a/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MeetingsSubsystem/InterpreterSpec.hs
@@ -400,9 +400,34 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
-        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing Nothing Nothing)
+        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing Nothing Nothing Nothing)
 
       result `shouldBe` Left EmptyUpdate
+
+    it "updates tzid when provided alone" $ do
+      let newMeeting =
+            API.NewMeeting
+              { title = fromJust $ checked "Tzid Meeting",
+                startTime = addUTCTime 3600 now,
+                endTime = addUTCTime 7200 now,
+                tzid = API.defaultLegacyTimeZone,
+                recurrence = Nothing,
+                invitedEmails = []
+              }
+          newTz = fromJust (API.parseTimeZone "Europe/London")
+      result <- runTestStack now gen Map.empty teamConfig $ do
+        meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
+        updateMeeting
+          zUser1
+          (ConnId "test-conn")
+          meeting.meeting.id
+          (API.UpdateMeeting Nothing Nothing Nothing Nothing (Just newTz))
+      case result of
+        Left err -> fail $ "Expected the update to be applied, got: " <> show err
+        Right Nothing -> fail "Expected the update to be applied"
+        Right (Just updated) -> do
+          updated.meeting.tzid `shouldBe` newTz
+          updated.meeting.title `shouldBe` newMeeting.title
 
     it "throws InvalidTimes when end_time is not after start_time" $ do
       let newMeeting =
@@ -422,7 +447,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 { startTime = Nothing,
                   endTime = Just (addUTCTime 3600 now),
                   title = Nothing,
-                  recurrence = Nothing
+                  recurrence = Nothing,
+                  tzid = Nothing
                 }
         updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
       result `shouldBe` Left (InvalidTimes EndBeforeStart)
@@ -445,7 +471,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 { startTime = Just (addUTCTime (negate 60) now),
                   endTime = Nothing,
                   title = Nothing,
-                  recurrence = Nothing
+                  recurrence = Nothing,
+                  tzid = Nothing
                 }
         updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
 
@@ -473,7 +500,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 { startTime = Just (addUTCTime (negate configuredPastEditPeriod) now),
                   endTime = Nothing,
                   title = Nothing,
-                  recurrence = Nothing
+                  recurrence = Nothing,
+                  tzid = Nothing
                 }
         updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
 
@@ -499,7 +527,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 { startTime = Just (addUTCTime (negate (configuredPastEditPeriod + 1)) now),
                   endTime = Nothing,
                   title = Nothing,
-                  recurrence = Nothing
+                  recurrence = Nothing,
+                  tzid = Nothing
                 }
         updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
       result `shouldBe` Left (InvalidTimes TimesBeyondPastEditWindow)
@@ -522,7 +551,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                 { startTime = Just (addUTCTime (negate 7200) now),
                   endTime = Just (addUTCTime (negate (configuredPastEditPeriod + 1)) now),
                   title = Nothing,
-                  recurrence = Nothing
+                  recurrence = Nothing,
+                  tzid = Nothing
                 }
         updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
       result `shouldBe` Left (InvalidTimes TimesBeyondPastEditWindow)
@@ -551,7 +581,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                     startTime = Just (addUTCTime 100 now),
                     endTime = Nothing,
                     title = Just (unsafeRange "Edited While Ongoing"),
-                    recurrence = Nothing
+                    recurrence = Nothing,
+                    tzid = Nothing
                   }
           updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
       case result of
@@ -580,7 +611,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                   { startTime = Just (addUTCTime 8000 now),
                     endTime = Nothing,
                     title = Nothing,
-                    recurrence = Nothing
+                    recurrence = Nothing,
+                    tzid = Nothing
                   }
           updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id update
       result `shouldBe` Left (InvalidTimes EndBeforeStart)
@@ -599,7 +631,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
       result <- runTestStack now gen Map.empty teamConfig $ do
         meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
         passTime validityWindow
-        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing)
+        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing Nothing)
 
       result `shouldBe` Right Nothing
 
@@ -616,7 +648,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
 
       result <- runTestStack now gen (Map.singleton teamId [teamMember1, teamMember2]) teamConfig $ do
         meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
-        updateMeeting zUser2 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing)
+        updateMeeting zUser2 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Test")) Nothing Nothing)
 
       result `shouldBe` Right Nothing
 
@@ -635,7 +667,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
         -- Simulate a data-inconsistency: the meeting's conversation vanished.
         modify @(Map ConvId StoredConversation) (Map.delete (qUnqualified meeting.meeting.conversationId))
-        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
+        updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing Nothing)
 
       result `shouldBe` Right Nothing
 
@@ -659,9 +691,10 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
               (fmap (max (addUTCTime (negate 60) now)) update.endTime)
               update.title
               update.recurrence
+              update.tzid
           effectiveStart = fromMaybe baseMeeting.startTime sanitizedUpdate.startTime
           effectiveEndTime = fromMaybe baseMeeting.endTime sanitizedUpdate.endTime
-          isNotEmpty = sanitizedUpdate /= API.UpdateMeeting Nothing Nothing Nothing Nothing
+          isNotEmpty = sanitizedUpdate /= API.UpdateMeeting Nothing Nothing Nothing Nothing Nothing
           hasValidTimes = effectiveEndTime > effectiveStart
        in isNotEmpty && hasValidTimes ==>
             ioProperty $ do
@@ -680,6 +713,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
                       .&&. m.meeting.startTime === effectiveStart
                       .&&. m.meeting.endTime === effectiveEndTime
                       .&&. m.meeting.recurrence === fromMaybe baseMeeting.recurrence sanitizedUpdate.recurrence
+                      .&&. m.meeting.tzid === fromMaybe baseMeeting.tzid sanitizedUpdate.tzid
                       .&&. m.meeting.conversationId === convId
 
   describe "deleteMeeting" $ do
@@ -1218,7 +1252,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         runTestStack now gen Map.empty teamConfig $ do
           meeting <- createMeeting zUser (ConnId "test-conn") (futureMeeting boundedRecurrence)
           passTime validityWindow
-          updateMeeting zUser (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
+          updateMeeting zUser (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing Nothing)
       fmap isJust result `shouldBe` Right True
 
     it "addInvitedEmails succeeds on a recurring meeting whose slot passed" $ do
@@ -1419,7 +1453,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         Right meeting -> do
           result2 <-
             runTestStack now gen (Map.singleton teamId [teamMember]) meetingsDisabled $
-              updateMeeting zUserTeam (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
+              updateMeeting zUserTeam (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing Nothing)
 
           result2 `shouldBe` Left MeetingsFeatureDisabled
 
@@ -1528,7 +1562,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         runTestStack now gen (Map.singleton teamId [teamMember1]) teamConfig $ do
           meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
           put @[Push] []
-          _ <- updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing)
+          _ <- updateMeeting zUser1 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Updated")) Nothing Nothing)
           get @[Push]
 
       case result of
@@ -1558,7 +1592,7 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
         runTestStack now gen (Map.singleton teamId [teamMember1, teamMember2]) teamConfig $ do
           meeting <- createMeeting zUser1 (ConnId "test-conn") newMeeting
           put @[Push] []
-          _ <- updateMeeting zUser2 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Hijack")) Nothing)
+          _ <- updateMeeting zUser2 (ConnId "test-conn") meeting.meeting.id (API.UpdateMeeting Nothing Nothing (Just (unsafeRange "Hijack")) Nothing Nothing)
           get @[Push]
 
       case result of
@@ -1666,7 +1700,8 @@ spec = describe "MeetingsSubsystem.Interpreter" $ do
               { startTime = Just newStart,
                 endTime = Just newEnd,
                 title = Nothing,
-                recurrence = Nothing
+                recurrence = Nothing,
+                tzid = Nothing
               }
       result <-
         runTestStack now gen Map.empty def $ do

--- a/libs/wire-subsystems/test/unit/Wire/MockInterpreters/MeetingsStore.hs
+++ b/libs/wire-subsystems/test/unit/Wire/MockInterpreters/MeetingsStore.hs
@@ -54,7 +54,7 @@ inMemoryMeetingsStoreInterpreter = interpret $ \case
     modify (Map.insert mid sm)
     pure sm
   GetMeeting mid -> gets (Map.lookup mid)
-  UpdateMeeting mid title startTime endTime recurrence -> do
+  UpdateMeeting mid title startTime endTime tzid recurrence -> do
     sm <- gets (Map.lookup mid)
     case sm of
       Nothing -> pure Nothing
@@ -65,6 +65,7 @@ inMemoryMeetingsStoreInterpreter = interpret $ \case
                 { title = fromMaybe (meeting.title) title,
                   startTime = startTime',
                   endTime = fromMaybe meeting.endTime endTime,
+                  tzid = fromMaybe meeting.tzid tzid,
                   recurrence = fromMaybe meeting.recurrence recurrence,
                   updatedAt = now
                 }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-28272

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)