### PR TITLE
Fix: Enforce correct host port assignment for postgresql connection strings

### DIFF
--- a/changelog.d/3-bug-fixes/postgresql-connection-string-parse-failure
+++ b/changelog.d/3-bug-fixes/postgresql-connection-string-parse-failure
@@ -1,0 +1,3 @@
+Postgresql connection strings with mismatched host/port counts in service
+configurations now lead to immediate failure with a clear error message instead
+of silently producing an erroneous connection.

--- a/flake.lock
+++ b/flake.lock
@@ -350,16 +350,16 @@
     "postgresql-connection-string": {
       "flake": false,
       "locked": {
-        "lastModified": 1778144330,
-        "narHash": "sha256-w/TFQX7PIsLQTG+Es2yla584Y3T7Q6H1iIlqFap8qUk=",
+        "lastModified": 1787930090,
+        "narHash": "sha256-ti+XZdhoCiDxgyUilva7EpV8SOfMlmwuKr28XkJ62N0=",
         "owner": "wireapp",
         "repo": "postgresql-connection-string",
-        "rev": "ff98790cb3058545ea978ea143cd57b04360c48c",
+        "rev": "bd5a2d72c15fa4ffe561e3b3f441e5809050f918",
         "type": "github"
       },
       "original": {
         "owner": "wireapp",
-        "ref": "expose-from-key-value-params",
+        "ref": "wire-patches",
         "repo": "postgresql-connection-string",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,8 @@
     };
 
     postgresql-connection-string = {
-      url = "github:wireapp/postgresql-connection-string?ref=expose-from-key-value-params";
+      url =
+        "github:wireapp/postgresql-connection-string?ref=wire-patches";
       flake = false;
     };
 

--- a/libs/extended/default.nix
+++ b/libs/extended/default.nix
@@ -27,6 +27,7 @@
 , http-types
 , imports
 , lib
+, megaparsec
 , metrics-wai
 , monad-control
 , postgresql-connection-string
@@ -76,6 +77,7 @@ mkDerivation {
     http-client-tls
     http-types
     imports
+    megaparsec
     metrics-wai
     monad-control
     postgresql-connection-string
@@ -101,12 +103,14 @@ mkDerivation {
     aeson
     base
     bytestring
+    containers
     crypton
     crypton-asn1-types
     crypton-pem
     crypton-x509
     hspec
     imports
+    postgresql-connection-string
     QuickCheck
     string-conversions
     temporary

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -108,6 +108,7 @@ library
     , http-client-tls
     , http-types
     , imports
+    , megaparsec
     , metrics-wai
     , monad-control
     , postgresql-connection-string
@@ -138,6 +139,7 @@ test-suite extended-tests
     Paths_extended
     Test.Data.Hourglass.ConstSpec
     Test.Data.X509.ExtendedSpec
+    Test.Hasql.Pool.ExtendedSpec
     Test.System.Logger.ExtendedSpec
 
   hs-source-dirs:     test
@@ -196,6 +198,7 @@ test-suite extended-tests
       aeson
     , base
     , bytestring
+    , containers
     , crypton
     , crypton-asn1-types
     , crypton-pem
@@ -203,6 +206,7 @@ test-suite extended-tests
     , extended
     , hspec
     , imports
+    , postgresql-connection-string
     , QuickCheck
     , string-conversions
     , temporary

--- a/libs/extended/src/Hasql/Pool/Extended.hs
+++ b/libs/extended/src/Hasql/Pool/Extended.hs
@@ -18,6 +18,7 @@
 module Hasql.Pool.Extended where
 
 import Data.Aeson
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Misc
 import Hasql.Connection qualified
 import Hasql.Connection.Settings qualified as HasqlConnSettings
@@ -25,6 +26,7 @@ import Hasql.Pool qualified as HasqlPool
 import Imports
 import PostgresqlConnectionString qualified
 import Prometheus
+import Text.Megaparsec qualified as Megaparsec
 import UnliftIO.IO (getMonotonicTime)
 import Util.Options
 
@@ -108,6 +110,27 @@ startHasqlPoolStatsReporter pool = void $ forkIO $ forever $ do
   recordHasqlPoolStats pool
   threadDelay (5 * 1_000_000) -- 5s
 
+-- | Run a postgresql-connection-string parser, turning a parse failure into
+-- an IO exception whose message is the parser's failure text, so the
+-- reason is visible wherever this call site's crash output is captured.
+--
+-- 'Megaparsec.errorBundlePretty' is avoided because 'fromKeyValueParams'
+-- never consumes the (always-empty) input stream, so its source-position
+-- pointer would be meaningless noise around the actual message.
+runConnStrParser :: Megaparsec.Parsec Void Text a -> IO a
+runConnStrParser p =
+  either
+    ( fail
+        . dropWhileEnd isSpace
+        . Megaparsec.parseErrorTextPretty
+        . NonEmpty.head
+        . Megaparsec.bundleErrors
+    )
+    pure
+    $ let file = ""
+          input = ""
+       in Megaparsec.parse p file input
+
 -- | Creates a pool from postgres config params.
 --
 -- 'acquisitionTimeout' is mapped to the pool acquisition timeout,
@@ -115,8 +138,9 @@ startHasqlPoolStatsReporter pool = void $ forkIO $ forever $ do
 initPostgresPool :: PoolConfig -> Map Text Text -> Maybe FilePathSecrets -> IO Pool
 initPostgresPool config pgConfig mFpSecrets = do
   mPw <- for mFpSecrets initCredentials
+  connStr <- runConnStrParser $ PostgresqlConnectionString.fromKeyValueParams pgConfig
   let pgSettings =
-        HasqlConnSettings.connectionString (PostgresqlConnectionString.toUrl $ PostgresqlConnectionString.fromKeyValueParams pgConfig)
+        HasqlConnSettings.connectionString (PostgresqlConnectionString.toUrl connStr)
           <> foldMap HasqlConnSettings.password mPw
   metrics <- mkHasqlPoolMetrics
   rawPool <-

--- a/libs/extended/test/Test/Hasql/Pool/ExtendedSpec.hs
+++ b/libs/extended/test/Test/Hasql/Pool/ExtendedSpec.hs
@@ -1,0 +1,70 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2026 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Hasql.Pool.ExtendedSpec where
+
+import Control.Exception (try)
+import Data.Map qualified as Map
+import Hasql.Pool.Extended (runConnStrParser)
+import Imports
+import PostgresqlConnectionString qualified
+import System.IO.Error (ioeGetErrorString)
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "runConnStrParser / fromKeyValueParams" $ do
+    it "parses a valid key/value connection string" $ do
+      let params =
+            Map.fromList
+              [ ("host", "localhost"),
+                ("port", "5432"),
+                ("dbname", "wire-server"),
+                ("user", "wire")
+              ]
+      connStr <- runConnStrParser $ PostgresqlConnectionString.fromKeyValueParams params
+      PostgresqlConnectionString.toUrl connStr `shouldBe` "postgresql://wire@localhost:5432/wire-server"
+
+    it "applies a single port to every host" $ do
+      let params =
+            Map.fromList
+              [ ("host", "IP1,IP2,IP3"),
+                ("port", "5000")
+              ]
+      connStr <- runConnStrParser $ PostgresqlConnectionString.fromKeyValueParams params
+      PostgresqlConnectionString.toUrl connStr `shouldBe` "postgresql://IP1:5000,IP2:5000,IP3:5000"
+
+    it "applies a single port to every host and keeps the dbname" $ do
+      let params =
+            Map.fromList
+              [ ("host", "IP1,IP2,IP3"),
+                ("port", "5000"),
+                ("dbname", "wire-server")
+              ]
+      connStr <- runConnStrParser $ PostgresqlConnectionString.fromKeyValueParams params
+      PostgresqlConnectionString.toUrl connStr `shouldBe` "postgresql://IP1:5000,IP2:5000,IP3:5000/wire-server"
+
+    it "surfaces a mismatched host/port count as an exception with the parse error" $ do
+      let params =
+            Map.fromList
+              [ ("host", "host1,host2,host3"),
+                ("port", "5432,5433")
+              ]
+      result <- try @IOException $ runConnStrParser (PostgresqlConnectionString.fromKeyValueParams params)
+      case result of
+        Left e -> ioeGetErrorString e `shouldBe` "could not match 2 port numbers to 3 hosts"
+        Right _ -> expectationFailure "expected a parse failure"

--- a/libs/wire-subsystems/src/Wire/JobSubsystem/Migrations.hs
+++ b/libs/wire-subsystems/src/Wire/JobSubsystem/Migrations.hs
@@ -36,6 +36,7 @@ import Hasql.Connection qualified as HasqlConnection
 import Hasql.Connection.Settings qualified as HasqlConnectionSettings
 import Hasql.Decoders qualified as HasqlDecoders
 import Hasql.Encoders qualified as HasqlEncoders
+import Hasql.Pool.Extended (runConnStrParser)
 import Hasql.Session qualified as HasqlSession
 import Hasql.Statement qualified as HasqlStatement
 import Hasql.TH
@@ -52,8 +53,8 @@ mkArbiterConnectionString :: Map Text Text -> Maybe FilePathSecrets -> IO Secret
 mkArbiterConnectionString pgConfig mFpSecrets = do
   mPw <- for mFpSecrets initCredentials
   let pgConfig' = maybe pgConfig (\pw -> Map.insert "password" pw pgConfig) mPw
-  pure . secretText . PostgresqlConnectionString.toKeyValueString $
-    PostgresqlConnectionString.fromKeyValueParams pgConfig'
+  connStr <- runConnStrParser $ PostgresqlConnectionString.fromKeyValueParams pgConfig'
+  pure . secretText $ PostgresqlConnectionString.toKeyValueString connStr
 
 -- | Apply all migrations for the job registry before constructing any worker
 -- pools or accepting jobs.


### PR DESCRIPTION
Host/port misconfigurations are now logged like:

```
[galley@example.com] galley: user error (could not match 2 port numbers to 3 hosts)
[galley@example.com] HasCallStack backtrace:
[galley@example.com]   collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
[galley@example.com]   toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
[galley@example.com]   throwIO, called at src/UnliftIO/Exception.hs:356:7 in unliftio-0.2.25.1-AdVaKH2Ubts3FYohk3WmeN:UnliftIO.Exception
[galley@example.com]
[galley@example.com]
[galley@b.example.com] galley: user error (could not match 2 port numbers to 3 hosts)
[galley@b.example.com] HasCallStack backtrace:
[galley@b.example.com]   collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
[galley@b.example.com]   toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
[galley@b.example.com]   throwIO, called at src/UnliftIO/Exception.hs:356:7 in unliftio-0.2.25.1-AdVaKH2Ubts3FYohk3WmeN:UnliftIO.Exception
[galley@b.example.com]
[galley@b.example.com]
[background-worker@example.com] background-worker: user error (could not match 2 port numbers to 3 hosts)
[background-worker@example.com]
[background-worker@b.example.com] background-worker: user error (could not match 2 port numbers to 3 hosts)
[background-worker@b.example.com]
```
 
Ticket: https://wearezeta.atlassian.net/browse/WPB-27405

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
