### PR TITLE
Fail on invalid Postgresql connection string combinations [backport]

### DIFF
--- a/changelog.d/3-bug-fixes/postgresql-connection-string-parse-failure
+++ b/changelog.d/3-bug-fixes/postgresql-connection-string-parse-failure
@@ -1,0 +1,3 @@
+Postgresql connection strings with mismatched host/port counts in service
+configurations now lead to immediate failure with a clear error message instead
+of silently producing an erroneous connection.

--- a/flake.lock
+++ b/flake.lock
@@ -314,6 +314,23 @@
         "type": "github"
       }
     },
+    "postgresql-connection-string": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787930090,
+        "narHash": "sha256-ti+XZdhoCiDxgyUilva7EpV8SOfMlmwuKr28XkJ62N0=",
+        "owner": "wireapp",
+        "repo": "postgresql-connection-string",
+        "rev": "bd5a2d72c15fa4ffe561e3b3f441e5809050f918",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wireapp",
+        "ref": "wire-patches",
+        "repo": "postgresql-connection-string",
+        "type": "github"
+      }
+    },
     "postie": {
       "flake": false,
       "locked": {
@@ -345,6 +362,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs_24_11": "nixpkgs_24_11",
+        "postgresql-connection-string": "postgresql-connection-string",
         "postie": "postie",
         "sbomnix": "sbomnix",
         "servant-openapi3": "servant-openapi3",

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,12 @@
       url = "github:wireapp/hasql-migration?ref=allow-no-transaction";
       flake = false;
     };
+
+    postgresql-connection-string = {
+      url =
+        "github:wireapp/postgresql-connection-string?ref=wire-patches";
+      flake = false;
+    };
   };
 
   outputs = inputs@{ nixpkgs, nixpkgs_24_11, nixpkgs-unstable, flake-utils, tom-bombadil, sbomnix, ... }:


### PR DESCRIPTION
Backport of https://github.com/wireapp/wire-server/pull/5494 . It is quite simpler, because `fromKeyValueParams` isn't used here. Thus we don't have to deal with its type change.

The CI will probably never get green, but there is a special pipeline for this "hotfix" branch which guards us from introducing regressions: https://concourse.ops.zinfra.io/teams/main/pipelines/wire-server-hotfix-2026-q3

Ticket: https://wearezeta.atlassian.net/browse/WPB-28416

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)
