### PR TITLE
[WPB-27169] Script listing all commits and releases in which given files have been touched.

### DIFF
--- a/changelog.d/5-internal/WPB-27169-script-listing-all-commits-and-releases-in-which-given-files-have-been-touched
+++ b/changelog.d/5-internal/WPB-27169-script-listing-all-commits-and-releases-in-which-given-files-have-been-touched
@@ -1,0 +1,1 @@
+Script listing all commits and releases in which given files have been touched.

--- a/hack/bin/super-blame.sh
+++ b/hack/bin/super-blame.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 [-h] <file> [file ...]
+
+List commits that changed the given file(s) in chronological order,
+annotated with the release in which each commit landed on master.
+
+A commit's release is the oldest chart/X.Y.0 tag on master whose
+tagged commit is not older than the commit itself.
+
+Options:
+  -h  Show this help
+EOF
+  exit 0
+}
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 [-h] <file> [file ...]" >&2
+  exit 1
+fi
+
+if [ "$1" = "-h" ]; then
+  usage
+fi
+
+releases_tmp=$(mktemp)
+trap 'rm -f "$releases_tmp"' EXIT
+
+while read -r tag; do
+  commit=$(git rev-list -1 "$tag")
+  ts=$(git log -1 --format="%ct" "$commit")
+  echo "${ts} ${tag}"
+done < <(git tag --merged master 'chart/*.0' | sort -V) > "$releases_tmp"
+
+for file in "$@"; do
+  if [ ! -f "$file" ]; then
+    echo "Error: file not found: $file" >&2
+    exit 1
+  fi
+
+  echo "=== $file ==="
+
+  git log --follow --format="%H %ct %ai %s" -- "$file" | while read -r commit commit_ts rest; do
+    release=""
+    while read -r ts tag; do
+      if [ "$ts" -ge "$commit_ts" ]; then
+        release="$tag"
+        break
+      fi
+    done < <(sort -n "$releases_tmp")
+
+    if [ -n "$release" ]; then
+      echo "$commit $rest [$release]"
+    else
+      echo "$commit $rest [unreleased]"
+    fi
+  done
+
+  echo
+done

--- a/hack/bin/super-blame.sh
+++ b/hack/bin/super-blame.sh
@@ -41,7 +41,7 @@ while read -r tag; do
 done < <(git tag --merged master 'chart/*.0' | sort -V) > "$releases_tmp"
 
 annotate() {
-  sort -k1,1n | while read -r commit_ts rest; do
+  while read -r commit_ts rest; do
     commit=$(echo "$rest" | awk '{print $4}')
     release=""
     release_date=""
@@ -53,7 +53,7 @@ annotate() {
       fi
     done < <(sort -n "$releases_tmp")
     if [ -n "$release" ]; then
-      echo "$rest [$release $release_date]"
+      echo "$rest [$release, $release_date]"
     else
       echo "$rest [unreleased]"
     fi
@@ -87,10 +87,11 @@ for arg in "$@"; do
         start="$r"
         end="$r"
       fi
-      git log -L "${start},${end}:${file}" --format="%ct %ai %H %s" 2>/dev/null \
-        | grep -E '^[0-9]{10} [0-9]{4}-' >> "$commits_tmp"
+      git log -L "${start},${end}:${file}" -s --format="%ct %ai %H %s" >> "$commits_tmp"
     done
-    awk '!seen[$2]++' "$commits_tmp" | annotate
+    # Each line-range query may return the same commit. `sort -u`
+    # deduplicates and sorts by timestamp (field 1).
+    sort -u -k1,1n "$commits_tmp" | annotate
     rm -f "$commits_tmp"
   fi
 

--- a/hack/bin/super-blame.sh
+++ b/hack/bin/super-blame.sh
@@ -30,6 +30,8 @@ if [ "$1" = "-h" ]; then
   usage
 fi
 
+git fetch --tags
+
 releases_tmp=$(mktemp)
 trap 'rm -f "$releases_tmp"' EXIT
 
@@ -38,7 +40,7 @@ while read -r tag; do
   ts=$(git log -1 --format="%ct" "$commit")
   date=$(git log -1 --format="%ai" "$commit")
   echo "${ts} ${tag} ${date}"
-done < <(git tag --merged master 'chart/*.0' | sort -V) > "$releases_tmp"
+done < <(git tag --merged origin/master 'chart/*.0' | sort -V) > "$releases_tmp"
 
 annotate() {
   while read -r commit_ts rest; do

--- a/hack/bin/super-blame.sh
+++ b/hack/bin/super-blame.sh
@@ -3,13 +3,17 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 [-h] <file> [file ...]
+Usage: $0 [-h] <file>[@<lines>] [file ...]
 
 List commits that changed the given file(s) in chronological order,
 annotated with the release in which each commit landed on master.
 
 A commit's release is the oldest chart/X.Y.0 tag on master whose
 tagged commit is not older than the commit itself.
+
+Line ranges limit output to commits that changed those lines.
+Syntax: file.hs@1,15-18  (single lines and ranges, comma-separated)
+If no line ranges are given, all commits for the file are shown.
 
 Options:
   -h  Show this help
@@ -18,7 +22,7 @@ EOF
 }
 
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 [-h] <file> [file ...]" >&2
+  echo "Usage: $0 [-h] <file>[@<lines>] [file ...]" >&2
   exit 1
 fi
 
@@ -32,32 +36,63 @@ trap 'rm -f "$releases_tmp"' EXIT
 while read -r tag; do
   commit=$(git rev-list -1 "$tag")
   ts=$(git log -1 --format="%ct" "$commit")
-  echo "${ts} ${tag}"
+  date=$(git log -1 --format="%ai" "$commit")
+  echo "${ts} ${tag} ${date}"
 done < <(git tag --merged master 'chart/*.0' | sort -V) > "$releases_tmp"
 
-for file in "$@"; do
+annotate() {
+  sort -k1,1n | while read -r commit_ts rest; do
+    commit=$(echo "$rest" | awk '{print $4}')
+    release=""
+    release_date=""
+    while read -r ts tag rdate; do
+      if [ "$ts" -ge "$commit_ts" ]; then
+        release="$tag"
+        release_date="$rdate"
+        break
+      fi
+    done < <(sort -n "$releases_tmp")
+    if [ -n "$release" ]; then
+      echo "$rest [$release $release_date]"
+    else
+      echo "$rest [unreleased]"
+    fi
+  done
+}
+
+for arg in "$@"; do
+  file="${arg%@*}"
+  lines="${arg##*@}"
+  if [ "$file" = "$arg" ]; then
+    lines=""
+  fi
+
   if [ ! -f "$file" ]; then
     echo "Error: file not found: $file" >&2
     exit 1
   fi
 
-  echo "=== $file ==="
+  echo "=== $arg ==="
 
-  git log --follow --format="%H %ct %ai %s" -- "$file" | while read -r commit commit_ts rest; do
-    release=""
-    while read -r ts tag; do
-      if [ "$ts" -ge "$commit_ts" ]; then
-        release="$tag"
-        break
+  if [ -z "$lines" ]; then
+    git log --follow --format="%ct %ai %H %s" -- "$file" | annotate
+  else
+    commits_tmp=$(mktemp)
+    IFS=',' read -ra ranges <<< "$lines"
+    for r in "${ranges[@]}"; do
+      if [[ "$r" == *"-"* ]]; then
+        start="${r%-*}"
+        end="${r#*-}"
+      else
+        start="$r"
+        end="$r"
       fi
-    done < <(sort -n "$releases_tmp")
-
-    if [ -n "$release" ]; then
-      echo "$commit $rest [$release]"
-    else
-      echo "$commit $rest [unreleased]"
-    fi
-  done
+      git log -L "${start},${end}:${file}" --format="%ct %ai %H %s" 2>/dev/null \
+        | grep -E '^[0-9]{10} [0-9]{4}-' >> "$commits_tmp"
+    done
+    awk '!seen[$2]++' "$commits_tmp" | annotate
+    rm -f "$commits_tmp"
+  fi
 
   echo
 done


### PR DESCRIPTION
example usage:

```
$ ./hack/bin/super-blame.sh libs/types-common-journal/proto/TeamEvents.proto@9,13-15 libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/TeamSize.hs
=== libs/types-common-journal/proto/TeamEvents.proto@9,13-15 ===
a0233f7d3169986dbb560bb8949b25bf386bcf89 2018-01-02 18:12:18 +0000 Added galley support and fixed JSON instances [chart/4.0.0 2022-02-03 10:12:59 +0100]
621b5fbe386dc65685983c30805875125996ad06 2017-08-03 18:43:34 +0200 Journal team events to SQS [chart/4.0.0 2022-02-03 10:12:59 +0100]

=== libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/TeamSize.hs ===
57d02a6040bd48fc0e7fdbe402c833eb6e877a96 2026-05-07 18:20:18 +0200 [WPB-25136] Do not count apps as paying users. (#5213) [chart/5.31.0 2026-05-12 08:43:26 +0200]
c82f654af6ead973f142c6e3da9484d1f8a23b08 2022-11-11 15:04:43 +0100 [SQSERVICES-1010]  Servantify brig team API (#2824) [chart/4.29.0 2022-12-12 14:47:18 +0100]
711bc155f9838ccc546f929f574fb1691d9b6391 2022-05-11 08:31:31 +0000 Adding linting. [chart/4.13.0 2022-06-08 14:01:03 +0200]
69ec12f2d6d926be1c67c6e98e7b1603c1637be7 2022-01-24 07:49:20 -0800 Add licenses to new Spar work (#2062) [chart/4.0.0 2022-02-03 10:12:59 +0100]
81d5a1c457883abceba2c26f06c2be9804626cca 2021-11-02 14:39:39 +0100  Galley polysemy (2/5) - Store effects (#1890) [chart/4.0.0 2022-02-03 10:12:59 +0100]
ee1575983e8543e670567393db04bb287e3f94fa 2020-04-06 18:04:18 +0200 Add license headers (#1045) [chart/4.0.0 2022-02-03 10:12:59 +0100]
b7dc74d6b25f09afdafb729a8805eb14b47f817c 2020-02-17 20:12:30 +0100 Formatting with ormolu (#974) [chart/4.0.0 2022-02-03 10:12:59 +0100]
8a21635d22dc392d173edf07433e9b28e0936146 2019-02-20 11:06:03 +0100 Cleanup gundeck (#628) [chart/4.0.0 2022-02-03 10:12:59 +0100]
1f50b8fe909004381b2d37782e6fe6c02755df38 2019-02-14 13:13:14 +0100 Extend the list of default language extensions (#619) [chart/4.0.0 2022-02-03 10:12:59 +0100]
f07d87be603a1e39b4302f6262374b080d677ae6 2018-11-13 17:52:05 +0100 Use Imports.hs in Brig, Spar, Galley (#507) [chart/4.0.0 2022-02-03 10:12:59 +0100]
d7bf352d51a263ded3fb9afce0c9d70cbddf9ffe 2017-07-27 08:49:19 +0200 Import brig [chart/4.0.0 2022-02-03 10:12:59 +0100]
```

Multiple line number ranges work:

```
$ ./hack/bin/super-blame.sh "services/galley/src/Galley/Cassandra.hs@1-10,23,15"
=== services/galley/src/Galley/Cassandra.hs@1-10,23,15 ===
2021-05-10 13:49:25 +0200 ee2f78720f90b88171319c1c5bd88a79ebfbab85 Golden tests for JSON instances (#1486) [chart/4.0.0 2022-02-03 10:12:59 +0100]
2021-11-02 14:39:39 +0100 81d5a1c457883abceba2c26f06c2be9804626cca  Galley polysemy (2/5) - Store effects (#1890) [chart/4.0.0 2022-02-03 10:12:59 +0100]
2022-01-24 07:49:20 -0800 69ec12f2d6d926be1c67c6e98e7b1603c1637be7 Add licenses to new Spar work (#2062) [chart/4.0.0 2022-02-03 10:12:59 +0100]
```

```
$ ./hack/bin/super-blame.sh "services/galley/src/Galley/Cassandra.hs@1-10" ; ./hack/bin/super-blame.sh "services/galley/src/Galley/Cassandra.hs@23" ; ./hack/bin/super-blame.sh "services/galley/src/Galley/Cassandra.hs@15"
=== services/galley/src/Galley/Cassandra.hs@1-10 ===
2021-05-10 13:49:25 +0200 ee2f78720f90b88171319c1c5bd88a79ebfbab85 Golden tests for JSON instances (#1486) [chart/4.0.0 2022-02-03 10:12:59 +0100]
2022-01-24 07:49:20 -0800 69ec12f2d6d926be1c67c6e98e7b1603c1637be7 Add licenses to new Spar work (#2062) [chart/4.0.0 2022-02-03 10:12:59 +0100]

=== services/galley/src/Galley/Cassandra.hs@23 ===
2021-11-02 14:39:39 +0100 81d5a1c457883abceba2c26f06c2be9804626cca  Galley polysemy (2/5) - Store effects (#1890) [chart/4.0.0 2022-02-03 10:12:59 +0100]

=== services/galley/src/Galley/Cassandra.hs@15 ===
2021-05-10 13:49:25 +0200 ee2f78720f90b88171319c1c5bd88a79ebfbab85 Golden tests for JSON instances (#1486) [chart/4.0.0 2022-02-03 10:12:59 +0100]
```

docs:

```
$ ./hack/bin/super-blame.sh
Usage: ./hack/bin/super-blame.sh [-h] <file>[@<lines>] [file ...]

$ ./hack/bin/super-blame.sh
Usage: ./hack/bin/super-blame.sh [-h] <file>[@<lines>] [file ...]

$ ./hack/bin/super-blame.sh -h
Usage: ./hack/bin/super-blame.sh [-h] <file>[@<lines>] [file ...]

List commits that changed the given file(s) in chronological order,
annotated with the release in which each commit landed on master.

A commit's release is the oldest chart/X.Y.0 tag on master whose
tagged commit is not older than the commit itself.

Line ranges limit output to commits that changed those lines.
Syntax: file.hs@1,15-18  (single lines and ranges, comma-separated)
If no line ranges are given, all commits for the file are shown.

Options:
  -h  Show this help
```

came up during work on https://wearezeta.atlassian.net/browse/WPB-27169

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/latest/developer/developer/pr-guidelines.html)

[WPB-25136]: https://wearezeta.atlassian.net/browse/WPB-25136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ