### PR TITLE
Fix: active team invitation after SCIM user deletion

### DIFF
--- a/changelog.d/3-bug-fixes/pending-invitations-for-deleted-SCIM-users
+++ b/changelog.d/3-bug-fixes/pending-invitations-for-deleted-SCIM-users
@@ -1,0 +1,2 @@
+Deleted SCIM users could still have pending team invitations. These are now
+deleted (invalidated) with the SCIM user.

--- a/integration/test/Test/Spar.hs
+++ b/integration/test/Test/Spar.hs
@@ -157,6 +157,37 @@ testTeamInvitationWhenScimAccountExists = do
   user %. "managed_by" `shouldMatch` "scim"
   user %. "status" `shouldMatch` "active"
 
+-- | Ensure that unused team invitations are invalidated when the SCIM user
+-- gets deleted.
+testTeamInvitationUsedAfterScimUserDeleted :: (HasCallStack) => App ()
+testTeamInvitationUsedAfterScimUserDeleted = do
+  (owner, tid, _) <- createTeam OwnDomain 1
+  token <- createScimToken owner def >>= getJSON 200 >>= (%. "token") >>= asString
+
+  email <- randomEmail
+  externalId <- randomExternalId
+  scimUser <- randomScimUserWithEmail externalId email
+  scid <- createScimUser OwnDomain token scimUser >>= getJSON 201 >>= (%. "id") >>= asString
+
+  code <-
+    getInvitationByEmail OwnDomain email
+      >>= getJSON 200
+      >>= getInvitationCodeForTeam OwnDomain tid
+      >>= getJSON 200
+      >>= (%. "code")
+      >>= asString
+
+  deleteScimUser OwnDomain token scid >>= assertSuccess
+
+  -- The invitation must no longer be usable: completing registration with
+  -- the previously-fetched code should fail, not resurrect the deleted
+  -- account. (This was bug WPB-28198)
+  registerUserWith OwnDomain email code "Eve" >>= assertStatus 400
+
+  getUsersByEmail OwnDomain [email] >>= getJSON 200 >>= asList >>= shouldBeEmpty
+
+  getInvitationByEmail OwnDomain email >>= assertStatus 404
+
 testSparUserCreationInvitationTimeout :: (HasCallStack) => App ()
 testSparUserCreationInvitationTimeout = do
   (owner, tid, _) <- createTeam OwnDomain 1

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -42,6 +42,7 @@ module Data.Id
     idToText,
     idToString,
     invitationIdToUserId,
+    userIdToInvitationId,
     idObjectSchema,
     IdObject (..),
 
@@ -106,6 +107,10 @@ import Test.QuickCheck.Instances ()
 -- | Pending invitation users reuse the invitation UUID as the user UUID.
 invitationIdToUserId :: InvitationId -> UserId
 invitationIdToUserId = Id . toUUID
+
+-- | Pending invitation users reuse the invitation UUID as the user UUID.
+userIdToInvitationId :: UserId -> InvitationId
+userIdToInvitationId = Id . toUUID
 
 data IdTag
   = Asset

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1170,7 +1170,7 @@ ensureAccountDeleted luid@(tUnqualified -> uid) = do
 -- states. Please change this order only with care!
 --
 -- FUTUREWORK(mangoiv): this uses 'UserStore', hence it must be moved to 'UserSubsystem'
--- as an effet operation
+-- as an effect operation
 -- FUTUREWORK: this does not need the whole User structure, only the User.
 deleteAccount ::
   ( Member (Embed HttpClientIO) r,
@@ -1197,8 +1197,10 @@ deleteAccount user = do
 
     PropertySubsystem.onUserDeleted uid
     UserStore.deleteUser user
-    for_ (userEmail user) $ \email ->
-      for_ (userTeam user) $ \tid ->
+    for_ (userTeam user) $ \tid -> do
+      -- Delete potentially pending team invitations for SCIM users
+      InvitationStore.deleteInvitation tid (userIdToInvitationId uid)
+      for_ (userEmail user) $ \email ->
         InvitationStore.deletePendingScimUser tid email uid
 
   traverse_ (removeUserFromAllGroups uid) user.userTeam


### PR DESCRIPTION
Best read the changelog entry for a description.

A bit for which I haven't found a good spot: Brig screams this on registration without the fix:
```
[brig@example.com] W, request=Spar.testTeamInvitationUsedAfterScimUserDeleted__POST_/v18/register__7, Found data about users which have been marked as deleted. This is likely a database inconsistence and must be addressed., userIds=[XXX]
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
