### PR TITLE
[WPB-28448] Remove headroom from treefmt config (releases < 0.5.0.0 are buggy).

### DIFF
--- a/changelog.d/5-internal/WPB-28448-remove-headroom-from-treefmt-config-_releases-_-0_5_0_0-are-buggy_
+++ b/changelog.d/5-internal/WPB-28448-remove-headroom-from-treefmt-config-_releases-_-0_5_0_0-are-buggy_
@@ -1,0 +1,1 @@
+Remove headroom from treefmt config (see https://github.com/xwinus/headroom/issues/117).

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -10,14 +10,6 @@ excludes = [
   "dist-newstyle/"
 ]
 
-[formatter.headroom]
-command = "hack/bin/headroom-treefmt.sh"
-includes = ["*.hs", "*.hsc", "*.rs"]
-excludes = [
-  "dist-newstyle/",
-  "services/wire-server-enterprise/*",
-]
-
 [formatter.shellcheck]
 command = "shellcheck"
 options = ["-x"]


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-28448

alternative: https://github.com/wireapp/wire-server/pull/5503  (we can also merge this, and merge the other PR without time pressure).

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)